### PR TITLE
fix  eidtorbox 'editBoxEditingReturn' events are triggered continuous…

### DIFF
--- a/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
+++ b/cocos/ui/UIEditBox/UIEditBoxImpl-win32.cpp
@@ -331,7 +331,6 @@ namespace ui {
                         s_previousFocusWnd = s_hwndCocos;
                     }
                 }
-                this->editBoxEditingReturn();
             }
             break;
         case WM_SETFOCUS:


### PR DESCRIPTION
…ly bug for fireball/issues/6358

https://github.com/cocos-creator/fireball/issues/6358

修复 EditorBox 回车以后响应 2 次 editBoxEditingReturn 事件（Windows 平台） 

因为在 WM_KILLFOCUS 事件中，会去发出 editBoxEditingReturn  事件，所以不需要在回车事件再次发出事件