### PR TITLE
Any kinds of se::Value should be able to be converted to std::string.

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/Value.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/Value.cpp
@@ -529,6 +529,10 @@ namespace se {
         {
             ret = "undefined";
         }
+        else
+        {
+            assert(false);
+        }
 
         return ret;
     }

--- a/cocos/scripting/js-bindings/manual/jsb_conversions.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_conversions.cpp
@@ -218,13 +218,8 @@ bool seval_to_ssize(const se::Value& v, ssize_t* ret)
 bool seval_to_std_string(const se::Value& v, std::string* ret)
 {
     assert(ret != nullptr);
-    if (v.isString() || v.isNumber())
-    {
-        *ret = v.toStringForce();
-        return true;
-    }
-    ret->clear();
-    return false;
+    *ret = v.toStringForce();
+    return true;
 }
 
 bool seval_to_Vec2(const se::Value& v, cocos2d::Vec2* pt)

--- a/cocos/scripting/js-bindings/script/jsb_cocos2d.js
+++ b/cocos/scripting/js-bindings/script/jsb_cocos2d.js
@@ -1126,23 +1126,3 @@ cc.GLProgram.prototype.setUniformLocationWithMatrix4fv = function(){
     tempArray.push(4);
     this.setUniformLocationWithMatrixfvUnion.apply(this, tempArray);
 };
-
-//
-// LocalStorage
-//
-sys.localStorage._setItem = sys.localStorage.setItem;
-sys.localStorage.setItem = function(itemKey,itemValue) {
-    if (typeof itemKey === 'string') {
-        if(itemValue !== undefined && itemValue !== null)
-        {
-            if (typeof itemValue !== 'string') {
-                cc.log("sys.localStorage.setItem Warning: itemValue[" + itemValue + "] is not string!");
-                itemValue = '' + itemValue;
-            }
-            sys.localStorage._setItem(itemKey, itemValue);
-        }
-    }
-    else
-        cc.log("sys.localStorage.setItem Warning: itemKey[" + itemKey + "] is not string!");
-}
-


### PR DESCRIPTION
Reverts localStorage changes in PR #545 since any js value could be converted to string.
This will keep the behavior the same as which in web browser.