### PR TITLE
Improves native window.console support. Message could be shown both in Browser while debugging and Creator's console.

### DIFF
--- a/cocos/scripting/js-bindings/docs/JSB2.0-learning-zh.md
+++ b/cocos/scripting/js-bindings/docs/JSB2.0-learning-zh.md
@@ -17,7 +17,7 @@ JS绑定的大部分工作其实就是设定JS相关操作的CPP回调，在回�
 
 如何做到抽象层开销最小而且暴露统一的API供上层使用？
 
-以注册JS函数的回调定义为例，JavaScriptCore, SpiderMoneky, V8, ChakraCore的定义各不相同，具体如下：
+以注册JS函数的回调定义为例，JavaScriptCore, SpiderMonkey, V8, ChakraCore的定义各不相同，具体如下：
 
 **JavaScriptCore:**
 

--- a/cocos/scripting/js-bindings/jswrapper/chakracore/Class.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/chakracore/Class.cpp
@@ -106,7 +106,7 @@ namespace se {
             internal::defineProperty(prototype, property.name, property.getter, property.setter, true, true);
         }
 
-        prototypeObj->setProperty("constructor", se::Value(ctorObj));
+        prototypeObj->setProperty("constructor", Value(ctorObj));
 
         ctorObj->setProperty("prototype", Value(prototypeObj));
 

--- a/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.cpp
@@ -5,6 +5,7 @@
 #include "Object.hpp"
 #include "Class.hpp"
 #include "Utils.hpp"
+#include "../State.hpp"
 #include "../MappingUtils.hpp"
 
 extern "C" JS_EXPORT void JSSynchronousGarbageCollectForDebugging(JSContextRef);
@@ -44,7 +45,7 @@ namespace se {
             {
                 std::string ret;
                 internal::forceConvertJsValueToStdString(ctx, arguments[0], &ret);
-                LOGD("%s\n", ret.c_str());
+                LOGD("JS: %s\n", ret.c_str());
             }
             return JSValueMakeUndefined(ctx);
         }
@@ -62,6 +63,103 @@ namespace se {
                 p->finalizeCb(obj);
             free(p);
         }
+
+        Value __oldConsoleLog;
+        Value __oldConsoleDebug;
+        Value __oldConsoleInfo;
+        Value __oldConsoleWarn;
+        Value __oldConsoleError;
+        Value __oldConsoleAssert;
+
+        bool JSB_console_format_log(State& s, const char* prefix, int msgIndex = 0)
+        {
+            if (msgIndex < 0)
+                return false;
+
+            const auto& args = s.args();
+            int argc = (int)args.size();
+            if ((argc - msgIndex) == 1)
+            {
+                std::string msg = args[msgIndex].toStringForce();
+                LOGD("JS: %s%s\n", prefix, msg.c_str());
+            }
+            else if (argc > 1)
+            {
+                std::string msg = args[msgIndex].toStringForce();
+                size_t pos;
+                for (int i = (msgIndex+1); i < argc; ++i)
+                {
+                    pos = msg.find("%");
+                    if (pos != std::string::npos && pos != (msg.length()-1) && (msg[pos+1] == 'd' || msg[pos+1] == 's' || msg[pos+1] == 'f'))
+                    {
+                        msg.replace(pos, 2, args[i].toStringForce());
+                    }
+                    else
+                    {
+                        msg += " " + args[i].toStringForce();
+                    }
+                }
+
+                LOGD("JS: %s%s\n", prefix, msg.c_str());
+            }
+
+            return true;
+        }
+
+        bool JSB_console_log(State& s)
+        {
+            JSB_console_format_log(s, "");
+            __oldConsoleDebug.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_log)
+
+        bool JSB_console_debug(State& s)
+        {
+            JSB_console_format_log(s, "[DEBUG]: ");
+            __oldConsoleDebug.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_debug)
+
+        bool JSB_console_info(State& s)
+        {
+            JSB_console_format_log(s, "[INFO]: ");
+            __oldConsoleInfo.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_info)
+
+        bool JSB_console_warn(State& s)
+        {
+            JSB_console_format_log(s, "[WARN]: ");
+            __oldConsoleWarn.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_warn)
+
+        bool JSB_console_error(State& s)
+        {
+            JSB_console_format_log(s, "[ERROR]: ");
+            __oldConsoleError.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_error)
+
+        bool JSB_console_assert(State& s)
+        {
+            const auto& args = s.args();
+            if (!args.empty())
+            {
+                if (args[0].isBoolean() && !args[0].toBoolean())
+                {
+                    JSB_console_format_log(s, "[ASSERT]: ", 1);
+                    __oldConsoleError.toObject()->call(s.args(), s.thisObject());
+                }
+            }
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_assert)
     }
 
     ScriptEngine *ScriptEngine::getInstance()
