### PR TITLE
Update the class SkeletonBatch in spine runtime.

### DIFF
--- a/cocos/editor-support/spine/SkeletonBatch.cpp
+++ b/cocos/editor-support/spine/SkeletonBatch.cpp
@@ -1,32 +1,31 @@
 /******************************************************************************
- * Spine Runtimes Software License
- * Version 2.3
- * 
- * Copyright (c) 2013-2015, Esoteric Software
+ * Spine Runtimes Software License v2.5
+ *
+ * Copyright (c) 2013-2016, Esoteric Software
  * All rights reserved.
- * 
- * You are granted a perpetual, non-exclusive, non-sublicensable and
- * non-transferable license to use, install, execute and perform the Spine
- * Runtimes Software (the "Software") and derivative works solely for personal
- * or internal use. Without the written permission of Esoteric Software (see
- * Section 2 of the Spine Software License Agreement), you may not (a) modify,
- * translate, adapt or otherwise create derivative works, improvements of the
- * Software or develop new applications using the Software or (b) remove,
- * delete, alter or obscure any trademarks or any copyright, trademark, patent
+ *
+ * You are granted a perpetual, non-exclusive, non-sublicensable, and
+ * non-transferable license to use, install, execute, and perform the Spine
+ * Runtimes software and derivative works solely for personal or internal
+ * use. Without the written permission of Esoteric Software (see Section 2 of
+ * the Spine Software License Agreement), you may not (a) modify, translate,
+ * adapt, or develop new applications using the Spine Runtimes or otherwise
+ * create derivative works or improvements of the Spine Runtimes or (b) remove,
+ * delete, alter, or obscure any trademarks or any copyright, trademark, patent,
  * or other intellectual property or proprietary rights notices on or in the
  * Software, including any copy thereof. Redistributions in binary or source
  * form must include this license and terms.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY ESOTERIC SOFTWARE "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
  * EVENT SHALL ESOTERIC SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, BUSINESS INTERRUPTION, OR LOSS OF
+ * USE, DATA, OR PROFITS) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
 #include <spine/SkeletonBatch.h>
@@ -39,101 +38,80 @@ using std::max;
 
 namespace spine {
 
-static SkeletonBatch* instance = nullptr;
+    static SkeletonBatch* instance = nullptr;
 
-void SkeletonBatch::setBufferSize (int vertexCount) {
-	if (instance) delete instance;
-	instance = new SkeletonBatch(vertexCount);
-}
-
-SkeletonBatch* SkeletonBatch::getInstance () {
-	if (!instance) instance = new SkeletonBatch(8192);
-	return instance;
-}
-
-void SkeletonBatch::destroyInstance () {
-    if (instance) {
-        delete instance;
-        instance = nullptr;
+    SkeletonBatch* SkeletonBatch::getInstance () {
+        if (!instance) instance = new SkeletonBatch();
+        return instance;
     }
-}
 
-SkeletonBatch::SkeletonBatch (int capacity) :
-	_capacity(capacity), _position(0)
-{
-	_buffer = new V3F_C4B_T2F[capacity];
-	_firstCommand = new Command();
-	_command = _firstCommand;
+    void SkeletonBatch::destroyInstance () {
+        if (instance) {
+            delete instance;
+            instance = nullptr;
+        }
+    }
 
-    Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_AFTER_DRAW_RESET_POSITION, [this](EventCustom* eventCustom){
-        this->update(0);
-    });;
-}
+    SkeletonBatch::SkeletonBatch ()
+    {
+        _firstCommand = new Command();
+        _command = _firstCommand;
 
-SkeletonBatch::~SkeletonBatch () {
-	Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(EVENT_AFTER_DRAW_RESET_POSITION);
+        Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_AFTER_DRAW_RESET_POSITION, [this](EventCustom* eventCustom){
+            this->update(0);
+        });;
+    }
 
-	Command* command = _firstCommand;
-	while (command) {
-		Command* next = command->next;
-		delete command;
-		command = next;
-	}
+    SkeletonBatch::~SkeletonBatch () {
+        Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(EVENT_AFTER_DRAW_RESET_POSITION);
 
-	delete [] _buffer;
-}
+        Command* command = _firstCommand;
+        while (command) {
+            Command* next = command->next;
+            delete command;
+            command = next;
+        }
+    }
 
-void SkeletonBatch::update (float delta) {
-	_position = 0;
-	_command = _firstCommand;
-}
+    void SkeletonBatch::update (float delta) {
+        _command = _firstCommand;
+    }
 
-void SkeletonBatch::addCommand (cocos2d::Renderer* renderer, float globalZOrder, GLuint textureID, GLProgramState* glProgramState,
-	BlendFunc blendFunc, const TrianglesCommand::Triangles& triangles, const Mat4& transform, uint32_t transformFlags
-) {
-	if (_position + triangles.vertCount > _capacity) {
-		int newCapacity = max(_capacity + _capacity / 2, _position + triangles.vertCount);
-		V3F_C4B_T2F* newBuffer = new V3F_C4B_T2F[newCapacity];
-		memcpy(newBuffer, _buffer, _position);
+    void SkeletonBatch::addCommand (cocos2d::Renderer* renderer, float globalZOrder, GLuint textureID, GLProgramState* glProgramState,
+                                    BlendFunc blendFunc, const TrianglesCommand::Triangles& triangles, const Mat4& transform, uint32_t transformFlags
+                                    ) {
+        if (_command->triangles->verts) {
+            free(_command->triangles->verts);
+            _command->triangles->verts = NULL;
+        }
+        
+        _command->triangles->verts = (V3F_C4B_T2F *)malloc(sizeof(V3F_C4B_T2F) * triangles.vertCount);
+        memcpy(_command->triangles->verts, triangles.verts, sizeof(V3F_C4B_T2F) * triangles.vertCount);
+        
+        _command->triangles->vertCount = triangles.vertCount;
+        _command->triangles->indexCount = triangles.indexCount;
+        _command->triangles->indices = triangles.indices;
+        
+        _command->trianglesCommand->init(globalZOrder, textureID, glProgramState, blendFunc, *_command->triangles, transform, transformFlags);
+        renderer->addCommand(_command->trianglesCommand);
+        
+        if (!_command->next) _command->next = new Command();
+        _command = _command->next;
+    }
 
-		int newPosition = 0;
-		Command* command = _firstCommand;
-		while (newPosition < _position) {
-			command->triangles->verts = newBuffer + newPosition;
-			newPosition += command->triangles->vertCount;
-			command = command->next;
-		}
+    SkeletonBatch::Command::Command () :
+    next(nullptr)
+    {
+        trianglesCommand = new TrianglesCommand();
+        triangles = new TrianglesCommand::Triangles();
+    }
 
-		delete [] _buffer;
-		_buffer = newBuffer;
-		_capacity = newCapacity;
-	}
-
-	memcpy(_buffer + _position, triangles.verts, sizeof(V3F_C4B_T2F) * triangles.vertCount);
-	_command->triangles->verts = _buffer + _position;
-	_position += triangles.vertCount;
-
-	_command->triangles->vertCount = triangles.vertCount;
-	_command->triangles->indexCount = triangles.indexCount;
-	_command->triangles->indices = triangles.indices;
-
-	_command->trianglesCommand->init(globalZOrder, textureID, glProgramState, blendFunc, *_command->triangles, transform, transformFlags);
-	renderer->addCommand(_command->trianglesCommand);
-
-	if (!_command->next) _command->next = new Command();
-	_command = _command->next;
-}
-
-SkeletonBatch::Command::Command () :
-	next(nullptr)
-{
-	trianglesCommand = new TrianglesCommand();
-	triangles = new TrianglesCommand::Triangles();
-}
-
-SkeletonBatch::Command::~Command () {
-	delete triangles;
-	delete trianglesCommand;
-}
+    SkeletonBatch::Command::~Command () {
+        if (triangles->verts) {
+            free(triangles->verts);
+        }
+        delete triangles;
+        delete trianglesCommand;
+    }
 
 }

--- a/cocos/editor-support/spine/SkeletonBatch.h
+++ b/cocos/editor-support/spine/SkeletonBatch.h
@@ -1,32 +1,31 @@
 /******************************************************************************
- * Spine Runtimes Software License
- * Version 2.3
- * 
- * Copyright (c) 2013-2015, Esoteric Software
+ * Spine Runtimes Software License v2.5
+ *
+ * Copyright (c) 2013-2016, Esoteric Software
  * All rights reserved.
- * 
- * You are granted a perpetual, non-exclusive, non-sublicensable and
- * non-transferable license to use, install, execute and perform the Spine
- * Runtimes Software (the "Software") and derivative works solely for personal
- * or internal use. Without the written permission of Esoteric Software (see
- * Section 2 of the Spine Software License Agreement), you may not (a) modify,
- * translate, adapt or otherwise create derivative works, improvements of the
- * Software or develop new applications using the Software or (b) remove,
- * delete, alter or obscure any trademarks or any copyright, trademark, patent
+ *
+ * You are granted a perpetual, non-exclusive, non-sublicensable, and
+ * non-transferable license to use, install, execute, and perform the Spine
+ * Runtimes software and derivative works solely for personal or internal
+ * use. Without the written permission of Esoteric Software (see Section 2 of
+ * the Spine Software License Agreement), you may not (a) modify, translate,
+ * adapt, or develop new applications using the Spine Runtimes or otherwise
+ * create derivative works or improvements of the Spine Runtimes or (b) remove,
+ * delete, alter, or obscure any trademarks or any copyright, trademark, patent,
  * or other intellectual property or proprietary rights notices on or in the
  * Software, including any copy thereof. Redistributions in binary or source
  * form must include this license and terms.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY ESOTERIC SOFTWARE "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
  * EVENT SHALL ESOTERIC SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
  * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
- * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
- * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, BUSINESS INTERRUPTION, OR LOSS OF
+ * USE, DATA, OR PROFITS) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
 #ifndef SPINE_SKELETONBATCH_H_
@@ -36,45 +35,36 @@
 #include "cocos2d.h"
 
 namespace spine {
-
-class SkeletonBatch {
-public:
-	/* Sets the max number of vertices that can be drawn in a single frame. The buffer will grow automatically as needed, but
-	 * setting it to the appropriate is more efficient. Best to call before getInstance is called for the first time. Default is
-	 * 8192. */
-	static void setBufferSize (int vertexCount);
-
-	static SkeletonBatch* getInstance ();
-
-	static void destroyInstance ();
-
-	void update (float delta);
-
-	void addCommand (cocos2d::Renderer* renderer, float globalOrder, GLuint textureID, cocos2d::GLProgramState* glProgramState,
-		cocos2d::BlendFunc blendType, const cocos2d::TrianglesCommand:: Triangles& triangles, const cocos2d::Mat4& mv, uint32_t flags);
-
-protected:
-	SkeletonBatch (int capacity);
-	virtual ~SkeletonBatch ();
-
-	cocos2d::V3F_C4B_T2F* _buffer;
-	int _capacity;
-	int _position;
-
-	class Command {
-	public:
-		Command ();
-		virtual ~Command ();
-
-		cocos2d::TrianglesCommand* trianglesCommand;
-		cocos2d::TrianglesCommand::Triangles* triangles;
-		Command* next;
-	};
-
-	Command* _firstCommand;
-	Command* _command;
-};
-
+    
+    class SkeletonBatch {
+    public:
+        static SkeletonBatch* getInstance ();
+        
+        static void destroyInstance ();
+        
+        void update (float delta);
+        
+        void addCommand (cocos2d::Renderer* renderer, float globalOrder, GLuint textureID, cocos2d::GLProgramState* glProgramState,
+                         cocos2d::BlendFunc blendType, const cocos2d::TrianglesCommand:: Triangles& triangles, const cocos2d::Mat4& mv, uint32_t flags);
+        
+    protected:
+        SkeletonBatch ();
+        virtual ~SkeletonBatch ();
+        
+        class Command {
+        public:
+            Command ();
+            virtual ~Command ();
+            
+            cocos2d::TrianglesCommand* trianglesCommand;
+            cocos2d::TrianglesCommand::Triangles* triangles;
+            Command* next;
+        };
+        
+        Command* _firstCommand;
+        Command* _command;
+    };
+    
 }
 
 #endif // SPINE_SKELETONBATCH_H_


### PR DESCRIPTION
最近一次升级 lite 仓库的 spine runtime 的时候，发现这个 cpp 升级之后不能正常工作，而且升级前 lite 仓库中的这个 cpp 与 -x 中的差别也很大。当时以为这个是 lite 仓库做了定制修改的，所以没有升级这个文件。

开发者在论坛中反馈，这个类中的代码可能导致崩溃：
http://forum.cocos.com/t/cocos2dx-lite-v1-4-skeletonbatch-cpp-bug/43382

所以，此 PR 重新升级 SkeletonBatch 类，并解决无法正常工作的问题。