### PR TITLE
Bug fix:

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -298,6 +298,7 @@ Sequence* Sequence::clone() const
 }
 
 Sequence::Sequence()
+: _split(0)
 {
     _actions[0] = nullptr;
     _actions[1] = nullptr;
@@ -321,14 +322,12 @@ void Sequence::startWithTarget(Node *target)
         log("Sequence::startWithTarget error: _actions[0] or _actions[1] is nullptr!");
         return;
     }
-    if (_duration < 0.000001f)
+    if (_duration > 0.000001f)
     {
-        log("Sequence::startWithTarget error: _duration is zero!");
-        return;
+        _split = _actions[0]->getDuration() / _duration;
     }
 
     ActionInterval::startWithTarget(target);
-    _split = _actions[0]->getDuration() / _duration;
     _last = -1;
 }
 

--- a/cocos/2d/CCTMXXMLParser.cpp
+++ b/cocos/2d/CCTMXXMLParser.cpp
@@ -445,7 +445,7 @@ void TMXMapInfo::startElement(void *ctx, const char *name, const char **atts)
         // Create an instance of TMXObjectInfo to store the object and its properties
         ValueMap dict;
         // Parse everything automatically
-        const char* keys[] = {"name", "type", "width", "height", "gid"};
+        const char* keys[] = {"name", "type", "width", "height", "gid", "id"};
 
         for (const auto& key : keys)
         {

--- a/cocos/network/CCDownloader-apple.mm
+++ b/cocos/network/CCDownloader-apple.mm
@@ -553,9 +553,7 @@ namespace cocos2d { namespace network {
 
         if ('/' == [destPath characterAtIndex:0])
         {
-            // absolute path, need add prefix
-            NSString *prefix = @"file://";
-            destURL = [NSURL URLWithString:[prefix stringByAppendingString: destPath]];
+            destURL = [NSURL fileURLWithPath:destPath];
             break;
         }
 

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -670,6 +670,8 @@ static Data getData(const std::string& filename, bool forString)
     if (nullptr == buffer || 0 == readsize)
     {
         CCLOG("Get data from file %s failed", filename.c_str());
+        if (buffer)
+            free(buffer);
     }
     else
     {


### PR DESCRIPTION
1.Downloader crash when storage path contains spaces on iOS
2.Memory leak when read empty file
3.Actions may not have been executed
4.TMXXMLParser::TMXObjectInfo support "id" key