### PR TITLE
Fixes ResizableBufferAdapter<Data>::resize doesn't consider the situation of new size which is lower than old size.

### DIFF
--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -100,7 +100,8 @@ class ResizableBufferAdapter<Data> : public ResizableBuffer {
 public:
     explicit ResizableBufferAdapter(BufferType* buffer) : _buffer(buffer) {}
     virtual void resize(size_t size) override {
-        if (static_cast<size_t>(_buffer->getSize()) < size) {
+        size_t oldSize = static_cast<size_t>(_buffer->getSize());
+        if (oldSize != size) {
             auto old = _buffer->getBytes();
             void* buffer = realloc(old, size);
             if (buffer)


### PR DESCRIPTION
Sync PR: https://github.com/cocos2d/cocos2d-x/pull/18553

解决 ResizableBufferAdapter<Data>::resize 没有考虑新size比旧size小的情况。

此 bug 在 JS 层无法重现，除非开发者写如下 C++ 扩展，即重复利用同一个 Data：

```c++
Data data;
ResizableBufferAdapter<Data> buffer(&data);
FileUtils::getInstance()->getContents("effect1.wav", &buffer);
FileUtils::getInstance()->getContents("effect2.ogg", &buffer); //  The size of buffer will be wrong.
```