### PR TITLE
remove superfluous code in CCEventDispatcher

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -793,25 +793,6 @@ void EventDispatcher::dispatchEventToListeners(EventListenerVector* listeners, c
             }
         }
     }
-
-    if (fixedPriorityListeners)
-    {
-        if (!shouldStopPropagation)
-        {
-            // priority > 0
-            ssize_t size = fixedPriorityListeners->size();
-            for (; i < size; ++i)
-            {
-                auto l = fixedPriorityListeners->at(i);
-
-                if (l->isEnabled() && !l->isPaused() && l->isRegistered() && onEvent(l))
-                {
-                    shouldStopPropagation = true;
-                    break;
-                }
-            }
-        }
-    }
 }
 
 void EventDispatcher::dispatchEvent(Event* event)


### PR DESCRIPTION
发现了一段代码重复写了 2 次（看了一下现在 -x 的并没有写了 2 次），可能是之前最早移植过来的时候写多了，现在删除多余的代码

@pandamicro @minggo @dumganhar 你们看看谁合