### PR TITLE
Removes unused Texture2D::forceDeleteALLTexture2D which was added from runtime.

### DIFF
--- a/cocos/renderer/CCTexture2D.cpp
+++ b/cocos/renderer/CCTexture2D.cpp
@@ -431,16 +431,6 @@ void Texture2D::convertRGBA8888ToRGB5A1(const unsigned char* data, ssize_t dataL
 }
 // converter function end
 //////////////////////////////////////////////////////////////////////////
-static std::unordered_set<Texture2D*> s_allGLTexture2D;
-
-void Texture2D::forceDeleteALLTexture2D()
-{
-    auto copyMap = s_allGLTexture2D;
-    for (auto&& it: copyMap) {
-        delete it;
-    }
-    s_allGLTexture2D.clear();
-}
 
 Texture2D::Texture2D()
 : _pixelFormat(Texture2D::PixelFormat::DEFAULT)
@@ -457,15 +447,11 @@ Texture2D::Texture2D()
 , _valid(true)
 , _alphaTexture(nullptr)
 {
-    s_allGLTexture2D.insert(this);
     _antialiasEnabled = Director::getInstance()->getOpenGLView()->isAntiAliasEnabled();
 }
 
 Texture2D::~Texture2D()
 {
-    if (s_allGLTexture2D.find(this) != s_allGLTexture2D.end()) {
-        s_allGLTexture2D.erase(this);
-    }
 #if CC_ENABLE_CACHE_TEXTURE_DATA
     VolatileTextureMgr::removeTexture(this);
 #endif

--- a/cocos/renderer/CCTexture2D.h
+++ b/cocos/renderer/CCTexture2D.h
@@ -179,8 +179,6 @@ public:
      */
     static Texture2D::PixelFormat getDefaultAlphaPixelFormat();
     
-    static void forceDeleteALLTexture2D();
-
 public:
     /**
      * @js ctor


### PR DESCRIPTION
解决退出游戏导致的低概率崩溃问题

移除 Texture2D:: forceDeleteALLTexture2D 无用函数，解决已经被释放全局变量导致的崩溃问题。