### PR TITLE
Fixes missing return value of onWavClose function.

### DIFF
--- a/cocos/audio/android/AudioDecoderWav.cpp
+++ b/cocos/audio/android/AudioDecoderWav.cpp
@@ -52,6 +52,7 @@ int AudioDecoderWav::onWavSeek(void* datasource, long offset, int whence)
 
 int AudioDecoderWav::onWavClose(void* datasource)
 {
+    return 0;
 }
 
 bool AudioDecoderWav::decodeToPcm()


### PR DESCRIPTION
解决 onWavClose 没有返回值得警告问题

Sync PR: https://github.com/cocos2d/cocos2d-x/pull/18544