### PR TITLE
remove copy_resources from android-studio build-cfg.json

### DIFF
--- a/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/build-cfg.json
+++ b/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/build-cfg.json
@@ -4,32 +4,5 @@
         "${COCOS_X_ROOT}/cocos",
         "${COCOS_X_ROOT}/external"
     ],
-    "copy_resources": [
-        {
-            "from": "../../../src",
-            "to": "src"
-        },
-        {
-            "from": "../../../res",
-            "to": "res"
-        },
-        {
-            "from": "../../../main.js",
-            "to": ""
-        }
-    ],
-    "must_copy_resources": [
-        {
-            "from": "../../../script",
-            "to": "script"
-        },
-        {
-            "from": "../../../config.json",
-            "to": ""
-        },
-        {
-            "from": "../../../project.json",
-            "to": ""
-        }
-    ]
+    "copy_resources": []
 }

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/build-cfg.json
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/build-cfg.json
@@ -4,26 +4,5 @@
         "../../cocos2d-x/cocos",
         "../../cocos2d-x/external"
     ],
-    "copy_resources": [
-        {
-            "from": "../../../src",
-            "to": "src"
-        },
-        {
-            "from": "../../../res",
-            "to": "res"
-        },
-        {
-            "from": "../../../main.js",
-            "to": ""
-        },
-        {
-            "from": "../../../project.json",
-            "to": ""
-        },
-        {
-            "from": "../../cocos2d-x/cocos/scripting/js-bindings/script",
-            "to": "script"
-        }
-    ]
+    "copy_resources": []
 }

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/build-cfg.json
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/build-cfg.json
@@ -4,26 +4,5 @@
         "${COCOS_X_ROOT}/cocos",
         "${COCOS_X_ROOT}/external"
     ],
-    "copy_resources": [
-        {
-            "from": "../../../src",
-            "to": "src"
-        },
-        {
-            "from": "../../../res",
-            "to": "res"
-        },
-        {
-            "from": "../../../main.js",
-            "to": ""
-        },
-        {
-            "from": "${COCOS_X_ROOT}/cocos/scripting/js-bindings/script",
-            "to": "script"
-        },
-        {
-            "from": "../../../project.json",
-            "to": ""
-        }
-    ]
+    "copy_resources": []
 }


### PR DESCRIPTION
android-studio copy resources in `proj.android-studio/app/build.gradle`, so do not need to copy resources in build-cfg.json