### PR TITLE
Bug fix of releasing JS object logic in CPP controls JS object's cycle mode (spine, dragonbones, box2d).

### DIFF
--- a/cocos/scripting/js-bindings/docs/JSB2.0-learning-en.md
+++ b/cocos/scripting/js-bindings/docs/JSB2.0-learning-en.md
@@ -178,33 +178,45 @@ Under normal circumstances, if CPP object is not a subclass of `cocos2d :: Ref`,
 
 ```c++
 spTrackEntry_setDisposeCallback([](spTrackEntry* entry){
-        // The callback of spTrackEntry destruction
-        auto cleanup = [entry](){
+        se::Object* seObj = nullptr;
 
-            if (!se::ScriptEngine::getInstance()->isValid())
+        auto iter = se::NativePtrToObjectMap::find(entry);
+        if (iter != se::NativePtrToObjectMap::end())
+        {
+            // Save se::Object pointer for being used in cleanup method.
+            seObj = iter->second;
+            // Unmap native and js object since native object was destroyed.
+            // Otherwise, it may trigger 'assertion' in se::Object::setPrivateData later
+            // since native obj is already released and the new native object may be assigned with
+            // the same address.
+            se::NativePtrToObjectMap::erase(iter);
+        }
+        else
+        {
+            return;
+        }
+
+        auto cleanup = [seObj](){
+
+            auto se = se::ScriptEngine::getInstance();
+            if (!se->isValid() || se->isInCleanup())
                 return;
 
             se::AutoHandleScope hs;
-            se::ScriptEngine::getInstance()->clearException();
+            se->clearException();
 
-            auto iter = se::NativePtrToObjectMap::find(entry);
-            if (iter != se::NativePtrToObjectMap::end())
-            {
-                CCLOG("spTrackEntry %p was recycled!", entry);
-                se::Object* seObj = iter->second;
-                seObj->clearPrivateData(); // Remove the mapping
-                seObj->unroot(); // unroot，make JS objects controlled by garbage collector
-                seObj->decRef(); // Decrease the reference of se::Object
-            }
+            // The native <-> JS mapping was cleared in the callback above.
+            // seObj->clearPrivateData isn't needed since the JS object will be garbage collected after unroot and decRef.
+            seObj->unroot();
+            seObj->decRef();
         };
 
-        // Make sure not to touch JS engine API while garbage collecting.
         if (!se::ScriptEngine::getInstance()->isGarbageCollecting())
         {
             cleanup();
         }
         else
-        { // Put the cleanning task at the end of current game frame if it's in garbage collection.
+        {
             CleanupTask::pushTaskToAutoReleasePool(cleanup);
         }
     });
@@ -221,7 +233,7 @@ In addition, `se::Object` currently supports the manual creation of the followin
 
 * Plain Object: Created by `se::Object::createPlainObject`, similar to `var a = {};` in JS
 * Array Object: Created by `se::Object::createArrayObject`, similar to `var a = [];` in JS
-* Uint8 Typed Array Object: Created by `se::Object::createUint8TypedArray`, like `var a = new Uint8Array(buffer);` in JS
+* Uint8 Typed Array Object: Created by `se::Object::createTypedArray`, like `var a = new Uint8Array(buffer);` in JS
 * Array Buffer Object: Created by `se::Object::createArrayBufferObject` similar to `var a = new ArrayBuffer(len);` in JS
 
 __The Release of The Objects Created Manually__

--- a/cocos/scripting/js-bindings/docs/JSB2.0-learning-zh.md
+++ b/cocos/scripting/js-bindings/docs/JSB2.0-learning-zh.md
@@ -178,23 +178,38 @@ se::Object 中提供了 root/unroot 方法供开发者调用，root 会把 JS �
 ```c++
 spTrackEntry_setDisposeCallback([](spTrackEntry* entry){
         // spTrackEntry 的销毁回调
-        auto cleanup = [entry](){
+        se::Object* seObj = nullptr;
 
-            if (!se::ScriptEngine::getInstance()->isValid())
+        auto iter = se::NativePtrToObjectMap::find(entry);
+        if (iter != se::NativePtrToObjectMap::end())
+        {
+            // 保存 se::Object 指针，用于在下面的 cleanup 函数中释放其内存
+            seObj = iter->second;
+            // Native 对象 entry 的内存已经被释放，因此需要立马解除 Native 对象与 JS 对象的关联。
+            // 如果解除引用关系放在下面的 cleanup 函数中处理，有可能触发 se::Object::setPrivateData 中
+            // 的断言，因为新生成的 Native 对象的地址可能与当前对象相同，而 cleanup 可能被延迟到帧结束前执行。
+            se::NativePtrToObjectMap::erase(iter);
+        }
+        else
+        {
+            return;
+        }
+
+        auto cleanup = [seObj](){
+
+            auto se = se::ScriptEngine::getInstance();
+            if (!se->isValid() || se->isInCleanup())
                 return;
 
             se::AutoHandleScope hs;
-            se::ScriptEngine::getInstance()->clearException();
-
-            auto iter = se::NativePtrToObjectMap::find(entry);
-            if (iter != se::NativePtrToObjectMap::end())
-            {
-                CCLOG("spTrackEntry %p was recycled!", entry);
-                se::Object* seObj = iter->second;
-                seObj->clearPrivateData(); // 解除 mapping 关系
-                seObj->unroot(); // unroot，使 JS 对象受 GC 管理
-                seObj->decRef(); // 释放 se::Object
-            }
+            se->clearException();
+            
+            // 没必要调用 seObj->clearPrivateData ，因为 Native 对象与 JS 对象的引用关系已经在上面被解除。
+            // 如果调用，反而会导致把新生成的 Native 对象的引用关系错误解除掉。
+            // 设置 seObj 的 privateData 为 nullptr 也无意义，因为在执行 unroot 和 decRef 后，
+            // 当前 JS 对象即将被回收。
+            seObj->unroot(); // unroot，使 JS 对象受 GC 管理
+            seObj->decRef(); // 释放 se::Object
         };
 
         // 确保不再垃圾回收中去操作 JS 引擎的 API
@@ -218,7 +233,7 @@ __对象类型__
 
 * Plain Object : 通过 se::Object::createPlainObject 创建，类似 JS 中的 `var a = {};`
 * Array Object : 通过 se::Object::createArrayObject 创建，类似 JS 中的 `var a = [];`
-* Uint8 Typed Array Object : 通过 se::Object::createUint8TypedArray 创建，类似 JS 中的 `var a = new Uint8Array(buffer);`
+* Uint8 Typed Array Object : 通过 se::Object::createTypedArray 创建，类似 JS 中的 `var a = new Uint8Array(buffer);`
 * Array Buffer Object : 通过 se::Object::createArrayBufferObject，类似 JS 中的 `var a = new ArrayBuffer(len);`
 
 __手动创建对象的释放__

--- a/cocos/scripting/js-bindings/manual/jsb_box2d_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_box2d_manual.cpp
@@ -1081,29 +1081,40 @@ bool register_all_box2d_manual(se::Object* obj)
 
     b2SetObjectDestroyNotifier([](void* obj, b2ObjectType type, const char* typeName){
 
-        std::string typeNameStr = typeName;
-        auto cleanup = [obj, typeNameStr](){
+        se::Object* seObj = nullptr;
 
-            if (!se::ScriptEngine::getInstance()->isValid())
+        auto iter = se::NativePtrToObjectMap::find(obj);
+        if (iter != se::NativePtrToObjectMap::end())
+        {
+            // Save se::Object pointer for being used in cleanup method.
+            seObj = iter->second;
+            // Unmap native and js object since native object was destroyed.
+            // Otherwise, it may trigger 'assertion' in se::Object::setPrivateData later
+            // since native obj is already released and the new native object may be assigned with
+            // the same address.
+            se::NativePtrToObjectMap::erase(iter);
+        }
+        else
+        {
+//            CCLOG("Didn't find %s, %p in map", typeName, obj);
+//            assert(false);
+            return;
+        }
+
+        std::string typeNameStr = typeName;
+        auto cleanup = [seObj, typeNameStr](){
+
+            auto se = se::ScriptEngine::getInstance();
+            if (!se->isValid() || se->isInCleanup())
                 return;
 
             se::AutoHandleScope hs;
-            se::ScriptEngine::getInstance()->clearException();
+            se->clearException();
 
-            auto iter = se::NativePtrToObjectMap::find(obj);
-            if (iter != se::NativePtrToObjectMap::end())
-            {
-//                CCLOG("%s, %p was recycled!", typeNameStr.c_str(), obj);
-                se::Object* seObj = iter->second;
-                seObj->clearPrivateData();
-                seObj->unroot();
-                seObj->decRef();
-            }
-            else
-            {
-//                 CCLOG("Didn't find %s, %p in map", typeNameStr.c_str(), obj);
-//                 assert(false);
-            }
+            // The native <-> JS mapping was cleared in the callback above.
+            // seObj->clearPrivateData isn't needed since the JS object will be garbage collected after unroot and decRef.
+            seObj->unroot();
+            seObj->decRef();
         };
 
         if (!se::ScriptEngine::getInstance()->isGarbageCollecting())


### PR DESCRIPTION
解决 spine, box2d, dragonbones 绑定中可能触发 se::Object::setPrivateData 中的断言的问题。