### PR TITLE
Reverts PR #1062 which may lead to other issues, fix it by another way. 

### DIFF
--- a/cocos/2d/CCActionInterval.cpp
+++ b/cocos/2d/CCActionInterval.cpp
@@ -290,6 +290,9 @@ bool Sequence::initWithTwoActions(FiniteTimeAction *actionOne, FiniteTimeAction 
         return false;
     }
 
+    CCASSERT(actionOne != this, "actionOne should not be sequence self!");
+    CCASSERT(actionTwo != this, "actionOne should not be sequence self!");
+
     float d = actionOne->getDuration() + actionTwo->getDuration();
     ActionInterval::initWithDuration(d);
 

--- a/cocos/2d/CCNode.cpp
+++ b/cocos/2d/CCNode.cpp
@@ -693,11 +693,8 @@ void Node::setGLProgram(GLProgram* glProgram)
 {
     if (_glProgramState == nullptr || (_glProgramState && _glProgramState->getGLProgram() != glProgram))
     {
-        CC_SAFE_RELEASE(_glProgramState);
-        _glProgramState = GLProgramState::getOrCreateWithGLProgram(glProgram);
-        _glProgramState->retain();
-
-        _glProgramState->setNodeBinding(this);
+        auto glProgramState = GLProgramState::getOrCreateWithGLProgram(glProgram);
+        setGLProgramState(glProgramState);
     }
 }
 

--- a/cocos/2d/CCNode.h
+++ b/cocos/2d/CCNode.h
@@ -985,7 +985,7 @@ public:
      * Since v2.0, each rendering node must set its shader program.
      * It should be set in initialize phase.
      @code
