### PR TITLE
Fix ScriptingCore::evalString

### DIFF
--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -513,9 +513,6 @@ bool ScriptingCore::evalString(const char *string, JS::MutableHandleValue outVal
 {
     JSAutoCompartment ac(cx, global);
     JS::PersistentRootedScript script(cx);
-    if (script == nullptr) {
-        return false;
-    }
     
     JS::CompileOptions op(cx);
     op.setUTF8(true);


### PR DESCRIPTION
For https://github.com/cocos-creator/fireball/issues/4477