### PR TITLE
Fixes thread race issue in `getImageInfo` method.

### DIFF
--- a/cocos/base/CCScheduler.cpp
+++ b/cocos/base/CCScheduler.cpp
@@ -444,9 +444,7 @@ void Scheduler::resumeTargets(const std::set<void*>& targetsToResume)
 void Scheduler::performFunctionInCocosThread(const std::function<void ()> &function)
 {
     _performMutex.lock();
-
     _functionsToPerform.push_back(function);
-
     _performMutex.unlock();
 }
 


### PR DESCRIPTION
NOTE: FileUtils::getInstance()->fullPathForFilename isn't a thread-safe method, Image::initWithImageFile will call fullPathForFilename internally which may cause thread race issues. Therefore, we get the full path of file before going into task callback. So be careful of invoking any Cocos2d-x interface in a sub-thread.