### PR TITLE
Fixing issue where JSScheduleTarget::dump will trigger a bad access

### DIFF
--- a/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
+++ b/cocos/scripting/js-bindings/manual/cocos2d_specifics.cpp
@@ -1234,8 +1234,9 @@ void JSScheduleWrapper::dump()
 
     schedFunc_proxy_t *current_func, *tmp_func;
     int jsfuncTargetCount = 0;
-    HASH_ITER(hh, _schedFunc_target_ht, current_func, tmp_func) {
-        auto targets = current->targets;
+    HASH_ITER(hh, _schedFunc_target_ht, current_func, tmp_func)
+    {
+        auto targets = current_func->targets;
         for (const auto& pObj : *targets)
         {
             CCLOG("js func ( %p ), native target[%d]=( %p )", current_func->jsfuncObj, jsfuncTargetCount, pObj);


### PR DESCRIPTION
Due to NULL pointer access.

In 32b8dfd6d8680c82c5b5ba0f52dc88295cea643d @pandamicro fixed an issue where cocos2d_specifics would not compile with COCOS2D_DEBUG=2, however this introduced a logical error that will cause a crash if that flag is set. In the second iteration loop, current will always be NULL and trigger a bad access. 