### PR TITLE
Fixing improperly named variable in cc.LabelBMFont.

### DIFF
--- a/cocos/scripting/js-bindings/script/jsb_cocos2d.js
+++ b/cocos/scripting/js-bindings/script/jsb_cocos2d.js
@@ -2288,7 +2288,7 @@ cc.LabelBMFont = cc.Label.extend({
         this.setString(text);
     },
     setWidth: function(maxWidth) {
-        this.setMaxLineWidth(width);
+        this.setMaxLineWidth(maxWidth);
     },
     setFntFile: function (fntFile, imageOffset) {
         if (imageOffset) {


### PR DESCRIPTION
There is no width variable defined in cc.LabelBMFont.setWidth. Attempting to use this function will cause a javascript error. This PR will fix that. 