### PR TITLE
Fix local reference table overflow error problem.

### DIFF
--- a/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
@@ -508,10 +508,7 @@ static bool JavaScriptJavaBridge_callStaticMethod(se::State& s)
         {
             int count = argc - 3;
             jvalue* jargs = new jvalue[count];
-            int *toRelease = new int[count];
-            for (int i = 0; i < count; ++i){
-                toRelease[i] = 0;
-            }
+            std::vector<jobject> toReleaseObjects;
             for (int i = 0; i < count; ++i)
             {
                 int index = i + 3;
@@ -548,15 +545,14 @@ static bool JavaScriptJavaBridge_callStaticMethod(se::State& s)
                         std::string str;
                         seval_to_std_string(args[index], &str);
                         jargs[i].l = call.getEnv()->NewStringUTF(str.c_str());
-                        toRelease[i] = 1;
+                        toReleaseObjects.push_back(jargs[i].l);
                         break;
                 }
             }
             ok = call.executeWithArgs(jargs);
-            for (int i=0; i<count; ++i) {
-                if (toRelease[i] == 1) {
-                    call.getEnv()->DeleteLocalRef(args[i].l);
-                }
+            for (const auto& obj : toReleaseObject)
+            {
+                call.getEnv()->DeleteLocalRef(obj);
             }
             if (jargs)
                 delete[] jargs;

--- a/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
@@ -508,6 +508,10 @@ static bool JavaScriptJavaBridge_callStaticMethod(se::State& s)
         {
             int count = argc - 3;
             jvalue* jargs = new jvalue[count];
+            int *toRelease = new int[count];
+            for (int i = 0; i < count; ++i){
+                toRelease[i] = 0;
+            }
             for (int i = 0; i < count; ++i)
             {
                 int index = i + 3;
@@ -544,10 +548,16 @@ static bool JavaScriptJavaBridge_callStaticMethod(se::State& s)
                         std::string str;
                         seval_to_std_string(args[index], &str);
                         jargs[i].l = call.getEnv()->NewStringUTF(str.c_str());
+                        toRelease[i] = 1;
                         break;
                 }
             }
             ok = call.executeWithArgs(jargs);
+            for (int i=0; i<count; ++i) {
+                if (toRelease[i] == 1) {
+                    call.getEnv()->DeleteLocalRef(args[i].l);
+                }
+            }
             if (jargs)
                 delete[] jargs;
             int errorCode = call.getErrorCode();

--- a/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
@@ -550,7 +550,7 @@ static bool JavaScriptJavaBridge_callStaticMethod(se::State& s)
                 }
             }
             ok = call.executeWithArgs(jargs);
-            for (const auto& obj : toReleaseObject)
+            for (const auto& obj : toReleaseObjects)
             {
                 call.getEnv()->DeleteLocalRef(obj);
             }


### PR DESCRIPTION
In our app, local reference table overflow errors occur frequently. 

After investigating, I found that such problem is caused by the `NewStringUTF()` function calling, which does not follows a `DeletLocalRef()` operation.

This pull request fixes it. It works well in our app and no more local reference table error occurs again.