### PR TITLE
Adds JS interfaces for getting JSBinding object count.

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -818,6 +818,22 @@ static bool js_performance_now(se::State& s)
 }
 SE_BIND_FUNC(js_performance_now)
 
+static bool JSB_getJSBindingObjectCount(se::State& s)
+{
+    size_t size = se::NativePtrToObjectMap::size();
+    s.rval().setUlong(size);
+    return true;
+}
+SE_BIND_FUNC(JSB_getJSBindingObjectCount)
+
+static bool JSB_getJSBindingObjectCountNonRefAndCreatedInJS(se::State& s)
+{
+    size_t size = se::NonRefNativePtrCreatedByCtorMap::size();
+    s.rval().setUlong(size);
+    return true;
+}
+SE_BIND_FUNC(JSB_getJSBindingObjectCountNonRefAndCreatedInJS)
+
 bool jsb_register_global_variables(se::Object* global)
 {
     global->defineFunction("require", _SE(require));
@@ -832,6 +848,8 @@ bool jsb_register_global_variables(se::Object* global)
 
     __jscObj->defineFunction("garbageCollect", _SE(jsc_garbageCollect));
     __jscObj->defineFunction("dumpNativePtrToSeObjectMap", _SE(jsc_dumpNativePtrToSeObjectMap));
+    __jscObj->defineFunction("getJSBindingObjectCount", _SE(JSB_getJSBindingObjectCount));
+    __jscObj->defineFunction("getJSBindingObjectCountNonRefCreatedInJS", _SE(JSB_getJSBindingObjectCountNonRefAndCreatedInJS));
 
     global->defineFunction("__getPlatform", _SE(JSBCore_platform));
     global->defineFunction("__getOS", _SE(JSBCore_os));


### PR DESCRIPTION
添加如下两个接口，方便游戏开发者发现绑定对象内存泄露问题。

```
__jsc__.getJSBindingObjectCount returns the mapping size of Ref's sub class object and non-Ref class but lifecycle controlled by C++.
__jsc__.getJSBindingObjectCountNonRefCreatedInJS returns the mapping size of Non-Ref class object and JS object created in JS.
```