### PR TITLE
fix webview bug for ios for fireball/issues/6328

### DIFF
--- a/cocos/ui/UIWebView-inl.h
+++ b/cocos/ui/UIWebView-inl.h
@@ -160,7 +160,7 @@ namespace experimental{
         void WebView::cleanup()
         {
             ProtectedNode::cleanup();
-            _impl->loadURL("about:blank");
+            CC_SAFE_DELETE(_impl);
         }
 
         void WebView::setBounces(bool bounces)


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/6328

统一跟 web 一样在 cleanup 的时候销毁 webview 对象