### PR TITLE
Don't trigger an assertion if can't find se::Object by a touch. Warning instead.

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_cocos2dx_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_cocos2dx_manual.cpp
@@ -853,8 +853,14 @@ static void onAfterDispatchTouchEvent(Event* event)
             for (auto&& touch : touches)
             {
                 auto iter = se::NativePtrToObjectMap::find(touch);
-                assert(iter != se::NativePtrToObjectMap::end());
-                iter->second->unroot();
+                if (iter != se::NativePtrToObjectMap::end())
+                {
+                    iter->second->unroot();
+                }
+                else
+                {
+                    CCLOGWARN("Could not find touch %p, it's possible while restarting game and not all touches are released!", touch);
+                }
             }
         }
     }


### PR DESCRIPTION
解决下多点操作 UI 触发重启游戏后的崩溃问题