### PR TITLE
fixed #1041: Potential crash in invokeJSTouchOneByOneCallback.

### DIFF
--- a/cocos/base/CCEventDispatcher.h
+++ b/cocos/base/CCEventDispatcher.h
@@ -185,6 +185,10 @@ public:
      */
     bool hasEventListener(const EventListener::ListenerID& listenerID) const;
 
+    using DispatchEventHook = void (*)(Event*);
+    void setBeforeDispatchEventHook(Event::Type type, const DispatchEventHook& hook);
+    void setAfterDispatchEventHook(Event::Type type, const DispatchEventHook& hook);
+
     /////////////////////////////////////////////
 
     /** Constructor of EventDispatcher.
@@ -328,15 +332,17 @@ protected:
     /** The nodes were associated with scene graph based priority listeners */
     std::set<Node*> _dirtyNodes;
 
+    std::set<std::string> _internalCustomListenerIDs;
+
+    static const int MAX_EVENT_TYPE = (int)Event::Type::CUSTOM + 1;
+    DispatchEventHook _beforeDispatchEventHooks[MAX_EVENT_TYPE];
+    DispatchEventHook _afterDispatchEventHooks[MAX_EVENT_TYPE];
+
     /** Whether the dispatcher is dispatching event */
     int _inDispatch;
-
+    int _nodePriorityIndex;
     /** Whether to enable dispatching event */
     bool _isEnabled;
-
-    int _nodePriorityIndex;
-
-    std::set<std::string> _internalCustomListenerIDs;
 };
 
 

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -56,8 +56,10 @@ TextureCache* TextureCache::getInstance()
 
 TextureCache::TextureCache()
 : _loadingThread(nullptr)
-, _needQuit(false)
+, _textureCreateHook(nullptr)
+, _textureDestroyHook(nullptr)
 , _asyncRefCount(0)
+, _needQuit(false)
 {
 }
 
@@ -298,6 +300,9 @@ void TextureCache::addImageAsyncCallBack(float dt)
                 texture->retain();
 
                 texture->autorelease();
+
+                if (_textureCreateHook != nullptr)
+                    _textureCreateHook(this, texture);
             } else {
                 texture = nullptr;
                 CCLOG("cocos2d: failed to call TextureCache::addImageAsync(%s)", asyncStruct->filename.c_str());
@@ -360,6 +365,9 @@ Texture2D * TextureCache::addImage(const std::string &path)
                 // texture already retained, no need to re-retain it
                 _textures.insert( std::make_pair(fullpath, texture) );
 
+                if (_textureCreateHook != nullptr)
+                    _textureCreateHook(this, texture);
+
                 //parse 9-patch info
                 this->parseNinePatchImage(image, texture, path);
             }
@@ -410,6 +418,9 @@ Texture2D* TextureCache::addImage(Image *image, const std::string &key)
             texture->retain();
 
             texture->autorelease();
