### PR TITLE
Set the default APP_ABI with armeabi-v7a for binary template..

### DIFF
--- a/templates/js-template-binary/frameworks/runtime-src/proj.android/jni/Application.mk
+++ b/templates/js-template-binary/frameworks/runtime-src/proj.android/jni/Application.mk
@@ -1,7 +1,7 @@
 APP_STL := gnustl_static
 
 # Uncomment this line to compile to armeabi-v7a, your application will run faster but support less devices
-#APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a
 
 APP_CPPFLAGS := -frtti -DCC_ENABLE_CHIPMUNK_INTEGRATION=1 -std=c++11 -fsigned-char -DPACKAGE_AS
 APP_LDFLAGS := -latomic


### PR DESCRIPTION
Related issue : cocos-creator/fireball#5176