### PR TITLE
Fix TTF and Bmfont word wrap

### DIFF
--- a/cocos/2d/CCLabel.h
+++ b/cocos/2d/CCLabel.h
@@ -663,6 +663,8 @@ protected:
     bool isHorizontalClamped(float letterPositionX, int lineInex);
     void restoreFontSize();
     void updateLetterSpriteScale(Sprite* sprite);
+    int getFirstCharLen(const std::u16string& utf16Text, int startIndex, int textLen);
+    int getFirstWordLen(const std::u16string& utf16Text, int startIndex, int textLen);
 
     void reset();
 


### PR DESCRIPTION
1. when the TTF or BMFont word boundary exceed the label width,
turn the word wrap to char wrap.

https://github.com/cocos-creator/fireball/issues/3376