### PR TITLE
Resolve delete targetScheduler map element wrongly.

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_node.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_node.cpp
@@ -176,6 +176,38 @@ static const char* SCHEDULE_FUNC_ID_KEY = "__seScheFuncId";
 static std::unordered_map<uint32_t/*targetId*/, std::unordered_map<uint32_t/*funcId*/, ScheduleElement>> __js_target_schedulekey_map;
 static std::unordered_map<uint32_t/*targetId*/, std::pair<int/*priority*/, se::Object*>> __js_target_schedule_update_map;
 
+static void printElementsInTargetSchedulerMap()
+{
+#if COCOS2D_DEBUG > 0
+    SE_LOGD("--------------------------\nschedule target count: %d\n", (int)__js_target_schedulekey_map.size());
+    for (const auto& e1 : __js_target_schedulekey_map)
+    {
+        uint32_t targetID = e1.first;
+        const auto& functions = e1.second;
+        std::string functionIDStr;
+        if (!functions.empty())
+            functionIDStr.append("[");
+
+        for (const auto& fn : functions)
+        {
+            assert(fn.second.getFuncId() == fn.first);
+            assert(fn.second.getTargetId() == targetID);
+            char idStr[20] = {0};
+            snprintf(idStr, sizeof(idStr), "%u", fn.first);
+            functionIDStr.append(idStr);
+            functionIDStr.append(",");
+        }
+        if (!functions.empty())
+        {
+            functionIDStr = functionIDStr.substr(0, functionIDStr.size()-1);
+            functionIDStr.append("]");
+        }
+        SE_LOGD("schedule target: %u, functions: %s\n", e1.first, functionIDStr.c_str());
+    }
+    SE_LOGD("-------------------------- \n");
+#endif
+}
+
 static bool isScheduleExist(uint32_t jsFuncId, uint32_t jsTargetId, const ScheduleElement** outElement)
 {
     bool found = false;
@@ -235,7 +267,7 @@ static bool isScheduleExist(const std::string& key, uint32_t jsTargetId, const S
     return found;
 }
 
-static void removeSchedule(uint32_t jsFuncId, uint32_t jsTargetId, bool needDetachChild)
+static void removeSchedule(const std::string& key, uint32_t jsFuncId, uint32_t jsTargetId, bool needDetachChild)
 {
     auto funcObjKeyMapIter = __js_target_schedulekey_map.find(jsTargetId);
     if (funcObjKeyMapIter != __js_target_schedulekey_map.end())
@@ -245,17 +277,20 @@ static void removeSchedule(uint32_t jsFuncId, uint32_t jsTargetId, bool needDeta
         auto iter = funcMap.find(jsFuncId);
         if (iter != funcMap.end())
         {
-            se::Object* target = iter->second.getTarget();
-            se::Object* func = iter->second.getFunc();
-            if (needDetachChild)
+            if (iter->second.getKey() == key)
             {
-                target->detachObject(func);
+                se::Object* target = iter->second.getTarget();
+                se::Object* func = iter->second.getFunc();
+                if (needDetachChild)
+                {
+                    target->detachObject(func);
+                }
+
+                func->decRef();
+                target->decRef();
+
+                funcMap.erase(iter);
             }
-
-            func->decRef();
-            target->decRef();
-
-            funcMap.erase(iter);
         }
 
         if (funcMap.empty())
@@ -420,22 +455,25 @@ static bool isTargetExistInScheduler(uint32_t targetId)
 class UnscheduleNotifier
 {
 public:
-    UnscheduleNotifier(uint32_t funcId, uint32_t targetId)
-    : _funcId(funcId)
+    UnscheduleNotifier(const std::string& key, uint32_t funcId, uint32_t targetId)
+    : _key(key)
+    , _funcId(funcId)
     , _targetId(targetId)
     {
     }
     ~UnscheduleNotifier()
     {
-//        SE_LOGD("~UnscheduleNotifier, targetId: %u, funcId: %u\n", _targetId, _funcId);
-
+#if COCOS2D_DEBUG > 1
+        SE_LOGD("~UnscheduleNotifier, key: %s, targetId: %u, funcId: %u\n", _key.c_str(), _targetId, _funcId);
+#endif
         se::ScriptEngine::getInstance()->clearException();
         se::AutoHandleScope hs;
 
-        removeSchedule(_funcId, _targetId, false);
+        removeSchedule(_key, _funcId, _targetId, false);
     }
 
 private:
+    std::string _key;
     uint32_t _funcId;
     uint32_t _targetId;
 };
@@ -476,7 +514,7 @@ static bool Scheduler_scheduleCommon(Scheduler* scheduler, const se::Value& jsTh
 
         if (found && !key.empty())
         {
-            removeSchedule(funcId, targetId, true);
+            removeSchedule(key, funcId, targetId, true);
             scheduler->unschedule(key, reinterpret_cast<void*>(targetId));
         }
     }
@@ -509,7 +547,7 @@ static bool Scheduler_scheduleCommon(Scheduler* scheduler, const se::Value& jsTh
 
     se::Object* target = jsThis.toObject();
     insertSchedule(funcId, targetId, ScheduleElement(target, jsFunc.toObject(), key, targetId, funcId));
-    std::shared_ptr<UnscheduleNotifier> unscheduleNotifier = std::make_shared<UnscheduleNotifier>(funcId, targetId);
+    std::shared_ptr<UnscheduleNotifier> unscheduleNotifier = std::make_shared<UnscheduleNotifier>(key, funcId, targetId);
 
     if (toRootTarget)
     {
@@ -815,7 +853,7 @@ static bool Scheduler_unscheduleCommon(Scheduler* scheduler, const se::Value& js
 
     if (found && !key.empty())
     {
-        removeSchedule(funcId, targetId, true);
+        removeSchedule(key, funcId, targetId, true);
         scheduler->unschedule(key, reinterpret_cast<void*>(targetId));
     }
     else
@@ -1132,13 +1170,9 @@ static bool js_cocos2dx_Scheduler_schedule(se::State& s)
 {
     const auto& args = s.args();
     int argc = (int)args.size();
-#if 0//COCOS2D_DEBUG > 0
-    SE_LOGD("--------------------------\nschedule target count: %d\n", (int)__js_target_schedulekey_map.size());
-    for (const auto& e1 : __js_target_schedulekey_map)
-    {
-        SE_LOGD("schedule target: %p, functions: %d\n", e1.first, (int)e1.second.size());
-    }
-    SE_LOGD("-------------------------- \n");
+#if COCOS2D_DEBUG > 1
+    SE_LOGD("js_cocos2dx_Scheduler_schedule begin ...\n");
+    printElementsInTargetSchedulerMap();
 #endif
 
     //
@@ -1198,7 +1232,12 @@ static bool js_cocos2dx_Scheduler_schedule(se::State& s)
             SE_PRECONDITION2(ok, false, "Converting 'isPaused' argument failed");
         }
 
-        return Scheduler_scheduleCommon(cobj, jsThis, jsFunc, interval, repeat, delay, isPaused, !isBindedObject, "cc.Scheduler.schedule");
+        bool ret = Scheduler_scheduleCommon(cobj, jsThis, jsFunc, interval, repeat, delay, isPaused, !isBindedObject, "cc.Scheduler.schedule");
+#if COCOS2D_DEBUG > 1
+        SE_LOGD("js_cocos2dx_Scheduler_schedule end ...\n");
+        printElementsInTargetSchedulerMap();
+#endif
+        return ret;
     }
 
     SE_REPORT_ERROR("wrong number of arguments: %d, expected: %s", argc, ">=2");
@@ -1209,6 +1248,10 @@ SE_BIND_FUNC(js_cocos2dx_Scheduler_schedule)
 
 static bool js_cocos2dx_Scheduler_unschedule(se::State& s)
 {
+#if COCOS2D_DEBUG > 1
+    SE_LOGD("js_cocos2dx_Scheduler_unschedule begin ...\n");
+    printElementsInTargetSchedulerMap();
+#endif
     const auto& args = s.args();
     int argc = (int)args.size();
 
@@ -1227,7 +1270,12 @@ static bool js_cocos2dx_Scheduler_unschedule(se::State& s)
             jsTarget = args[0];
         }
         Scheduler* cobj = (Scheduler*)s.nativeThisObject();
-        return Scheduler_unscheduleCommon(cobj, jsTarget, jsFuncOrKey);
+        bool ret = Scheduler_unscheduleCommon(cobj, jsTarget, jsFuncOrKey);
+#if COCOS2D_DEBUG > 1
+        SE_LOGD("js_cocos2dx_Scheduler_unschedule end ...\n");
+        printElementsInTargetSchedulerMap();
+#endif
+        return ret;
     }
     SE_REPORT_ERROR("wrong number of arguments: %d, expected: %s", argc, ">=2");
     return false;

--- a/cocos/scripting/js-bindings/manual/jsb_node.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_node.cpp
@@ -176,9 +176,9 @@ static const char* SCHEDULE_FUNC_ID_KEY = "__seScheFuncId";
 static std::unordered_map<uint32_t/*targetId*/, std::unordered_map<uint32_t/*funcId*/, ScheduleElement>> __js_target_schedulekey_map;
 static std::unordered_map<uint32_t/*targetId*/, std::pair<int/*priority*/, se::Object*>> __js_target_schedule_update_map;
 
+#if COCOS2D_DEBUG > 1
 static void printElementsInTargetSchedulerMap()
 {
-#if COCOS2D_DEBUG > 0
     SE_LOGD("--------------------------\nschedule target count: %d\n", (int)__js_target_schedulekey_map.size());
     for (const auto& e1 : __js_target_schedulekey_map)
     {
@@ -205,8 +205,8 @@ static void printElementsInTargetSchedulerMap()
         SE_LOGD("schedule target: %u, functions: %s\n", e1.first, functionIDStr.c_str());
     }
     SE_LOGD("-------------------------- \n");
-#endif
 }
+#endif
 
 static bool isScheduleExist(uint32_t jsFuncId, uint32_t jsTargetId, const ScheduleElement** outElement)
 {


### PR DESCRIPTION
修复在 schedule 回调中 unschedule 和再次 schedule 当前回调函数触发的JS异常问题

```c++
    count: function (dt) {
        this.ttt -= dt;
        if (this.ttt <= 0) {
            this.ttt = 5;
            this.unschedule(this.count);
            this.schedule(this.count, 0.1);
        }
        this.node.getComponent(cc.Label).string = parseInt(this.ttt);
    },
```