### PR TITLE
Sync PR: cocos2d-x #18299: JNI ERROR (app bug): local reference table overflow (max=512)

### DIFF
--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxHelper.cpp
@@ -148,6 +148,7 @@ void conversionEncodingJNI(const char* src, int byteSize, const char* fromCharse
         methodInfo.env->DeleteLocalRef(strArray);
         methodInfo.env->DeleteLocalRef(stringArg1);
         methodInfo.env->DeleteLocalRef(stringArg2);
+        methodInfo.env->DeleteLocalRef(newArray);
         methodInfo.env->DeleteLocalRef(methodInfo.classID);
     }
 }

--- a/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
@@ -387,6 +387,7 @@ bool JavaScriptJavaBridge::CallInfo::getMethodInfo()
 
     if (NULL == m_classID) {
         SE_LOGD("Classloader failed to find class of %s", m_className.c_str());
+        m_env->DeleteLocalRef(_jstrClassName);
         m_env->ExceptionClear();
         m_error = JSJ_ERR_CLASS_NOT_FOUND;
         return false;


### PR DESCRIPTION
https://github.com/cocos2d/cocos2d-x/pull/18299
And fixes potential memory leak if can't find class by jsb.reflection.callStaticMethod.