### PR TITLE
Fixes memory issue in TMXLayer

### DIFF
--- a/cocos/2d/CCFastTMXLayer.cpp
+++ b/cocos/2d/CCFastTMXLayer.cpp
@@ -125,7 +125,7 @@ TMXLayer::~TMXLayer()
 {
     CC_SAFE_RELEASE(_tileSet);
     CC_SAFE_RELEASE(_texture);
-    CC_SAFE_DELETE_ARRAY(_tiles);
+    CC_SAFE_FREE(_tiles);
     CC_SAFE_RELEASE(_vData);
     CC_SAFE_RELEASE(_vertexBuffer);
     CC_SAFE_RELEASE(_indexBuffer);

--- a/cocos/2d/CCTMXLayer.cpp
+++ b/cocos/2d/CCTMXLayer.cpp
@@ -145,16 +145,12 @@ TMXLayer::~TMXLayer()
         _atlasIndexArray = nullptr;
     }
 
-    CC_SAFE_DELETE_ARRAY(_tiles);
+    CC_SAFE_FREE(_tiles);
 }
 
 void TMXLayer::releaseMap()
 {
-    if (_tiles)
-    {
-        delete [] _tiles;
-        _tiles = nullptr;
-    }
+    CC_SAFE_FREE(_tiles);
 
     if (_atlasIndexArray)
     {


### PR DESCRIPTION
_tiles is allocated by `malloc`

https://github.com/cocos-creator/cocos2d-x-lite/blob/develop/cocos/2d/CCTMXXMLParser.cpp#L510

https://github.com/cocos-creator/cocos2d-x-lite/blob/develop/cocos/2d/CCTMXXMLParser.cpp#L777

https://github.com/cocos-creator/cocos2d-x-lite/blob/develop/cocos/2d/CCTMXXMLParser.cpp#L781

However, code in Cocos2d-x-lite repo uses `delete[]` to release its memory.

https://github.com/cocos-creator/cocos2d-x-lite/blob/develop/cocos/2d/CCTMXLayer.cpp#L155

Cocos2d-x is using `free` : https://github.com/cocos2d/cocos2d-x/blob/v3/cocos/2d/CCTMXLayer.cpp#L148

