### PR TITLE
Corrects the wrong logic of using delete to remove memory allocated by malloc.

### DIFF
--- a/cocos/editor-support/creator/CCGraphicsNode.cpp
+++ b/cocos/editor-support/creator/CCGraphicsNode.cpp
@@ -70,8 +70,8 @@ GraphicsBuffer::GraphicsBuffer()
     
 GraphicsBuffer::~GraphicsBuffer()
 {
-    CC_SAFE_DELETE(verts);
-    CC_SAFE_DELETE(indices);
+    CC_SAFE_FREE(verts);
+    CC_SAFE_FREE(indices);
 }
     
 bool GraphicsBuffer::allocVerts(int vertsCount)


### PR DESCRIPTION
解决 GraphicsNode 中用 delete 去释放 malloc 申请的内存。