### PR TITLE
Auto binds RenderTexture::saveToFile and fix js memory leak while saveToFile.

### DIFF
--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -746,6 +746,7 @@ void RenderTexture::draw(Renderer *renderer, const Mat4 &transform, uint32_t fla
 
 void RenderTexture::cleanup()
 {
+    Node::cleanup();
     _saveFileCallback = nullptr;
 }
 

--- a/cocos/2d/CCRenderTexture.cpp
+++ b/cocos/2d/CCRenderTexture.cpp
@@ -744,6 +744,11 @@ void RenderTexture::draw(Renderer *renderer, const Mat4 &transform, uint32_t fla
     }
 }
 
+void RenderTexture::cleanup()
+{
+    _saveFileCallback = nullptr;
+}
+
 void RenderTexture::begin()
 {
     Director* director = Director::getInstance();

--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -262,6 +262,7 @@ public:
     // Overrides
     virtual void visit(Renderer *renderer, const Mat4 &parentTransform, uint32_t parentFlags) override;
     virtual void draw(Renderer *renderer, const Mat4 &transform, uint32_t flags) override;
+    virtual void cleanup() override;
 
     /** Flag: Use stack matrix computed from scene hierarchy or generate new modelView and projection matrix.
      *

--- a/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
+++ b/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
@@ -13742,6 +13742,24 @@ begin : function (
 },
 
 /**
+ * @method saveToFile
+* @param {String|String} str
+* @param {cc.Image::Format|bool} format
+* @param {bool|function} bool
+* @param {function} func
+* @return {bool|bool}
+*/
+saveToFile : function(
+str,
+format,
+bool,
+func 
+)
+{
+    return false;
+},
+
+/**
  * @method setAutoDraw
  * @param {bool} arg0
  */

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
@@ -31224,6 +31224,173 @@ static bool js_cocos2dx_RenderTexture_begin(se::State& s)
 }
 SE_BIND_FUNC(js_cocos2dx_RenderTexture_begin)
 
