### PR TITLE
sync bug fix++

### DIFF
--- a/cocos/2d/CCDrawNode.cpp
+++ b/cocos/2d/CCDrawNode.cpp
@@ -326,9 +326,7 @@ void DrawNode::draw(Renderer *renderer, const Mat4 &transform, uint32_t flags)
 
 void DrawNode::onDraw(const Mat4 &transform, uint32_t flags)
 {
-    auto glProgram = getGLProgram();
-    glProgram->use();
-    glProgram->setUniformsForBuiltins(transform);
+    getGLProgramState()->apply(transform);
 
     GL::blendFunc(_blendFunc.src, _blendFunc.dst);
 

--- a/cocos/2d/CCFontFNT.cpp
+++ b/cocos/2d/CCFontFNT.cpp
@@ -779,15 +779,17 @@ FontAtlas * FontFNT::createFontAtlas()
     // Purge uniform hash
     HASH_ITER(hh, _configuration->_fontDefDictionary, currentElement, tmp)
     {
-
-        FontLetterDefinition tempDefinition;
-
         fontDef = currentElement->fontDef;
+        if (fontDef.charID > 65535) {
+            CCLOGWARN("Warning: 65535 < fontDef.charID (%u), ignored", fontDef.charID);
+            continue;
+        }
+        
         Rect tempRect;
-
         tempRect = fontDef.rect;
         tempRect = CC_RECT_PIXELS_TO_POINTS(tempRect);
 
+        FontLetterDefinition tempDefinition;
         tempDefinition.offsetX  = fontDef.xOffset;
         tempDefinition.offsetY  = fontDef.yOffset;
 

--- a/cocos/platform/CCApplicationProtocol.h
+++ b/cocos/platform/CCApplicationProtocol.h
@@ -46,18 +46,18 @@ public:
      */
     enum class Platform
     {
-        OS_WINDOWS,/** Windows */
-        OS_LINUX,/** Linux */
-        OS_MAC,/** Mac*/
-        OS_ANDROID,/** Android */
-        OS_IPHONE,/** Iphone */
-        OS_IPAD,/** Ipad */
-        OS_BLACKBERRY,/** BLACKBERRY */
-        OS_NACL,/** Nacl */
-        OS_EMSCRIPTEN,/** Emscripten */
-        OS_TIZEN,/** Tizen */
-        OS_WINRT,/** Windows Store Applications */
-        OS_WP8/** Windows Phone Applications */
+        OS_WINDOWS,     /**< Windows */
+        OS_LINUX,       /**< Linux */
+        OS_MAC,         /**< Mac OS X*/
+        OS_ANDROID,     /**< Android */
+        OS_IPHONE,      /**< iPhone */
+        OS_IPAD,        /**< iPad */
+        OS_BLACKBERRY,  /**< BlackBerry */
+        OS_NACL,        /**< Native Client in Chrome */
+        OS_EMSCRIPTEN,  /**< Emscripten */
+        OS_TIZEN,       /**< Tizen */
+        OS_WINRT,       /**< Windows Runtime Applications */
+        OS_WP8          /**< Windows Phone 8 Applications */
     };
 
     /**

--- a/cocos/scripting/js-bindings/script/jsb_cocos2d.js
+++ b/cocos/scripting/js-bindings/script/jsb_cocos2d.js
@@ -1661,7 +1661,7 @@ cc.visibleRect.init();
 // Predefined font definition
 cc.FontDefinition = function () {
     this.fontName = "Arial";
-    this.fontSize = 12;
+    this.fontSize = 18;
     this.textAlign = cc.TEXT_ALIGNMENT_CENTER;
     this.verticalAlign = cc.VERTICAL_TEXT_ALIGNMENT_TOP;
     this.fillStyle = cc.color(255, 255, 255, 255);
@@ -1962,30 +1962,9 @@ cc.TMXLayer.prototype.getPositonAt = function(x, y){
     return this._getPositionAt(pos);
 };
 
-// Predefined font definition
-cc.FontDefinition = function () {
-    this.fontName = "Arial";
-    this.fontSize = 32;
-    this.textAlign = cc.TEXT_ALIGNMENT_CENTER;
-    this.verticalAlign = cc.VERTICAL_TEXT_ALIGNMENT_TOP;
-    this.fillStyle = cc.color(255, 255, 255, 255);
-    this.boundingWidth = 0;
-    this.boundingHeight = 0;
-
-    this.strokeEnabled = false;
-    this.strokeStyle = cc.color(255, 255, 255, 255);
-    this.lineWidth = 1;
-
-    this.shadowEnabled = false;
-    this.shadowOffsetX = 0;
-    this.shadowOffsetY = 0;
-    this.shadowBlur = 0;
-    this.shadowOpacity = 1.0;
-};
-
 //LabelTTF
 cc.LabelTTF.prototype.initWithString = function(text, fontName, fontSize, dimensions, hAlignment, vAlignment) {
-    var fontDef = {};
+    var fontDef = new cc.FontDefinition();
     if(typeof fontName === 'string') fontDef.fontName = fontName;
     if(typeof fontSize === 'number') fontDef.fontSize = fontSize;
     if(dimensions) {

--- a/cocos/scripting/js-bindings/script/jsb_create_apis.js
+++ b/cocos/scripting/js-bindings/script/jsb_create_apis.js
@@ -814,7 +814,8 @@ cc.LabelTTF.prototype._ctor = function(text, fontName, fontSize, dimensions, hAl
     }
     else {
         fontName = fontName || '';
-        fontSize = fontSize || 16;
+        if(!fontSize)
+            fontSize = 16;
         dimensions = dimensions || cc.size(0,0);
         hAlignment = hAlignment ? hAlignment : cc.TEXT_ALIGNMENT_LEFT;
         vAlignment = vAlignment ? vAlignment : cc.VERTICAL_TEXT_ALIGNMENT_TOP;


### PR DESCRIPTION
1.Allow to use custom shader uniforms and attributes on drawNode
2.Remove duplicate definition of `cc.FontDefinition`
3.Warn if fontDef.charID exceeds 16bits