### PR TITLE
Fix redundant zero while se::Value::toStringForce for a float number.

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/Value.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/Value.cpp
@@ -509,12 +509,8 @@ namespace se {
         }
         else if (_type == Type::Number)
         {
-            char tmp[350] = {0};
-            double remainder = fmod(_u._number, 1.0);
-            if (std::abs(remainder) > 0)
-                snprintf(tmp, sizeof(tmp), "%lf", _u._number);
-            else
-                snprintf(tmp, sizeof(tmp), "%d", (int32_t)_u._number);
+            char tmp[50] = {0};
+            snprintf(tmp, sizeof(tmp), "%.17g", _u._number);
             ret = tmp;
         }
         else if (_type == Type::Object)


### PR DESCRIPTION
解决 JS 浮点数转换到 native 字符串的时候出现多余的 0 的情况。