### PR TITLE
[android] Fixes Cocos2dxActivity is re-created which causes crash if launching app first time and re-opening from icon

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -260,6 +260,16 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        // Workaround in https://stackoverflow.com/questions/16283079/re-launch-of-activity-on-home-button-but-only-the-first-time/16447508
+        if (!isTaskRoot()) {
+            // Android launched another instance of the root activity into an existing task
+            //  so just quietly finish and go away, dropping the user back into the activity
+            //  at the top of the stack (ie: the last state of this task)
+            finish();
+            Log.w(TAG, "[Workaround] Ignore the activity started from icon!");
+            return;
+        }
+
         this.hideVirtualButton();
 
         onLoadNativeLibraries();


### PR DESCRIPTION
Sync PR: https://github.com/cocos2d/cocos2d-x/pull/18247
Also fix: http://forum.cocos.com/t/1-6-1-performing-stop-of-activity-that-is-not-resumed-debug/50895