### PR TITLE
Fixes crash of missing se::AutoHandleScrope before se::createObjectWithClass in ScriptingCore::retainScriptObject.

### DIFF
--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -59,6 +59,9 @@ void ScriptingCore::retainScriptObject(Ref* owner, Ref* target)
         return;
     }
 
+    se::ScriptEngine::getInstance()->clearException();
+    se::AutoHandleScope hs;
+
     se::Value targetVal;
     se::Object* targetObj = nullptr;
     auto iterTarget = se::NativePtrToObjectMap::find(target);
@@ -78,8 +81,6 @@ void ScriptingCore::retainScriptObject(Ref* owner, Ref* target)
         targetObj = iterTarget->second;
     }
 
-    se::ScriptEngine::getInstance()->clearException();
-    se::AutoHandleScope hs;
     iterOwner->second->attachObject(targetObj);
 }
 


### PR DESCRIPTION
属于发布版本前导致的问题，不用写在Changelog里面。

属于 这个 PR 中漏考虑 createObjectWithClass 前需要HandleScope的问题，只有windows和android有问题。

错误信息为：

[FATAL ERROR] location: v8::HandleScope::CreateHandle(), message: Cannot create a handle without a HandleScope