### PR TITLE
Don’t invoke simple audio engine stuff in AppDelegate. And send missing game_on_hide & game_on_show event for AppDelegate in Simulator.

### DIFF
--- a/templates/js-template-binary/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-binary/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -17,7 +17,6 @@
 
 #include "base/CCDirector.h"
 #include "base/CCEventDispatcher.h"
-#include "SimpleAudioEngine.h"
 
 #include "js_module_register.h"
 
@@ -95,8 +94,6 @@ void AppDelegate::applicationDidEnterBackground()
     auto director = Director::getInstance();
     director->stopAnimation();
     director->getEventDispatcher()->dispatchCustomEvent("game_on_hide");
-    SimpleAudioEngine::getInstance()->pauseBackgroundMusic();
-    SimpleAudioEngine::getInstance()->pauseAllEffects();
 }
 
 // this function will be called when the app is active again
@@ -105,6 +102,4 @@ void AppDelegate::applicationWillEnterForeground()
     auto director = Director::getInstance();
     director->startAnimation();
     director->getEventDispatcher()->dispatchCustomEvent("game_on_show");
-    SimpleAudioEngine::getInstance()->resumeBackgroundMusic();
-    SimpleAudioEngine::getInstance()->resumeAllEffects();
 }

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -17,7 +17,6 @@
 
 #include "base/CCDirector.h"
 #include "base/CCEventDispatcher.h"
-#include "SimpleAudioEngine.h"
 
 #include "js_module_register.h"
 
@@ -94,8 +93,6 @@ void AppDelegate::applicationDidEnterBackground()
     auto director = Director::getInstance();
     director->stopAnimation();
     director->getEventDispatcher()->dispatchCustomEvent("game_on_hide");
-    SimpleAudioEngine::getInstance()->pauseBackgroundMusic();
-    SimpleAudioEngine::getInstance()->pauseAllEffects();
 }
 
 // this function will be called when the app is active again
@@ -104,6 +101,4 @@ void AppDelegate::applicationWillEnterForeground()
     auto director = Director::getInstance();
     director->startAnimation();
     director->getEventDispatcher()->dispatchCustomEvent("game_on_show");
-    SimpleAudioEngine::getInstance()->resumeBackgroundMusic();
-    SimpleAudioEngine::getInstance()->resumeAllEffects();
 }

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -17,7 +17,6 @@
 
 #include "base/CCDirector.h"
 #include "base/CCEventDispatcher.h"
-#include "SimpleAudioEngine.h"
 
 #include "js_module_register.h"
 
@@ -94,8 +93,6 @@ void AppDelegate::applicationDidEnterBackground()
     auto director = Director::getInstance();
     director->stopAnimation();
     director->getEventDispatcher()->dispatchCustomEvent("game_on_hide");
-    SimpleAudioEngine::getInstance()->pauseBackgroundMusic();
-    SimpleAudioEngine::getInstance()->pauseAllEffects();
 }
 
 // this function will be called when the app is active again
@@ -104,6 +101,4 @@ void AppDelegate::applicationWillEnterForeground()
     auto director = Director::getInstance();
     director->startAnimation();
     director->getEventDispatcher()->dispatchCustomEvent("game_on_show");
-    SimpleAudioEngine::getInstance()->resumeBackgroundMusic();
-    SimpleAudioEngine::getInstance()->resumeAllEffects();
 }

--- a/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -17,7 +17,6 @@
 
 #include "base/CCDirector.h"
 #include "base/CCEventDispatcher.h"
-#include "SimpleAudioEngine.h"
 
 #include "ide-support/CodeIDESupport.h"
 #include "runtime/Runtime.h"
@@ -34,8 +33,6 @@ AppDelegate::AppDelegate()
 
 AppDelegate::~AppDelegate()
 {
-    SimpleAudioEngine::end();
-
     // NOTE:Please don't remove this call if you want to debug with Cocos Code IDE
     RuntimeEngine::getInstance()->end();
 }
@@ -70,15 +67,15 @@ bool AppDelegate::applicationDidFinishLaunching()
 // This function will be called when the app is inactive. When comes a phone call,it's be invoked too
 void AppDelegate::applicationDidEnterBackground()
 {
-    Director::getInstance()->stopAnimation();
-
-    SimpleAudioEngine::getInstance()->pauseBackgroundMusic();
+    auto director = Director::getInstance();
+    director->stopAnimation();
+    director->getEventDispatcher()->dispatchCustomEvent("game_on_hide");
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
-    Director::getInstance()->startAnimation();
-
-    SimpleAudioEngine::getInstance()->resumeBackgroundMusic();
+    auto director = Director::getInstance();
+    director->startAnimation();
+    director->getEventDispatcher()->dispatchCustomEvent("game_on_show");
 }


### PR DESCRIPTION
@VisualSJ @pandamicro , please review. thanks.