### PR TITLE
Fixes potential crash in eventDispatcher.removeListener(listener).

### DIFF
--- a/cocos/base/CCEventDispatcher.cpp
+++ b/cocos/base/CCEventDispatcher.cpp
@@ -690,7 +690,10 @@ void EventDispatcher::removeEventListener(EventListener* listener)
 
     if (isFound)
     {
-        releaseListener(listener);
+        if (_inDispatch > 0)
+            CC_SAFE_RELEASE(listener);
+        else
+            releaseListener(listener);
     }
     else
     {


### PR DESCRIPTION
Fixed https://github.com/cocos-creator/fireball/issues/6631， https://github.com/cocos-creator/fireball/issues/6615

It may invoke `releaseListener` two times if it's dispatching event. `releaseListener` will call `releaseScriptObject` internally which may cause the `listener` being garbage collected.
It's hard to reproduce this issue in v1.6 since v1.6 uses SpiderMonkey as its JS engine which is not sensitive to do a GC operation. It's difficult to reproduce even in v1.7.