@@ -128,9 +226,31 @@ namespace se {
 
         _globalObj = Object::_createJSObject(nullptr, globalObj);
         _globalObj->root();
-        _globalObj->setProperty("window", se::Value(_globalObj));
+        _globalObj->setProperty("window", Value(_globalObj));
 
-        _globalObj->setProperty("scriptEngineType", se::Value("JavaScriptCore"));
+        Value consoleVal;
+        if (_globalObj->getProperty("console", &consoleVal) && consoleVal.isObject())
+        {
+            consoleVal.toObject()->getProperty("log", &__oldConsoleLog);
+            consoleVal.toObject()->defineFunction("log", _SE(JSB_console_log));
+
+            consoleVal.toObject()->getProperty("debug", &__oldConsoleDebug);
+            consoleVal.toObject()->defineFunction("debug", _SE(JSB_console_debug));
+
+            consoleVal.toObject()->getProperty("info", &__oldConsoleInfo);
+            consoleVal.toObject()->defineFunction("info", _SE(JSB_console_info));
+
+            consoleVal.toObject()->getProperty("warn", &__oldConsoleWarn);
+            consoleVal.toObject()->defineFunction("warn", _SE(JSB_console_warn));
+
+            consoleVal.toObject()->getProperty("error", &__oldConsoleError);
+            consoleVal.toObject()->defineFunction("error", _SE(JSB_console_error));
+
+            consoleVal.toObject()->getProperty("assert", &__oldConsoleAssert);
+            consoleVal.toObject()->defineFunction("assert", _SE(JSB_console_assert));
+        }
+
+        _globalObj->setProperty("scriptEngineType", Value("JavaScriptCore"));
 
         JSStringRef propertyName = JSStringCreateWithUTF8CString("log");
         JSObjectSetProperty(_cx, globalObj, propertyName, JSObjectMakeFunctionWithCallback(_cx, propertyName, __log), kJSPropertyAttributeReadOnly, nullptr);
@@ -177,6 +297,13 @@ namespace se {
         Object::cleanup();
         Class::cleanup();
         garbageCollect();
+
+        __oldConsoleLog.setUndefined();
+        __oldConsoleDebug.setUndefined();
+        __oldConsoleInfo.setUndefined();
+        __oldConsoleWarn.setUndefined();
+        __oldConsoleError.setUndefined();
+        __oldConsoleAssert.setUndefined();
 
         JSGlobalContextRelease(_cx);
 

--- a/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.cpp
@@ -154,7 +154,7 @@ namespace se {
                 if (args[0].isBoolean() && !args[0].toBoolean())
                 {
                     JSB_console_format_log(s, "[ASSERT]: ", 1);
-                    __oldConsoleError.toObject()->call(s.args(), s.thisObject());
+                    __oldConsoleAssert.toObject()->call(s.args(), s.thisObject());
                 }
             }
             return true;

--- a/cocos/scripting/js-bindings/jswrapper/jsc/Utils.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/Utils.cpp
@@ -71,13 +71,13 @@ namespace se {
         if (getter != nullptr)
         {
             HandleObject getterObj(Object::_createJSObject(nullptr, getter));
-            desc->setProperty("get", se::Value(getterObj));
+            desc->setProperty("get", Value(getterObj));
         }
 
         if (setter != nullptr)
         {
             HandleObject setterObj(Object::_createJSObject(nullptr, setter));
-            desc->setProperty("set", se::Value(setterObj));
+            desc->setProperty("set", Value(setterObj));
         }
 
         args.push_back(Value(desc));

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -5,6 +5,7 @@
 #include "Object.hpp"
 #include "Class.hpp"
 #include "Utils.hpp"
+#include "../State.hpp"
 #include "../MappingUtils.hpp"
 
 #if SE_ENABLE_INSPECTOR
@@ -77,6 +78,104 @@ namespace se {
 
             return stackStr;
         }
+
+        se::Value __oldConsoleLog;
+        se::Value __oldConsoleDebug;
+        se::Value __oldConsoleInfo;
+        se::Value __oldConsoleWarn;
+        se::Value __oldConsoleError;
+        se::Value __oldConsoleAssert;
+
+        bool JSB_console_format_log(State& s, const char* prefix, int msgIndex = 0)
+        {
+            if (msgIndex < 0)
+                return false;
+
+            const auto& args = s.args();
+            int argc = (int)args.size();
+            if ((argc - msgIndex) == 1)
+            {
+                std::string msg = args[msgIndex].toStringForce();
+                LOGD("JS: %s%s\n", prefix, msg.c_str());
+            }
+            else if (argc > 1)
+            {
+                std::string msg = args[msgIndex].toStringForce();
+                size_t pos;
+                for (int i = (msgIndex+1); i < argc; ++i)
+                {
+                    pos = msg.find("%");
+                    if (pos != std::string::npos && pos != (msg.length()-1) && (msg[pos+1] == 'd' || msg[pos+1] == 's' || msg[pos+1] == 'f'))
+                    {
+                        msg.replace(pos, 2, args[i].toStringForce());
+                    }
+                    else
+                    {
+                        msg += " " + args[i].toStringForce();
+                    }
+                }
+
+                LOGD("JS: %s%s\n", prefix, msg.c_str());
+            }
+
+            return true;
+        }
+
+        bool JSB_console_log(State& s)
+        {
+            JSB_console_format_log(s, "");
+            __oldConsoleDebug.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_log)
+
+        bool JSB_console_debug(State& s)
+        {
+            JSB_console_format_log(s, "[DEBUG]: ");
+            __oldConsoleDebug.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_debug)
+
+        bool JSB_console_info(State& s)
+        {
+            JSB_console_format_log(s, "[INFO]: ");
+            __oldConsoleInfo.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_info)
+
+        bool JSB_console_warn(State& s)
+        {
+            JSB_console_format_log(s, "[WARN]: ");
+            __oldConsoleWarn.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_warn)
+
+        bool JSB_console_error(State& s)
+        {
+            JSB_console_format_log(s, "[ERROR]: ");
+            __oldConsoleError.toObject()->call(s.args(), s.thisObject());
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_error)
+
+        bool JSB_console_assert(State& s)
+        {
+            const auto& args = s.args();
+            if (!args.empty())
+            {
+                if (args[0].isBoolean() && !args[0].toBoolean())
+                {
+                    JSB_console_format_log(s, "[ASSERT]: ", 1);
+                    __oldConsoleError.toObject()->call(s.args(), s.thisObject());
+                }
+            }
+            return true;
+        }
+        SE_BIND_FUNC(JSB_console_assert)
+
     } // namespace {
 
     void ScriptEngine::onFatalErrorCallback(const char* location, const char* message)
@@ -270,6 +369,28 @@ namespace se {
         _globalObj = Object::_createJSObject(nullptr, _context.Get(_isolate)->Global());
         _globalObj->root();
 
+        se::Value consoleVal;
+        if (_globalObj->getProperty("console", &consoleVal) && consoleVal.isObject())
+        {
+            consoleVal.toObject()->getProperty("log", &__oldConsoleLog);
+            consoleVal.toObject()->defineFunction("log", _SE(JSB_console_log));
+
+            consoleVal.toObject()->getProperty("debug", &__oldConsoleDebug);
+            consoleVal.toObject()->defineFunction("debug", _SE(JSB_console_debug));
+
+            consoleVal.toObject()->getProperty("info", &__oldConsoleInfo);
+            consoleVal.toObject()->defineFunction("info", _SE(JSB_console_info));
+
+            consoleVal.toObject()->getProperty("warn", &__oldConsoleWarn);
+            consoleVal.toObject()->defineFunction("warn", _SE(JSB_console_warn));
+
+            consoleVal.toObject()->getProperty("error", &__oldConsoleError);
+            consoleVal.toObject()->defineFunction("error", _SE(JSB_console_error));
+
+            consoleVal.toObject()->getProperty("assert", &__oldConsoleAssert);
+            consoleVal.toObject()->defineFunction("assert", _SE(JSB_console_assert));
+        }
+
         _globalObj->setProperty("scriptEngineType", se::Value("V8"));
 
         _globalObj->defineFunction("log", __log);
@@ -311,6 +432,13 @@ namespace se {
             Object::cleanup();
             Class::cleanup();
             garbageCollect();
+
+            __oldConsoleLog.setUndefined();
+            __oldConsoleDebug.setUndefined();
+            __oldConsoleInfo.setUndefined();
+            __oldConsoleWarn.setUndefined();
+            __oldConsoleError.setUndefined();
+            __oldConsoleAssert.setUndefined();
 
 #if SE_ENABLE_INSPECTOR
             _env->inspector_agent()->Stop();

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -169,7 +169,7 @@ namespace se {
                 if (args[0].isBoolean() && !args[0].toBoolean())
                 {
                     JSB_console_format_log(s, "[ASSERT]: ", 1);
-                    __oldConsoleError.toObject()->call(s.args(), s.thisObject());
+                    __oldConsoleAssert.toObject()->call(s.args(), s.thisObject());
                 }
             }
             return true;

--- a/cocos/scripting/js-bindings/script/jsb_boot.js
+++ b/cocos/scripting/js-bindings/script/jsb_boot.js
@@ -721,9 +721,6 @@ jsb.urlRegExp = new RegExp("^(?:https?|ftp)://\\S*$", "i");
 
 cc._engineLoaded = false;
 
-var console = console || {}
-console.log = log;
-
 (function (config) {
     require("script/jsb.js");
     cc._engineLoaded = true;


### PR DESCRIPTION
The line number of console.log(debug,info,warn,error) output in browser is precise.

This PR depend on https://github.com/cocos-creator/engine/pull/2048