+static bool js_cocos2dx_RenderTexture_saveToFile(se::State& s)
+{
+    CC_UNUSED bool ok = true;
+    cocos2d::RenderTexture* cobj = (cocos2d::RenderTexture*)s.nativeThisObject();
+    SE_PRECONDITION2( cobj, false, "js_cocos2dx_RenderTexture_saveToFile : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    do {
+        if (argc == 2) {
+            std::string arg0;
+            ok &= seval_to_std_string(args[0], &arg0);
+            if (!ok) { ok = true; break; }
+            cocos2d::Image::Format arg1;
+            ok &= seval_to_int32(args[1], (int32_t*)&arg1);
+            if (!ok) { ok = true; break; }
+            bool result = cobj->saveToFile(arg0, arg1);
+            ok &= boolean_to_seval(result, &s.rval());
+            SE_PRECONDITION2(ok, false, "js_cocos2dx_RenderTexture_saveToFile : Error processing arguments");
+            return true;
+        }
+    } while(false);
+
+    do {
+        if (argc == 3) {
+            std::string arg0;
+            ok &= seval_to_std_string(args[0], &arg0);
+            if (!ok) { ok = true; break; }
+            cocos2d::Image::Format arg1;
+            ok &= seval_to_int32(args[1], (int32_t*)&arg1);
+            if (!ok) { ok = true; break; }
+            bool arg2;
+            ok &= seval_to_boolean(args[2], &arg2);
+            bool result = cobj->saveToFile(arg0, arg1, arg2);
+            ok &= boolean_to_seval(result, &s.rval());
+            SE_PRECONDITION2(ok, false, "js_cocos2dx_RenderTexture_saveToFile : Error processing arguments");
+            return true;
+        }
+    } while(false);
+
+    do {
+        if (argc == 4) {
+            std::string arg0;
+            ok &= seval_to_std_string(args[0], &arg0);
+            if (!ok) { ok = true; break; }
+            cocos2d::Image::Format arg1;
+            ok &= seval_to_int32(args[1], (int32_t*)&arg1);
+            if (!ok) { ok = true; break; }
+            bool arg2;
+            ok &= seval_to_boolean(args[2], &arg2);
+            std::function<void (cocos2d::RenderTexture *, const std::basic_string<char> &)> arg3;
+            do {
+                if (args[3].isObject() && args[3].toObject()->isFunction())
+                {
+                    se::Value jsThis(s.thisObject());
+                    se::Value jsFunc(args[3]);
+                    jsThis.toObject()->attachObject(jsFunc.toObject());
+                    auto lambda = [=](cocos2d::RenderTexture* larg0, const std::basic_string<char> & larg1) -> void {
+                        se::ScriptEngine::getInstance()->clearException();
+                        se::AutoHandleScope hs;
+            
+                        CC_UNUSED bool ok = true;
+                        se::ValueArray args;
+                        args.resize(2);
+                        ok &= native_ptr_to_seval<cocos2d::RenderTexture>((cocos2d::RenderTexture*)larg0, &args[0]);
+                        ok &= std_string_to_seval(larg1, &args[1]);
+                        se::Value rval;
+                        se::Object* thisObj = jsThis.isObject() ? jsThis.toObject() : nullptr;
+                        se::Object* funcObj = jsFunc.toObject();
+                        bool succeed = funcObj->call(args, thisObj, &rval);
+                        if (!succeed) {
+                            se::ScriptEngine::getInstance()->clearException();
+                        }
+                    };
+                    arg3 = lambda;
+                }
+                else
+                {
+                    arg3 = nullptr;
+                }
+            } while(false)
+            ;
+            if (!ok) { ok = true; break; }
+            bool result = cobj->saveToFile(arg0, arg1, arg2, arg3);
+            ok &= boolean_to_seval(result, &s.rval());
+            SE_PRECONDITION2(ok, false, "js_cocos2dx_RenderTexture_saveToFile : Error processing arguments");
+            return true;
+        }
+    } while(false);
+
+    do {
+        if (argc == 1) {
+            std::string arg0;
+            ok &= seval_to_std_string(args[0], &arg0);
+            if (!ok) { ok = true; break; }
+            bool result = cobj->saveToFile(arg0);
+            ok &= boolean_to_seval(result, &s.rval());
+            SE_PRECONDITION2(ok, false, "js_cocos2dx_RenderTexture_saveToFile : Error processing arguments");
+            return true;
+        }
+    } while(false);
+
+    do {
+        if (argc == 2) {
+            std::string arg0;
+            ok &= seval_to_std_string(args[0], &arg0);
+            if (!ok) { ok = true; break; }
+            bool arg1;
+            ok &= seval_to_boolean(args[1], &arg1);
+            bool result = cobj->saveToFile(arg0, arg1);
+            ok &= boolean_to_seval(result, &s.rval());
+            SE_PRECONDITION2(ok, false, "js_cocos2dx_RenderTexture_saveToFile : Error processing arguments");
+            return true;
+        }
+    } while(false);
+
+    do {
+        if (argc == 3) {
+            std::string arg0;
+            ok &= seval_to_std_string(args[0], &arg0);
+            if (!ok) { ok = true; break; }
+            bool arg1;
+            ok &= seval_to_boolean(args[1], &arg1);
+            std::function<void (cocos2d::RenderTexture *, const std::basic_string<char> &)> arg2;
+            do {
+                if (args[2].isObject() && args[2].toObject()->isFunction())
+                {
+                    se::Value jsThis(s.thisObject());
+                    se::Value jsFunc(args[2]);
+                    jsThis.toObject()->attachObject(jsFunc.toObject());
+                    auto lambda = [=](cocos2d::RenderTexture* larg0, const std::basic_string<char> & larg1) -> void {
+                        se::ScriptEngine::getInstance()->clearException();
+                        se::AutoHandleScope hs;
+            
+                        CC_UNUSED bool ok = true;
+                        se::ValueArray args;
+                        args.resize(2);
+                        ok &= native_ptr_to_seval<cocos2d::RenderTexture>((cocos2d::RenderTexture*)larg0, &args[0]);
+                        ok &= std_string_to_seval(larg1, &args[1]);
+                        se::Value rval;
+                        se::Object* thisObj = jsThis.isObject() ? jsThis.toObject() : nullptr;
+                        se::Object* funcObj = jsFunc.toObject();
+                        bool succeed = funcObj->call(args, thisObj, &rval);
+                        if (!succeed) {
+                            se::ScriptEngine::getInstance()->clearException();
+                        }
+                    };
+                    arg2 = lambda;
+                }
+                else
+                {
+                    arg2 = nullptr;
+                }
+            } while(false)
+            ;
+            if (!ok) { ok = true; break; }
+            bool result = cobj->saveToFile(arg0, arg1, arg2);
+            ok &= boolean_to_seval(result, &s.rval());
+            SE_PRECONDITION2(ok, false, "js_cocos2dx_RenderTexture_saveToFile : Error processing arguments");
+            return true;
+        }
+    } while(false);
+
+    SE_REPORT_ERROR("wrong number of arguments: %d", (int)argc);
+    return false;
+}
+SE_BIND_FUNC(js_cocos2dx_RenderTexture_saveToFile)
+
 static bool js_cocos2dx_RenderTexture_setAutoDraw(se::State& s)
 {
     cocos2d::RenderTexture* cobj = (cocos2d::RenderTexture*)s.nativeThisObject();
@@ -31629,6 +31796,7 @@ bool js_register_cocos2dx_RenderTexture(se::Object* obj)
     cls->defineFunction("setKeepMatrix", _SE(js_cocos2dx_RenderTexture_setKeepMatrix));
     cls->defineFunction("setClearFlags", _SE(js_cocos2dx_RenderTexture_setClearFlags));
     cls->defineFunction("begin", _SE(js_cocos2dx_RenderTexture_begin));
+    cls->defineFunction("saveToFile", _SE(js_cocos2dx_RenderTexture_saveToFile));
     cls->defineFunction("setAutoDraw", _SE(js_cocos2dx_RenderTexture_setAutoDraw));
     cls->defineFunction("setClearColor", _SE(js_cocos2dx_RenderTexture_setClearColor));
     cls->defineFunction("beginWithClear", _SE(js_cocos2dx_RenderTexture_beginWithClear));

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp
@@ -2077,6 +2077,7 @@ SE_DECLARE_FUNC(js_cocos2dx_RenderTexture_isAutoDraw);
 SE_DECLARE_FUNC(js_cocos2dx_RenderTexture_setKeepMatrix);
 SE_DECLARE_FUNC(js_cocos2dx_RenderTexture_setClearFlags);
 SE_DECLARE_FUNC(js_cocos2dx_RenderTexture_begin);
+SE_DECLARE_FUNC(js_cocos2dx_RenderTexture_saveToFile);
 SE_DECLARE_FUNC(js_cocos2dx_RenderTexture_setAutoDraw);
 SE_DECLARE_FUNC(js_cocos2dx_RenderTexture_setClearColor);
 SE_DECLARE_FUNC(js_cocos2dx_RenderTexture_beginWithClear);

--- a/tools/tojs/cocos2dx.ini
+++ b/tools/tojs/cocos2dx.ini
@@ -111,7 +111,7 @@ skip = Node::[update ^setPosition$ setGLServerState description getUserObject .*
         Application::[^application.* ^run$ getCurrentLanguageCode setAnimationInterval],
         ccFontDefinition::[*],
         NewTextureAtlas::[*],
-        RenderTexture::[listenToBackground listenToForeground saveToFile],
+        RenderTexture::[listenToBackground listenToForeground],
         TextFieldTTF::[(g|s)etDelegate],
         EventListenerVector::[*],
         EventListener(Touch|Keyboard|Mouse|Acceleration|Focus|Custom).*::[create],


### PR DESCRIPTION
Fixes https://github.com/cocos-creator/fireball/issues/6527

The callback _saveFileCallback has to be set to nullptr to release se::Value the std::function captures.

Test code:
```js
             let dirpath = jsb.fileUtils.getWritablePath() + 'ScreenShoot/';
             if( !jsb.fileUtils.isDirectoryExist(dirpath)){
                 jsb.fileUtils.createDirectory(dirpath);
             }
             let name = 'ScreenShoot-' + (new Date()).valueOf() + '.png';
             let filepath = dirpath + name;
             let size = cc.winSize;
             let rt = cc.RenderTexture.create(size.width, size.height);
             cc.director.getScene()._sgNode.addChild(rt);
             rt.setVisible(false);
             rt.begin();
             cc.director.getScene()._sgNode.visit();
             rt.end();
             var func = function(path) {
                 console.log(path);
             };

             rt.saveToFile('ScreenShoot/' + name, cc.ImageFormat.PNG, true, function() {
                           cc.log('save succ');
                           rt.removeFromParent();
                           if (func) {
                           func(filepath);
                           }
                           // memory leak if lambda isn't set to null or `rt` isn't set to null.
                           // rt = null; // Adds rt = null to avoid memory leak.
                           });
```