+
+            if (_textureCreateHook != nullptr)
+                _textureCreateHook(this, texture);
         }
         else
         {
@@ -483,6 +494,9 @@ cocos2d::Vector<Texture2D*> TextureCache::getAllTextures() const
 void TextureCache::removeAllTextures()
 {
     for( auto it=_textures.begin(); it!=_textures.end(); ++it ) {
+        if (_textureDestroyHook != nullptr)
+            _textureDestroyHook(this, it->second);
+
         (it->second)->release();
     }
     _textures.clear();
@@ -494,6 +508,8 @@ void TextureCache::removeUnusedTextures()
         Texture2D *tex = it->second;
         if( tex->getReferenceCount() == 1 ) {
             CCLOG("cocos2d: TextureCache: removing unused texture: %s", it->first.c_str());
+            if (_textureDestroyHook != nullptr)
+                _textureDestroyHook(this, tex);
 
             tex->release();
             it = _textures.erase(it);
@@ -514,6 +530,9 @@ void TextureCache::removeTexture(Texture2D* texture)
 
     for( auto it=_textures.cbegin(); it!=_textures.cend(); /* nothing */ ) {
         if( it->second == texture ) {
+            if (_textureDestroyHook != nullptr)
+                _textureDestroyHook(this, texture);
+
             it->second->release();
             it = _textures.erase(it);
             break;
@@ -534,6 +553,9 @@ void TextureCache::removeTextureForKey(const std::string &textureKeyName)
     }
 
     if( it != _textures.end() ) {
+        if (_textureDestroyHook != nullptr)
+            _textureDestroyHook(this, it->second);
+
         (it->second)->release();
         _textures.erase(it);
     }
@@ -655,6 +677,16 @@ void TextureCache::renameTextureWithKey(const std::string& srcName, const std::s
             CC_SAFE_RELEASE(image);
         }
     }
+}
+
+void TextureCache::setTextureCreateHook(TextureLifeCycleHook hook)
+{
+    _textureCreateHook = hook;
+}
+
+void TextureCache::setTextureDestroyHook(TextureLifeCycleHook hook)
+{
+    _textureDestroyHook = hook;
 }
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -212,6 +212,9 @@ public:
     */
     void renameTextureWithKey(const std::string& srcName, const std::string& dstName);
 
+    using TextureLifeCycleHook = void (*)(TextureCache*, Texture2D*);
+    void setTextureCreateHook(TextureLifeCycleHook hook);
+    void setTextureDestroyHook(TextureLifeCycleHook hook);
 
 private:
     void addImageAsyncCallBack(float dt);
@@ -221,8 +224,6 @@ public:
 protected:
     struct AsyncStruct;
 
-    std::thread* _loadingThread;
-
     std::deque<AsyncStruct*> _asyncStructQueue;
     std::deque<AsyncStruct*> _requestQueue;
     std::deque<AsyncStruct*> _responseQueue;
@@ -231,12 +232,15 @@ protected:
     std::mutex _responseMutex;
 
     std::condition_variable _sleepCondition;
+    std::unordered_map<std::string, Texture2D*> _textures;
 
-    bool _needQuit;
+    std::thread* _loadingThread;
+
+    TextureLifeCycleHook _textureCreateHook;
+    TextureLifeCycleHook _textureDestroyHook;
 
     int _asyncRefCount;
-
-    std::unordered_map<std::string, Texture2D*> _textures;
+    bool _needQuit;
 };
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA

--- a/cocos/scripting/js-bindings/script/jsb_cocos2d.js
+++ b/cocos/scripting/js-bindings/script/jsb_cocos2d.js
@@ -1089,3 +1089,57 @@ cc.GLProgram.prototype.setUniformLocationWithMatrix4fv = function(){
     tempArray.push(4);
     this.setUniformLocationWithMatrixfvUnion.apply(this, tempArray);
 };
+
+// Hack for the lifecycle of JS objects
+cc.Director.prototype._jsb_getScheduler = cc.Director.prototype.getScheduler;
+cc.Director.prototype.getScheduler = function() {
+    var scheduler = this._jsb_getScheduler();
+    if (this._jsb_scheduler != scheduler)
+    {
+        this._jsb_scheduler = scheduler;
+    }
+    return scheduler;
+}
+
+cc.Director.prototype._jsb_getActionManager = cc.Director.prototype.getActionManager;
+cc.Director.prototype.getActionManager = function() {
+    var actionManager = this._jsb_getActionManager();
+    if (this._jsb_actionManager != actionManager)
+    {
+        this._jsb_actionManager = actionManager;
+    }
+    return actionManager;
+}
+
+cc.Director.prototype._jsb_getEventDispatcher = cc.Director.prototype.getEventDispatcher;
+cc.Director.prototype.getEventDispatcher = function() {
+    var eventDispatcher = this._jsb_getEventDispatcher();
+    if (this._jsb_eventDispatcher != eventDispatcher)
+    {
+        this._jsb_eventDispatcher = eventDispatcher;
+    }
+    return eventDispatcher;
+}
+
+cc.SpriteFrame.prototype._jsb_getTexture = cc.SpriteFrame.prototype.getTexture;
+cc.SpriteFrame.prototype.getTexture = function() {
+    var texture = this._jsb_getTexture();
+    if (this._jsb_texture != texture)
+    {
+        this._jsb_texture = texture;
+    }
+    return texture;
+}
+
+cc.Sprite.prototype._jsb_getTexture = cc.Sprite.prototype.getTexture;
+cc.Sprite.prototype.getTexture = function() {
+    var texture = this._jsb_getTexture();
+    if (this._jsb_texture != texture)
+    {
+        this._jsb_texture = texture;
+    }
+    return texture;
+}
+
+//
+


### PR DESCRIPTION
* 修复 invokeJSTouchOneByOneCallback 内潜在的崩溃问题
* 修复调用 director.getScheduler()/.getActionManager()/.getEventDispatcher() 返回临时 JS 对象被 Mark GC 后导致的潜在崩溃问题
* 在 EventDispather 中添加回调函数用于通知派发事件开始和结束
* 在 TextureCache 中添加回调函数用于通知纹理加入缓存与从缓存中移除
* 修复 event.stopPropagation() 停止所有触点的响应的问题
* 修复 EventDispatcher::updateListener 可能未被调用的问题


* fixed potential invalid se::Object after invoking cc.director.getScheduler/getActionManager/getEventDispatcher, cc.SpriteFrame/Sprite.getTexture.
* Added hook functions in EventDispatcher, TextureCache to prevent using dangerous se::Object.
* Stop propagation for TouchOneByOne event should only affect current Touch point.
* Fixed updateListener may not be invoked.