### PR TITLE
Best gradle configuration for Android.

### DIFF
--- a/cocos/platform/android/libcocos2dx-with-controller/build.gradle
+++ b/cocos/platform/android/libcocos2dx-with-controller/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion 22
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }

--- a/cocos/platform/android/libcocos2dx/build.gradle
+++ b/cocos/platform/android/libcocos2dx/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
-        minSdkVersion 10
-        targetSdkVersion PROP_TARGET_SDK_VERSION
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }

--- a/cocos/platform/android/libcocos2dx/build.gradle
+++ b/cocos/platform/android/libcocos2dx/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '26.0.2'
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion PROP_TARGET_SDK_VERSION
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"

--- a/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.cocos2dx.hellojavascript"
-        minSdkVersion 14
+        minSdkVersion PROP_TARGET_SDK_VERSION
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -19,7 +19,7 @@ android {
                     // skip the NDK Build step if PROP_NDK_MODE is none
                     targets 'cocos2djs'
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
-                    arguments 'APP_PLATFORM=android-14'
+                    arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
                     
                     def module_paths = [project.file("${COCOS_X_ROOT}"),
                                         project.file("${COCOS_X_ROOT}/cocos"),

--- a/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -3,13 +3,13 @@ import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "org.cocos2dx.hellojavascript"
-        minSdkVersion 10
-        targetSdkVersion PROP_TARGET_SDK_VERSION
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -19,7 +19,7 @@ android {
                     // skip the NDK Build step if PROP_NDK_MODE is none
                     targets 'cocos2djs'
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
-                    arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
+                    arguments 'APP_PLATFORM=android-14'
                     
                     def module_paths = [project.file("${COCOS_X_ROOT}"),
                                         project.file("${COCOS_X_ROOT}/cocos"),

--- a/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/gradle.properties
+++ b/templates/js-template-binary/frameworks/runtime-src/proj.android-studio/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-PROP_TARGET_SDK_VERSION=22
+PROP_TARGET_SDK_VERSION=14
 PROP_APP_ABI=armeabi-v7a
 
 RELEASE_STORE_FILE=

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -3,13 +3,13 @@ import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "org.cocos2d.helloworld"
-        minSdkVersion 10
-        targetSdkVersion PROP_TARGET_SDK_VERSION
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -19,7 +19,7 @@ android {
                     // skip the NDK Build step if PROP_NDK_MODE is none
                     targets 'cocos2djs'
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
-                    arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
+                    arguments 'APP_PLATFORM=android-14'
                     
                     def module_paths = [project.file("../../../cocos2d-x"),
                                         project.file("../../../cocos2d-x/cocos"),

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.cocos2d.helloworld"
-        minSdkVersion 14
+        minSdkVersion PROP_TARGET_SDK_VERSION
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -19,7 +19,7 @@ android {
                     // skip the NDK Build step if PROP_NDK_MODE is none
                     targets 'cocos2djs'
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
-                    arguments 'APP_PLATFORM=android-14'
+                    arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
                     
                     def module_paths = [project.file("../../../cocos2d-x"),
                                         project.file("../../../cocos2d-x/cocos"),

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/gradle.properties
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-PROP_TARGET_SDK_VERSION=22
+PROP_TARGET_SDK_VERSION=14
 PROP_APP_ABI=armeabi-v7a
 
 RELEASE_STORE_FILE=

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.cocos2dx.hellojavascript"
-        minSdkVersion 14
+        minSdkVersion PROP_TARGET_SDK_VERSION
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -19,7 +19,7 @@ android {
                     // skip the NDK Build step if PROP_NDK_MODE is none
                     targets 'cocos2djs'
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
-                    arguments 'APP_PLATFORM=android-14'
+                    arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
                     
                     def module_paths = [project.file("${COCOS_X_ROOT}"),
                                         project.file("${COCOS_X_ROOT}/cocos"),

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -3,13 +3,13 @@ import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "org.cocos2dx.hellojavascript"
-        minSdkVersion 10
-        targetSdkVersion PROP_TARGET_SDK_VERSION
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -19,7 +19,7 @@ android {
                     // skip the NDK Build step if PROP_NDK_MODE is none
                     targets 'cocos2djs'
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
-                    arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
+                    arguments 'APP_PLATFORM=android-14'
                     
                     def module_paths = [project.file("${COCOS_X_ROOT}"),
                                         project.file("${COCOS_X_ROOT}/cocos"),

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/gradle.properties
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-PROP_TARGET_SDK_VERSION=22
+PROP_TARGET_SDK_VERSION=14
 PROP_APP_ABI=armeabi-v7a
 
 RELEASE_STORE_FILE=

--- a/tools/simulator/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/tools/simulator/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -3,13 +3,13 @@ import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
+    compileSdkVersion 26
     buildToolsVersion '26.0.2'
 
     defaultConfig {
         applicationId "org.cocos2d.helloworld"
-        minSdkVersion 10
-        targetSdkVersion PROP_TARGET_SDK_VERSION
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 
@@ -19,7 +19,7 @@ android {
                     // skip the NDK Build step if PROP_NDK_MODE is none
                     targets 'cocos2djs'
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
-                    arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
+                    arguments 'APP_PLATFORM=android-14'
                     
                     def module_paths = [project.file("../../../../../.."),
                                         project.file("../../../../../../cocos"),

--- a/tools/simulator/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/tools/simulator/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "org.cocos2d.helloworld"
-        minSdkVersion 14
+        minSdkVersion PROP_TARGET_SDK_VERSION
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
@@ -19,7 +19,7 @@ android {
                     // skip the NDK Build step if PROP_NDK_MODE is none
                     targets 'cocos2djs'
                     arguments 'NDK_TOOLCHAIN_VERSION=4.9'
-                    arguments 'APP_PLATFORM=android-14'
+                    arguments 'APP_PLATFORM=android-'+PROP_TARGET_SDK_VERSION
                     
                     def module_paths = [project.file("../../../../../.."),
                                         project.file("../../../../../../cocos"),

--- a/tools/simulator/frameworks/runtime-src/proj.android-studio/gradle.properties
+++ b/tools/simulator/frameworks/runtime-src/proj.android-studio/gradle.properties
@@ -17,7 +17,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-PROP_TARGET_SDK_VERSION=22
+PROP_TARGET_SDK_VERSION=14
 PROP_APP_ABI=armeabi:armeabi-v7a:arm64-v8a:x86
 
 RELEASE_STORE_FILE=debug.keystore


### PR DESCRIPTION
Issue report: http://forum.cocos.com/t/1-8-x-creator/56189/7

这是目前为止，兼容性比较好的配置，由于 https://github.com/cocos-creator/fireball/issues/6675 任务需要在 1.9 中完成，而开发者选择不同的 api level 可能会掉进各种不兼容的坑中。
这个 PR 写死了最优的配置，看是否合并吧。

合并后，构建面板的 API Level 的表示的是编译出的 apk 支持在`最低`的哪个 Android 版本中运行。
需要建议用户选择 14 进行编译。而且需要在 release note 中说明，防止用户吐槽。