### PR TITLE
Generate multi app-abi libraries for android in gulp gen-libs.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,7 +106,7 @@ gulp.task('gen-libs', function(cb) {
   else {
     cocosConsoleBin = Path.join(cocosConsoleRoot, 'cocos.bat');
   }
-  execSync(cocosConsoleBin + ' gen-libs -m release', '.');
+  execSync(cocosConsoleBin + ' gen-libs -m release --app-abi armeabi:arm64-v8a:armeabi-v7a:x86', '.');
   cb();
 });
 


### PR DESCRIPTION
Related issue : cocos-creator/fireball#4514