### PR TITLE
Some Android Simulators don't support SSE instruction, so disable it for x86 arch.

### DIFF
--- a/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/app/jni/Application.mk
+++ b/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/app/jni/Application.mk
@@ -26,3 +26,5 @@ else
   APP_OPTIM := release
 endif
 
+# Some Android Simulators don't support SSE instruction, so disable it for x86 arch.
+APP_CPPFLAGS += -U__SSE__

--- a/templates/js-template-binary/frameworks/runtime-src/proj.android/jni/Application.mk
+++ b/templates/js-template-binary/frameworks/runtime-src/proj.android/jni/Application.mk
@@ -26,3 +26,5 @@ else
   APP_OPTIM := release
 endif
 
+# Some Android Simulators don't support SSE instruction, so disable it for x86 arch.
+APP_CPPFLAGS += -U__SSE__

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/jni/Application.mk
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/jni/Application.mk
@@ -25,3 +25,6 @@ else
   APP_CFLAGS += -DNDEBUG
   APP_OPTIM := release
 endif
+
+# Some Android Simulators don't support SSE instruction, so disable it for x86 arch.
+APP_CPPFLAGS += -U__SSE__

--- a/templates/js-template-default/frameworks/runtime-src/proj.android/jni/Application.mk
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android/jni/Application.mk
@@ -25,3 +25,6 @@ else
   APP_CFLAGS += -DNDEBUG
   APP_OPTIM := release
 endif
+
+# Some Android Simulators don't support SSE instruction, so disable it for x86 arch.
+APP_CPPFLAGS += -U__SSE__

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/app/jni/Application.mk
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/app/jni/Application.mk
@@ -25,3 +25,6 @@ else
   APP_CFLAGS += -DNDEBUG
   APP_OPTIM := release
 endif
+
+# Some Android Simulators don't support SSE instruction, so disable it for x86 arch.
+APP_CPPFLAGS += -U__SSE__

--- a/templates/js-template-link/frameworks/runtime-src/proj.android/jni/Application.mk
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android/jni/Application.mk
@@ -25,3 +25,6 @@ else
   APP_CFLAGS += -DNDEBUG
   APP_OPTIM := release
 endif
+
+# Some Android Simulators don't support SSE instruction, so disable it for x86 arch.
+APP_CPPFLAGS += -U__SSE__

--- a/tools/simulator/frameworks/runtime-src/proj.android-studio/app/jni/Application.mk
+++ b/tools/simulator/frameworks/runtime-src/proj.android-studio/app/jni/Application.mk
@@ -21,3 +21,6 @@ endif
 
 COCOS_SIMULATOR_BUILD := 1
 USE_ARM_MODE := 1
+
+# Some Android Simulators don't support SSE instruction, so disable it for x86 arch.
+APP_CPPFLAGS += -U__SSE__

--- a/tools/simulator/frameworks/runtime-src/proj.android/jni/Application.mk
+++ b/tools/simulator/frameworks/runtime-src/proj.android/jni/Application.mk
@@ -18,3 +18,6 @@ endif
 
 COCOS_SIMULATOR_BUILD := 1
 USE_ARM_MODE := 1
+
+# Some Android Simulators don't support SSE instruction, so disable it for x86 arch.
+APP_CPPFLAGS += -U__SSE__


### PR DESCRIPTION
Fixed https://github.com/cocos-creator/fireball/issues/6666