### PR TITLE
Fix potential crash after WebSocket.close and send onclose event after onerror is received

### DIFF
--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -406,7 +406,7 @@ SIOClientImpl::~SIOClientImpl()
     if (_connected)
         disconnect();
 
-    CC_SAFE_DELETE(_ws);
+    _ws->release();
 }
 
 void SIOClientImpl::handshake()
@@ -588,7 +588,7 @@ void SIOClientImpl::openSocket()
     _ws = new (std::nothrow) WebSocket();
     if (!_ws->init(*this, s.str(), nullptr, _caFilePath))
     {
-        CC_SAFE_DELETE(_ws);
+        CC_SAFE_RELEASE_NULL(_ws);
     }
 
     return;

--- a/cocos/network/WebSocket.h
+++ b/cocos/network/WebSocket.h
@@ -28,6 +28,7 @@
 
 #include "platform/CCPlatformMacros.h"
 #include "platform/CCStdC.h"
+#include "base/CCRef.h"
 
 #include <string>
 #include <vector>
@@ -55,7 +56,7 @@ namespace network {
  * WebSocket is wrapper of the libwebsockets-protocol, let the develop could call the websocket easily.
  * Please note that all public methods of WebSocket have to be invoked on Cocos Thread.
  */
-class CC_DLL WebSocket
+class CC_DLL WebSocket : public Ref
 {
 public:
     /**
@@ -70,6 +71,8 @@ public:
      * @js ctor
      */
     WebSocket();
+
+private:
     /**
      * Destructor of WebSocket.
      *
@@ -78,6 +81,7 @@ public:
      */
     virtual ~WebSocket();
 
+public:
     /**
      * Data structure for message
      */

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "v3-deps-35",
+    "version": "v3-deps-36",
     "zip_file_size": "114318593",
     "repo_name": "cocos2d-x-lite-external",
     "repo_parent": "https://github.com/cocos-creator/"


### PR DESCRIPTION
Since the finalize function will get a invalid pointer of WebSocket, invoking ws->closeAysnc() will generate unknown result, probably crash.
HOW TO FIX:
WebSocket and JSB_WebSocketDelegate inhert from Ref. After websocket is initialized successfully, retain websocket instance and delegate, they will both have 2 reference count.
release their reference both in onClose callback and finalize function. The reason is that the order of invoking onClose and finalize function will be unpredictable, ref count technique help to handle this.

Another fix is sending onclose event after onerror is received.