### PR TITLE
Solve the error effect in the spine runtime.

### DIFF
--- a/cocos/editor-support/spine/AnimationState.c
+++ b/cocos/editor-support/spine/AnimationState.c
@@ -351,6 +351,7 @@ void spAnimationState_apply (spAnimationState* self, spSkeleton* skeleton) {
 			}
 		}
 		_spAnimationState_queueEvents(self, current, animationTime);
+		internal->eventsCount = 0;
 		current->nextAnimationLast = animationTime;
 		current->nextTrackLast = current->trackTime;
 	}
@@ -414,7 +415,8 @@ float _spAnimationState_applyMixingFrom (spAnimationState* self, spTrackEntry* e
 		}
 	}
 
-	_spAnimationState_queueEvents(self, from, animationTime);
+	if (entry->mixDuration > 0) _spAnimationState_queueEvents(self, from, animationTime);
+	internal->eventsCount = 0;
 	from->nextAnimationLast = animationTime;
 	from->nextTrackLast = from->trackTime;
 
@@ -528,7 +530,6 @@ void _spAnimationState_queueEvents (spAnimationState* self, spTrackEntry* entry,
 		if (event->time < animationStart) continue; /* Discard events outside animation start/end. */
 		_spEventQueue_event(internal->queue, entry, event);
 	}
-	internal->eventsCount = 0;
 }
 
 void spAnimationState_clearTracks (spAnimationState* self) {
@@ -582,7 +583,7 @@ void _spAnimationState_setCurrent (spAnimationState* self, int index, spTrackEnt
 		from->timelinesRotationCount = 0;
 
 		/* If not completely mixed in, set mixAlpha so mixing out happens from current mix to zero. */
-		if (from->mixingFrom) current->mixAlpha *= MIN(from->mixTime / from->mixDuration, 1);
+		if (from->mixingFrom && from->mixDuration > 0) current->mixAlpha *= MIN(from->mixTime / from->mixDuration, 1);
 	}
 
 	_spEventQueue_start(internal->queue, current);
@@ -715,7 +716,7 @@ spTrackEntry* _spAnimationState_trackEntry (spAnimationState* self, int trackInd
 	entry->trackTime = 0;
 	entry->trackLast = -1;
 	entry->nextTrackLast = -1;
-	entry->trackEnd = loop ? (float)INT_MAX : entry->animationEnd;
+	entry->trackEnd = (float)INT_MAX;
 	entry->timeScale = 1;
 
 	entry->alpha = 1;

--- a/cocos/editor-support/spine/Atlas.c
+++ b/cocos/editor-support/spine/Atlas.c
@@ -66,11 +66,11 @@ typedef struct {
 } Str;
 
 static void trim (Str* str) {
-	while (isspace(*str->begin) && str->begin < str->end)
+	while (isspace((unsigned char)*str->begin) && str->begin < str->end)
 		(str->begin)++;
 	if (str->begin == str->end) return;
 	str->end--;
-	while (isspace(*str->end) && str->end >= str->begin)
+	while (isspace((unsigned char)*str->end) && str->end >= str->begin)
 		str->end--;
 	str->end++;
 }

--- a/cocos/editor-support/spine/SkeletonBinary.c
+++ b/cocos/editor-support/spine/SkeletonBinary.c
@@ -36,7 +36,7 @@
 #include "kvec.h"
 
 typedef struct {
-	const unsigned char* cursor;
+	const unsigned char* cursor; 
 	const unsigned char* end;
 } _dataInput;
 
@@ -373,7 +373,7 @@ static spAnimation* _spSkeletonBinary_readAnimation (spSkeletonBinary* self, con
 		for (frameIndex = 0; frameIndex < frameCount; ++frameIndex) {
 			float time = readFloat(input);
 			float mix = readFloat(input);
-			char bendDirection = readSByte(input);
+			signed char bendDirection = readSByte(input);
 			spIkConstraintTimeline_setFrame(timeline, frameIndex, time, mix, bendDirection);
 			if (frameIndex < frameCount - 1) readCurve(input, SUPER(timeline), frameIndex);
 		}
@@ -582,6 +582,7 @@ static spAnimation* _spSkeletonBinary_readAnimation (spSkeletonBinary* self, con
 	kv_trim(spTimeline*, timelines);
 
 	animation = spAnimation_create(name, 0);
+	FREE(animation->timelines);
 	animation->duration = duration;
 	animation->timelinesCount = kv_size(timelines);
 	animation->timelines = kv_array(timelines);


### PR DESCRIPTION
Related issue : cocos-creator/fireball#5036

The error effect is : When the played animation is end, the spine node is reset to the first frame. But it should be stopped at the last frame of the animation.