### PR TITLE
fix WebView bug for fireball/issues/6328

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebViewHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebViewHelper.java
@@ -101,6 +101,8 @@ public class Cocos2dxWebViewHelper {
                 if (webView != null) {
                     webViews.remove(index);
                     sLayout.removeView(webView);
+                    webView.destroy();
+                    webView = null;
                 }
             }
         });

--- a/cocos/ui/UIWebView-inl.h
+++ b/cocos/ui/UIWebView-inl.h
@@ -156,7 +156,13 @@ namespace experimental{
             Widget::onExit();
             _impl->setVisible(false);
         }
-        
+
+        void WebView::cleanup()
+        {
+            ProtectedNode::cleanup();
+            _impl->loadURL("about:blank");
+        }
+
         void WebView::setBounces(bool bounces)
         {
           _impl->setBounces(bounces);

--- a/cocos/ui/UIWebView.h
+++ b/cocos/ui/UIWebView.h
@@ -211,6 +211,7 @@ public:
     virtual void setVisible(bool visible) override;
     virtual void onEnter() override;
     virtual void onExit() override;
+    virtual void cleanup() override;
 
 protected:
     virtual cocos2d::ui::Widget* createCloneInstance() override;


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/6328

修复以下 2 个问题
- [x] 当 GC 后，android 的 removeView 无效，还需要调用 destroy 才能真正的销毁自身
- [x] 因为 webview 需要等 js gc 以后才能被销毁，所以在 C++ 层添加 cleanup 函数，该函数中加载一个空的页面，解决切换场景切换后还会继续播放页面声音（视频） 的 bug

已经测试
