### PR TITLE
fix android project name in system setting app

### DIFF
--- a/cocos/platform/android/libcocos2dx/AndroidManifest.xml
+++ b/cocos/platform/android/libcocos2dx/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.cocos2dx.lib">
 
-    <application android:allowBackup="true" android:label="libcocos2dx">
+    <application android:allowBackup="true">
 
     </application>
 


### PR DESCRIPTION
show "libcocos2dx" when  android:label="libcocos2dx"