### PR TITLE
jsb_enable_debugger() uses local IP "0, 0, 0, 0", then Android debugging doesn't need to change IP.

### DIFF
--- a/cocos/scripting/js-bindings/docs/JSB2.0-learning-zh.md
+++ b/cocos/scripting/js-bindings/docs/JSB2.0-learning-zh.md
@@ -850,7 +850,6 @@ Profile
 #### Android
 
 * 保证Android设备与PC或者Mac在同一个局域网中
-* 修改AppDelegate.cpp, 把`jsb_enable_debugger(ip, port)`那行的IP改为Android设备的IP
 * 编译，运行游戏
 * 用Chrome浏览器打开[chrome-devtools://devtools/bundled/inspector.html?v8only=true&ws=xxx.xxx.xxx.xxx:5086/00010002-0003-4004-8005-000600070008](chrome-devtools://devtools/bundled/inspector.html?v8only=true&ws=xxx.xxx.xxx.xxx:5086/00010002-0003-4004-8005-000600070008), 其中`xxx.xxx.xxx.xxx`为局域网中Android设备的IP地址
 * 调试界面与Windows相同

--- a/cocos/scripting/js-bindings/manual/jsb_cocos2dx_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_cocos2dx_manual.cpp
@@ -62,7 +62,7 @@ static bool js_PlistParser_getInstance(se::State& s)
     SAXParser* parser = delegator->getParser();
 
     if (parser) {
-        native_ptr_to_seval<SAXParser>(parser, __jsb_cocos2d_SAXParser_class, &s.rval());
+        native_ptr_to_rooted_seval<SAXParser>(parser, __jsb_cocos2d_SAXParser_class, &s.rval());
         return true;
     }
     return false;

--- a/templates/js-template-binary/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-binary/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -64,7 +64,8 @@ bool AppDelegate::applicationDidFinishLaunching()
     jsb_init_file_operation_delegate();
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
-    jsb_enable_debugger("127.0.0.1", 5086);   // Enable debugger here
+    // Enable debugger here
+    jsb_enable_debugger("0.0.0.0", 5086);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -65,8 +65,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     // Enable debugger here
-    // Change IP while remote debugging on Android device.
-    jsb_enable_debugger("127.0.0.1", 5086);
+    jsb_enable_debugger("0.0.0.0", 5086);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -65,8 +65,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     // Enable debugger here
-    // Change IP while remote debugging on Android device.
-    jsb_enable_debugger("127.0.0.1", 5086);
+    jsb_enable_debugger("0.0.0.0", 5086);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){

--- a/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
@@ -159,8 +159,7 @@ bool RuntimeJsImpl::initJsEnv()
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     // Enable debugger here
-    // Change IP while remote debugging on Android device.
-    jsb_enable_debugger("127.0.0.1", 5086);
+    jsb_enable_debugger("0.0.0.0", 5086);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){


### PR DESCRIPTION
And fix SAXParser is a singleton, root it.