-     node->setGLrProgram(GLProgramCache::getInstance()->getProgram(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
+     node->setGLProgram(GLProgramCache::getInstance()->getProgram(GLProgram::SHADER_NAME_POSITION_TEXTURE_COLOR));
      @endcode
      *
      * @param glprogram The shader program.

--- a/cocos/renderer/CCGLProgramCache.h
+++ b/cocos/renderer/CCGLProgramCache.h
@@ -84,12 +84,20 @@ public:
     /** reload default programs these are relative to light */
     void reloadDefaultGLProgramsRelativeToLights();
 
+    using GLProgramLifeCycleHook = void (*)(GLProgramCache*, GLProgram*);
+    static void setGLProgramCreateHook(GLProgramLifeCycleHook hook);
+    static void setGLProgramDestroyHook(GLProgramLifeCycleHook hook);
+
+    void notifyAllGLProgramsCreated();
+
 private:
     /**
     @{
         Init and load predefined shaders.
     */
     bool init();
+    void cleanup();
+
     void loadDefaultGLProgram(GLProgram *program, int type);
     /**
     @}

--- a/cocos/renderer/CCGLProgramStateCache.h
+++ b/cocos/renderer/CCGLProgramStateCache.h
@@ -62,6 +62,10 @@ public:
     /**Remove unused GLProgramState.*/
     void removeUnusedGLProgramState();
 
+    using GLProgramStateLifeCycleHook = void (*)(GLProgramStateCache*, GLProgramState*);
+    static void setGLProgramStateCreateHook(GLProgramStateLifeCycleHook hook);
+    static void setGLProgramStateDestroyHook(GLProgramStateLifeCycleHook hook);
+
 protected:
     GLProgramStateCache();
     ~GLProgramStateCache();

--- a/cocos/renderer/CCTextureCache.cpp
+++ b/cocos/renderer/CCTextureCache.cpp
@@ -41,11 +41,14 @@ THE SOFTWARE.
 #include "base/ccUtils.h"
 #include "base/CCNinePatchImageParser.h"
 
-
-
 using namespace std;
 
 NS_CC_BEGIN
+
+namespace {
+    TextureCache::TextureLifeCycleHook __textureCreateHook = nullptr;
+    TextureCache::TextureLifeCycleHook __textureDestroyHook = nullptr;
+}
 
 // implementation TextureCache
 
@@ -56,8 +59,6 @@ TextureCache* TextureCache::getInstance()
 
 TextureCache::TextureCache()
 : _loadingThread(nullptr)
-, _textureCreateHook(nullptr)
-, _textureDestroyHook(nullptr)
 , _asyncRefCount(0)
 , _needQuit(false)
 {
@@ -301,8 +302,8 @@ void TextureCache::addImageAsyncCallBack(float dt)
 
                 texture->autorelease();
 
-                if (_textureCreateHook != nullptr)
-                    _textureCreateHook(this, texture);
+                if (__textureCreateHook != nullptr)
+                    __textureCreateHook(this, texture);
             } else {
                 texture = nullptr;
                 CCLOG("cocos2d: failed to call TextureCache::addImageAsync(%s)", asyncStruct->filename.c_str());
@@ -365,8 +366,8 @@ Texture2D * TextureCache::addImage(const std::string &path)
                 // texture already retained, no need to re-retain it
                 _textures.insert( std::make_pair(fullpath, texture) );
 
-                if (_textureCreateHook != nullptr)
-                    _textureCreateHook(this, texture);
+                if (__textureCreateHook != nullptr)
+                    __textureCreateHook(this, texture);
 
                 //parse 9-patch info
                 this->parseNinePatchImage(image, texture, path);
@@ -419,8 +420,8 @@ Texture2D* TextureCache::addImage(Image *image, const std::string &key)
 
             texture->autorelease();
 
-            if (_textureCreateHook != nullptr)
-                _textureCreateHook(this, texture);
+            if (__textureCreateHook != nullptr)
+                __textureCreateHook(this, texture);
         }
         else
         {
@@ -494,8 +495,8 @@ cocos2d::Vector<Texture2D*> TextureCache::getAllTextures() const
 void TextureCache::removeAllTextures()
 {
     for( auto it=_textures.begin(); it!=_textures.end(); ++it ) {
-        if (_textureDestroyHook != nullptr)
-            _textureDestroyHook(this, it->second);
+        if (__textureDestroyHook != nullptr)
+            __textureDestroyHook(this, it->second);
 
         (it->second)->release();
     }
@@ -508,8 +509,8 @@ void TextureCache::removeUnusedTextures()
         Texture2D *tex = it->second;
         if( tex->getReferenceCount() == 1 ) {
             CCLOG("cocos2d: TextureCache: removing unused texture: %s", it->first.c_str());
-            if (_textureDestroyHook != nullptr)
-                _textureDestroyHook(this, tex);
+            if (__textureDestroyHook != nullptr)
+                __textureDestroyHook(this, tex);
 
             tex->release();
             it = _textures.erase(it);
@@ -530,8 +531,8 @@ void TextureCache::removeTexture(Texture2D* texture)
 
     for( auto it=_textures.cbegin(); it!=_textures.cend(); /* nothing */ ) {
         if( it->second == texture ) {
-            if (_textureDestroyHook != nullptr)
-                _textureDestroyHook(this, texture);
+            if (__textureDestroyHook != nullptr)
+                __textureDestroyHook(this, texture);
 
             it->second->release();
             it = _textures.erase(it);
@@ -553,8 +554,8 @@ void TextureCache::removeTextureForKey(const std::string &textureKeyName)
     }
 
     if( it != _textures.end() ) {
-        if (_textureDestroyHook != nullptr)
-            _textureDestroyHook(this, it->second);
+        if (__textureDestroyHook != nullptr)
+            __textureDestroyHook(this, it->second);
 
         (it->second)->release();
         _textures.erase(it);
@@ -679,14 +680,16 @@ void TextureCache::renameTextureWithKey(const std::string& srcName, const std::s
     }
 }
 
+/* static */
 void TextureCache::setTextureCreateHook(TextureLifeCycleHook hook)
 {
-    _textureCreateHook = hook;
+    __textureCreateHook = hook;
 }
 
+/* static */
 void TextureCache::setTextureDestroyHook(TextureLifeCycleHook hook)
 {
-    _textureDestroyHook = hook;
+    __textureDestroyHook = hook;
 }
 
 #if CC_ENABLE_CACHE_TEXTURE_DATA

--- a/cocos/renderer/CCTextureCache.h
+++ b/cocos/renderer/CCTextureCache.h
@@ -213,8 +213,8 @@ public:
     void renameTextureWithKey(const std::string& srcName, const std::string& dstName);
 
     using TextureLifeCycleHook = void (*)(TextureCache*, Texture2D*);
-    void setTextureCreateHook(TextureLifeCycleHook hook);
-    void setTextureDestroyHook(TextureLifeCycleHook hook);
+    static void setTextureCreateHook(TextureLifeCycleHook hook);
+    static void setTextureDestroyHook(TextureLifeCycleHook hook);
 
 private:
     void addImageAsyncCallBack(float dt);
@@ -235,9 +235,6 @@ protected:
     std::unordered_map<std::string, Texture2D*> _textures;
 
     std::thread* _loadingThread;
-
-    TextureLifeCycleHook _textureCreateHook;
-    TextureLifeCycleHook _textureDestroyHook;
 
     int _asyncRefCount;
     bool _needQuit;

--- a/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
+++ b/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
@@ -14228,6 +14228,14 @@ GLProgram : function (
 cc.ShaderCache = {
 
 /**
+ * @method notifyAllGLProgramsCreated
+ */
+notifyAllGLProgramsCreated : function (
+)
+{
+},
+
+/**
  * @method loadDefaultGLPrograms
  */
 loadDefaultGLPrograms : function (

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
@@ -32612,6 +32612,21 @@ bool js_register_cocos2dx_GLProgram(se::Object* obj)
 se::Object* __jsb_cocos2d_GLProgramCache_proto = nullptr;
 se::Class* __jsb_cocos2d_GLProgramCache_class = nullptr;
 
+static bool js_cocos2dx_GLProgramCache_notifyAllGLProgramsCreated(se::State& s)
+{
+    cocos2d::GLProgramCache* cobj = (cocos2d::GLProgramCache*)s.nativeThisObject();
+    SE_PRECONDITION2(cobj, false, "js_cocos2dx_GLProgramCache_notifyAllGLProgramsCreated : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    if (argc == 0) {
+        cobj->notifyAllGLProgramsCreated();
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_cocos2dx_GLProgramCache_notifyAllGLProgramsCreated)
+
 static bool js_cocos2dx_GLProgramCache_loadDefaultGLPrograms(se::State& s)
 {
     cocos2d::GLProgramCache* cobj = (cocos2d::GLProgramCache*)s.nativeThisObject();
@@ -32759,6 +32774,7 @@ bool js_register_cocos2dx_GLProgramCache(se::Object* obj)
 {
     auto cls = se::Class::create("ShaderCache", obj, nullptr, _SE(js_cocos2dx_GLProgramCache_constructor));
 
+    cls->defineFunction("notifyAllGLProgramsCreated", _SE(js_cocos2dx_GLProgramCache_notifyAllGLProgramsCreated));
     cls->defineFunction("loadDefaultShaders", _SE(js_cocos2dx_GLProgramCache_loadDefaultGLPrograms));
     cls->defineFunction("reloadDefaultGLProgramsRelativeToLights", _SE(js_cocos2dx_GLProgramCache_reloadDefaultGLProgramsRelativeToLights));
     cls->defineFunction("addProgram", _SE(js_cocos2dx_GLProgramCache_addGLProgram));

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp
@@ -2128,6 +2128,7 @@ extern se::Class* __jsb_cocos2d_GLProgramCache_class;
 
 bool js_register_cocos2d_GLProgramCache(se::Object* obj);
 bool register_all_cocos2dx(se::Object* obj);
+SE_DECLARE_FUNC(js_cocos2dx_GLProgramCache_notifyAllGLProgramsCreated);
 SE_DECLARE_FUNC(js_cocos2dx_GLProgramCache_loadDefaultGLPrograms);
 SE_DECLARE_FUNC(js_cocos2dx_GLProgramCache_reloadDefaultGLProgramsRelativeToLights);
 SE_DECLARE_FUNC(js_cocos2dx_GLProgramCache_addGLProgram);

--- a/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
+++ b/cocos/scripting/js-bindings/manual/ScriptingCore.cpp
@@ -59,29 +59,29 @@ void ScriptingCore::retainScriptObject(Ref* owner, Ref* target)
         return;
     }
 
-    se::ScriptEngine::getInstance()->clearException();
-    se::AutoHandleScope hs;
-
-    se::Value targetVal;
-    se::Object* targetObj = nullptr;
+    // NOTE: If target isn't created from JS, we should return directly here.
+    // When JS invokes getter method, we should hack the getter method to invoke jsb.registerNativeRef.
+    // For example, you could refer to jsb_cocos2d.js, there are some code like:
+    /*
+         cc.TMXLayer.prototype._getTileAt = cc.TMXLayer.prototype.getTileAt;
+         cc.TMXLayer.prototype.getTileAt = function(x, y){
+            var pos = y !== undefined ? cc.p(x, y) : x;
+            var ret = this._getTileAt(pos);
+            jsb.registerNativeRef(this, ret); // Re-attach the target since ret is created in C++ and retainScriptObject failed.
+            return ret;
+         };
+     */
     auto iterTarget = se::NativePtrToObjectMap::find(target);
     if (iterTarget == se::NativePtrToObjectMap::end())
     {
-        se::Class* cls = JSBClassType::findClass(target);
-        if (cls == nullptr)
-            return;
-
-        targetObj = se::Object::createObjectWithClass(cls);
-        targetVal.setObject(targetObj, true);
-        targetObj->setPrivateData(target);
-        target->retain(); // Retain the native object to unify the logic in finalize method of js object.
-    }
-    else
-    {
-        targetObj = iterTarget->second;
+        return;
     }
 
-    iterOwner->second->attachObject(targetObj);
+    assert(!se::ScriptEngine::getInstance()->isGarbageCollecting());
+    se::ScriptEngine::getInstance()->clearException();
+    se::AutoHandleScope hs;
+
+    iterOwner->second->attachObject(iterTarget->second);
 }
 
 void ScriptingCore::rootScriptObject(Ref* target)

--- a/cocos/scripting/js-bindings/script/jsb_boot.js
+++ b/cocos/scripting/js-bindings/script/jsb_boot.js
@@ -89,6 +89,9 @@ cc.eventManager._resizeListener = cc.eventManager.addCustomListener('window-resi
 cc.configuration = cc.Configuration.getInstance();
 cc.textureCache = cc.director.getTextureCache();
 cc.shaderCache = cc.ShaderCache.getInstance();
+// The first time we invoke cc.ShaderCache.getInstance, notifyAllGLProgramsCreated needs to be called.
+// It should be invoked only once.
+cc.shaderCache.notifyAllGLProgramsCreated();
 cc.plistParser = cc.PlistParser.getInstance();
 
 // File utils (Temporary, won't be accessible)

--- a/cocos/scripting/js-bindings/script/jsb_boot.js
+++ b/cocos/scripting/js-bindings/script/jsb_boot.js
@@ -74,6 +74,13 @@ cc.view.getTargetDensityDPI = function() {return cc.macro.DENSITYDPI_DEVICE;};
 
 cc.eventManager = cc.director.getEventDispatcher();
 
+cc.EventDispatcher.prototype._addCustomListener = cc.EventDispatcher.prototype.addCustomListener;
+cc.EventDispatcher.prototype.addCustomListener = function(eventName, callback) {
+    var ret = this._addCustomListener(eventName, callback);
+    jsb.registerNativeRef(cc.eventManager, ret);
+    return ret;
+};
+
 cc.eventManager._resizeListener = cc.eventManager.addCustomListener('window-resize', function () {
     cc.winSize = cc.director.getWinSize();
     cc.visibleRect.init();

--- a/cocos/scripting/js-bindings/script/jsb_cocos2d.js
+++ b/cocos/scripting/js-bindings/script/jsb_cocos2d.js
@@ -629,15 +629,45 @@ cc.TMXTiledMap.prototype.allLayers = function(){
         length = locChildren.length;
     for(var i = 0; i< length; i++){
         var layer = locChildren[i];
-        if(layer && layer instanceof cc.TMXLayer)
+        if(layer && layer instanceof cc.TMXLayer) {
+            jsb.registerNativeRef(this, layer);
             retArr.push(layer);
+        }
     }
     return retArr;
 };
+
+cc.TMXTiledMap.prototype._getLayer = cc.TMXTiledMap.prototype.getLayer;
+cc.TMXTiledMap.prototype.getLayer = function(layerName) {
+    var ret = this._getLayer(layerName);
+    jsb.registerNativeRef(this, ret);
+    return ret;
+};
+
+cc.TMXTiledMap.prototype._getObjectGroup = cc.TMXTiledMap.prototype.getObjectGroup;
+cc.TMXTiledMap.prototype.getObjectGroup = function(groupName) {
+    var ret = this._getObjectGroup(groupName);
+    jsb.registerNativeRef(this, ret);
+    return ret;
+};
+
+cc.TMXTiledMap.prototype._getObjectGroups = cc.TMXTiledMap.prototype.getObjectGroups;
+cc.TMXTiledMap.prototype.getObjectGroups = function() {
+    var ret = this._getObjectGroups();
+    if (ret && ret instanceof Array) {
+        for (var i = 0, len = ret.length; i < len; ++i) {
+            jsb.registerNativeRef(this, ret[i]);
+        }
+    }
+    return ret;
+};
+
 cc.TMXLayer.prototype._getTileAt = cc.TMXLayer.prototype.getTileAt;
 cc.TMXLayer.prototype.getTileAt = function(x, y){
     var pos = y !== undefined ? cc.p(x, y) : x;
-    return this._getTileAt(pos);
+    var ret = this._getTileAt(pos);
+    jsb.registerNativeRef(this, ret);
+    return ret;
 };
 cc.TMXLayer.prototype._getTileGIDAt = cc.TMXLayer.prototype.getTileGIDAt;
 cc.TMXLayer.prototype.getTileGIDAt = function(x, y){
@@ -670,6 +700,31 @@ cc.TMXLayer.prototype.getPositonAt = function(x, y){
 };
 
 cc.TMXLayer.prototype.tileFlagsAt = cc.TMXLayer.prototype.getTileFlagsAt;
+
+cc.TMXObjectGroup.prototype._getObject = cc.TMXObjectGroup.prototype.getObject;
+cc.TMXObjectGroup.prototype.getObject = function(objectName) {
+    var ret = this._getObject(objectName);
+    jsb.registerNativeRef(this, ret);
+    return ret;
+};
+
+cc.TMXObjectGroup.prototype._getObjects = cc.TMXObjectGroup.prototype.getObjects;
+cc.TMXObjectGroup.prototype.getObjects = function() {
+    var ret = this._getObjects();
+    if (ret && ret instanceof Array) {
+        for (var i = 0, len = ret.length; i < len; ++i) {
+            jsb.registerNativeRef(this, ret[i]);
+        }
+    }
+    return ret;
+};
+
+cc.TMXObject.prototype._getNode = cc.TMXObject.prototype.getNode;
+cc.TMXObject.prototype.getNode = function() {
+    var ret = this._getNode();
+    jsb.registerNativeRef(this, ret);
+    return ret;
+};
 
 //
 // setBlendFunc JS API Wrapper


### PR DESCRIPTION
解决 Scale9SpriteV2::setState 崩溃问题（http://forum.cocos.com/t/ios-1-8-2-bate-3/56294 http://forum.cocos.com/t/1-8-1-ios-ipad/55690）


![](http://forum.cocos.com/uploads/default/original/3X/b/7/b76b02c02a3cafef2f0d1addd97ab5aea87a6ba8.png)

之前在 https://github.com/cocos-creator/cocos2d-x-lite/pull/1062 中修复一个JS 层频繁调用 TileMap getLayer 或者 getTileAt 导致的崩溃问题。PR #1062 中的修复方式为：如果 target 不存在，则新建一个target 挂载在 owner 上面，但是这种方式会导致论坛上反馈的 setState 的问题。
原因是：假设开发者频繁调用 node.interactable = true / false, 在 C++ 层中，会频繁调用 node->setGLProgramState, 其内部会频繁去 releaseScriptObject 和 retainScriptObject ，但是在 JS 层中并没有对 GLProgramState 对象的任何引用，这个 GLProgramState 对象可能正在被标记为 GC 状态，但是 finalize 方法并没有被调用，如果这个时候又去 attachObject 则会导致崩溃。

Reverts PR #1062 which may lead to other issues, fix it by another way.

* JS LifeCycle control for GLProgram, GLProgramState.
* jsb.registerNativeRef should be invoked in JS for cc.TMXTiledMap.getLayer/getObjectGroup/getObjectGroups, cc.TMXObjectGroup.getObject, cc.TMXObjectGroup.getObjects, cc.TMXObject.prototype.getNode.