### PR TITLE
Comments code of listening EVENT_RESET in WebSocket-libwebsockets.cpp since it isn't needed for JSB.

### DIFF
--- a/cocos/network/WebSocket-libwebsockets.cpp
+++ b/cocos/network/WebSocket-libwebsockets.cpp
@@ -616,7 +616,7 @@ WebSocketImpl::WebSocketImpl(cocos2d::network::WebSocket* ws)
 
 // NOTE: !!! Be careful while merging cocos2d-x-lite back to cocos2d-x. !!!
 // 'close' is a synchronous operation which may wait some seconds to make sure connection is closed.
-// But JSB doesn't need to listen on EVENT_RESET event to close connection.
+// But JSB doesn't need to listen on EVENT_RESET event to close connection,
 // since finalize callback (refer to 'WebSocket_finalize' function in jsb_websocket.cpp) will invoke 'closeAsync'.
 //
 //    std::shared_ptr<std::atomic<bool>> isDestroyed = _isDestroyed;

--- a/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
@@ -330,7 +330,7 @@ void XMLHttpRequest::onResponse(HttpClient* client, HttpResponse* response)
     std::string tag = response->getHttpRequest()->getTag();
     if (!tag.empty())
     {
-        CCLOG("%s completed", tag.c_str());
+        LOGD("XMLHttpRequest::onResponse, %s completed\n", tag.c_str());
     }
 
     long statusCode = response->getResponseCode();
@@ -343,7 +343,7 @@ void XMLHttpRequest::onResponse(HttpClient* client, HttpResponse* response)
     if (!response->isSucceed())
     {
         std::string errorBuffer = response->getErrorBuffer();
-        LOGD("Response failed, error buffer: %s", errorBuffer.c_str());
+        LOGD("Response failed, error buffer: %s\n", errorBuffer.c_str());
         if (statusCode == 0 || statusCode == -1)
         {
             _errorFlag = true;


### PR DESCRIPTION
Minior fix: CCLOG -> LOGD in jsb_xmlhttprequest.cpp.