### PR TITLE
Uses shorter module name (cocos2dx_internal_static -> cis) to avoid compilation errors on Windows system which has a limitation of 260 bytes for build path.

### DIFF
--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -2,7 +2,9 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := cocos2dx_internal_static
+# cis is short name for cocos2dx_internal_static
+# Shorter name could avoid compilation errors on Windows system which has a limitation of 260 bytes for build path.
+LOCAL_MODULE := cis
 LOCAL_MODULE_FILENAME := libcocos2dxinternal
 
 LOCAL_ARM_MODE := arm
@@ -283,7 +285,7 @@ LOCAL_STATIC_LIBRARIES += cocos_ui_static
 LOCAL_STATIC_LIBRARIES += spine_static
 LOCAL_STATIC_LIBRARIES += dragonbones_static
 LOCAL_STATIC_LIBRARIES += creator_static
-LOCAL_STATIC_LIBRARIES += cocos2dx_internal_static
+LOCAL_STATIC_LIBRARIES += cis
 
 include $(BUILD_STATIC_LIBRARY)
 

--- a/cocos/editor-support/creator/Android.mk
+++ b/cocos/editor-support/creator/Android.mk
@@ -26,6 +26,4 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/.. \
                     $(LOCAL_PATH)/../.. \
                     $(LOCAL_PATH)/../../../external/sources
 
-# LOCAL_STATIC_LIBRARIES := cocos2dx_internal_static
-
 include $(BUILD_STATIC_LIBRARY)

--- a/cocos/editor-support/dragonbones/proj.android/Android.mk
+++ b/cocos/editor-support/dragonbones/proj.android/Android.mk
@@ -39,8 +39,6 @@ LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../.. \
                            $(LOCAL_PATH)/../../.. \
                            $(LOCAL_PATH)/../../../../external/sources
 
-# LOCAL_STATIC_LIBRARIES := cocos2dx_internal_static
-
 LOCAL_CFLAGS += -Wno-psabi
 LOCAL_EXPORT_CFLAGS += -Wno-psabi
 

--- a/cocos/network/Android.mk
+++ b/cocos/network/Android.mk
@@ -22,7 +22,6 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../external/websockets/include/android \
 					$(LOCAL_PATH)/.. \
                     $(LOCAL_PATH)/../../external/sources
 
-# LOCAL_STATIC_LIBRARIES := cocos2dx_internal_static
 LOCAL_STATIC_LIBRARIES += libwebsockets_static
 LOCAL_STATIC_LIBRARIES += cocos_ssl_static
 LOCAL_STATIC_LIBRARIES += cocos_crypto_static

--- a/extensions/Android.mk
+++ b/extensions/Android.mk
@@ -15,7 +15,7 @@ assets-manager/AssetsManagerEx.cpp \
 assets-manager/CCEventAssetsManagerEx.cpp \
 assets-manager/CCEventListenerAssetsManagerEx.cpp \
 
-LOCAL_STATIC_LIBRARIES := cocos2dx_internal_static
+LOCAL_STATIC_LIBRARIES := cis
 LOCAL_STATIC_LIBRARIES += cocos_chipmunk_static
 
 LOCAL_CXXFLAGS += -fexceptions


### PR DESCRIPTION
Yep, probably, we could define `buildDir` variable in build.gradle, but let's investigate later.