### PR TITLE
PR #1114 fix is incorrect, fix it again.

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_cocos2dx_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_cocos2dx_manual.cpp
@@ -1468,21 +1468,23 @@ static bool js_cocos2dx_CallFunc_create(se::State& s)
         CallFuncN* ret = new (std::nothrow) CallFuncN;
         se::Object* jsobj = se::Object::createObjectWithClass(__jsb_cocos2d_CallFuncN_class);
         jsobj->setPrivateData(ret);
-        // Assign jsobj to s.rval() to avoid jsobj be swept by GC immediately.
+
+        // Assign jsobj to jsVal and auto root it to avoid jsobj be swept by GC immediately.
         // Because there is "jsobj->attachObject(funcVal.toObject());" in "js_cocos2dx_CallFunc_init" function.
         // attachObject will do a function invocation which may mark 'jsobj' into an invalid state but without
         // invoking CallFuncN's finalize callback immediately.
         // AddressSanitizer in Xcode will prompt: heap-use-after-free on address.
-        s.rval().setObject(jsobj);
+        se::Value jsVal;
+        jsVal.setObject(jsobj, true); // Pass true to indicate auto root / unroot by jsVal
 
-        if (!js_cocos2dx_CallFunc_init(ret, jsobj, args))
+        if (js_cocos2dx_CallFunc_init(ret, jsobj, args))
         {
-            s.rval().setUndefined();
-            SE_REPORT_ERROR("js_cocos2dx_CallFunc_create: initWithFunction failed!");
-            return false;
+            s.rval() = std::move(jsVal);
+            return true;
         }
 
-        return true;
+        SE_REPORT_ERROR("js_cocos2dx_CallFunc_create: initWithFunction failed!");
+        return false;
     }
     SE_REPORT_ERROR("js_cocos2dx_CallFunc_create: Invalid number of arguments");
     return false;


### PR DESCRIPTION
解决 iOS 平台上调用 cc.callFunc 低概率崩溃问题。

PR #1114 fix is incorrect, fix it again.
Potential crash fix in cc.callFunc binding.