### PR TITLE
fix editorBox setText error for engine/issues/1961

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -341,7 +341,7 @@ public class Cocos2dxEditBoxHelper {
                 if (editBox != null) {
                     editBox.setChangedTextProgrammatically(true);
                     editBox.setText(text);
-                    int position = text.length();
+                    int position = editBox.getText().length();
                     editBox.setSelection(position);
                 }
             }


### PR DESCRIPTION
```js
editBox.setText(text);
int position = text.length();		
editBox.setSelection(position);
```
这样写，会导致部分机型崩溃（错误信息是越界，有些平台可能有最大长度限制），进而修改为下面的方式

```js
editBox.setText(text);
int position = editBox.getText().length();
editBox.setSelection(position);
```

@minggo @dumganhar @jareguo 

https://github.com/cocos-creator/engine/issues/1961
