### PR TITLE
插入结点时对CascadeColor和cascadeOpacity的优化

### DIFF
--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -976,12 +976,14 @@ void Node::postInsertChild(Node* child)
 
     if (_cascadeColorEnabled)
     {
-        updateCascadeColor();
+		if (_displayedColor.r < 255 || _displayedColor.g < 255 || _displayedColor.b < 255)
+			child->updateCascadeColor();
     }
 
     if (_cascadeOpacityEnabled)
     {
-        updateCascadeOpacity();
+		if (_displayedOpacity < 255)
+			child->updateCascadeOpacity();
     }
 }
 

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -976,14 +976,12 @@ void Node::postInsertChild(Node* child)
 
     if (_cascadeColorEnabled)
     {
-		if (_displayedColor.r < 255 || _displayedColor.g < 255 || _displayedColor.b < 255)
-			child->updateCascadeColor();
+        child->updateCascadeColor();
     }
 
     if (_cascadeOpacityEnabled)
     {
-		if (_displayedOpacity < 255)
-			child->updateCascadeOpacity();
+        child->updateCascadeOpacity();
     }
 }
 


### PR DESCRIPTION
主要优化两个地点：
1. 当插入子结点时，判断当前结点的cascadeOpacity是否小于255，如果等于255，其实对子结点的opacity不会有影响，因此不用调用updateCascadeOpacity。CascadeColor也一样。
2. 只需要调用新插入的子结点的updateCascadeOpacity的就行了，不用调自己，否则当自己的子结点越多，这个代价也越大，而且对原有的子结点是做无用功。