### PR TITLE
Ignore infinite loop in Exception handling.

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.cpp
@@ -354,7 +354,9 @@ namespace se {
     ScriptEngine::ExceptionInfo ScriptEngine::_formatException(JSValueRef exception)
     {
         ExceptionInfo ret;
-        internal::forceConvertJsValueToStdString(_cx, exception, &ret.message);
+
+        // Ignore Exception in forceConvertJsValueToStdString invocation to avoid infinite loop.
+        internal::forceConvertJsValueToStdString(_cx, exception, &ret.message, true);
 
         JSType type = JSValueGetType(_cx, exception);
 

--- a/cocos/scripting/js-bindings/jswrapper/jsc/Utils.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/Utils.cpp
@@ -217,20 +217,27 @@ namespace se {
         }
     }
 
-    void forceConvertJsValueToStdString(JSContextRef cx, JSValueRef jsval, std::string* ret)
+    void forceConvertJsValueToStdString(JSContextRef cx, JSValueRef jsval, std::string* ret, bool ignoreException/* = false */)
     {
         JSValueRef exception = nullptr;
         JSStringRef jsstr = JSValueToStringCopy(cx, jsval, &exception);
         if (exception != nullptr)
         {
-            ScriptEngine::getInstance()->_clearException(exception);
+            // NOTE: ignoreException is true in ScriptEngine::_formatException because it's already in the _clearException process.
+            // Adds this flag to avoid infinite loop of _clearException -> _formatException -> forceConvertJsValueToStdString -> _clearException -> ...
+            if (!ignoreException)
+            {
+                ScriptEngine::getInstance()->_clearException(exception);
+            }
             ret->clear();
         }
         else
         {
             jsStringToStdString(cx, jsstr, ret);
         }
-        JSStringRelease(jsstr);
+
+        if (jsstr != nullptr)
+            JSStringRelease(jsstr);
     }
 
     void jsStringToStdString(JSContextRef cx, JSStringRef jsStr, std::string* ret)

--- a/cocos/scripting/js-bindings/jswrapper/jsc/Utils.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/Utils.hpp
@@ -50,7 +50,7 @@ namespace se {
         void jsToSeValue(JSContextRef cx, JSValueRef jsval, Value* v);
         void seToJsValue(JSContextRef cx, const Value& v, JSValueRef* jsval);
 
-        void forceConvertJsValueToStdString(JSContextRef cx, JSValueRef jsval, std::string* ret);
+        void forceConvertJsValueToStdString(JSContextRef cx, JSValueRef jsval, std::string* ret, bool ignoreException = false);
         void jsStringToStdString(JSContextRef cx, JSStringRef jsStr, std::string* ret);
 
         bool hasPrivate(JSObjectRef obj);


### PR DESCRIPTION
解决 JS 代码异常导致低概率的异常处理过程中的崩溃问题