### PR TITLE
fix editbox can't input on macos sierra

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -209,7 +209,7 @@ void FontAtlas::conversionU16TOGB2312(const std::u16string& u16Text, std::unorde
 #else
         if (_iconv == nullptr)
         {
-            _iconv = iconv_open("gb2312", "utf-16le");
+            _iconv = iconv_open("GBK//TRANSLIT", "UTF-16LE");
         }
 
         if (_iconv == (iconv_t)-1)

--- a/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
+++ b/cocos/platform/desktop/CCGLViewImpl-desktop.cpp
@@ -822,6 +822,10 @@ void GLViewImpl::onGLFWframebuffersize(GLFWwindow* window, int w, int h)
         _retinaFactor = 1;
         glfwSetWindowSize(window, static_cast<int>(frameSizeW * _retinaFactor * _frameZoomFactor), static_cast<int>(frameSizeH * _retinaFactor * _frameZoomFactor));
     }
+
+    //FIXME: https://github.com/cocos2d/cocos2d-x/issues/16779
+    Director::getInstance()->setViewport();
+    Director::getInstance()->mainLoop();
 }
 
 void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int height)
@@ -830,7 +834,7 @@ void GLViewImpl::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int 
     {
         Size baseDesignSize = _designResolutionSize;
         ResolutionPolicy baseResolutionPolicy = _resolutionPolicy;
-        
+
         int frameWidth = width / _frameZoomFactor;
         int frameHeight = height / _frameZoomFactor;
         setFrameSize(frameWidth, frameHeight);

--- a/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
+++ b/cocos/ui/UIEditBox/Mac/CCUIEditBoxMac.mm
@@ -63,6 +63,7 @@
 - (void)createMultiLineTextField
 {
     CCUIMultilineTextField *textView = [[[CCUIMultilineTextField alloc] initWithFrame:self.frameRect] autorelease];
+    [textView setVerticallyResizable:NO];
     self.textInput = textView;
 }
 
@@ -96,7 +97,7 @@
  
     if (![_textInput isKindOfClass:[NSTextView class]]) {
         [_textInput performSelector:@selector(setBordered:)
-                         withObject:[NSNumber numberWithBool:NO]];
+                         withObject:nil];
     }
     _textInput.hidden = NO;
     _textInput.wantsLayer = YES;

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version":"v3-deps-15",
+    "version":"v3-deps-16",
     "zip_file_size":"60696601",
     "repo_name":"cocos2d-x-lite-external",
     "repo_parent":"https://github.com/cocos-creator/"


### PR DESCRIPTION
1. fix missing some Chinese characters when TTF is encoded with GB2312
2. remove border of EditBox on Mac
3. Fix EditBox can't input text on Mac OS sierra

@pandamicro  This PR depend on https://github.com/cocos-creator/cocos2d-x-lite-external/pull/12

And it should generate a deps-16 external