### PR TITLE
[mac] Shader version should be at least 120 to fix "GLSL 110 does not allow sub- or super-matrix constructors" issue.

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -584,11 +584,13 @@ static bool js_loadImage(se::State& s)
         std::string fullPath;
         int imageBytes = 0;
         unsigned char* imageData = nullptr;
-        std::smatch match;
-        if (path.find("data:") == 0 && std::regex_match(path.cbegin(), path.cend(), match, std::regex("^data:image/\\w+;base64,(.*?)$")))
+        size_t pos = std::string::npos;
+        if (path.find("data:") == 0 && (pos = path.find("base64,")) != std::string::npos)
         {
-            std::string base64Str = match[1];
-            imageBytes = base64Decode((const unsigned char *)base64Str.data(), (unsigned int)base64Str.length(), &imageData);
+            size_t dataStartPos = pos + strlen("base64,");
+            const char* base64Data = path.data() + dataStartPos;
+            size_t dataLen = path.length() - dataStartPos;
+            imageBytes = base64Decode((const unsigned char *)base64Data, (unsigned int)dataLen, &imageData);
             if (imageBytes <= 0 || imageData == nullptr)
             {
                 SE_REPORT_ERROR("Decode base64 image data failed!");

--- a/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
@@ -2688,7 +2688,8 @@ static bool JSB_glShaderSource(se::State& s) {
     size_t firstLinePos = shaderSource.find("\n");
     if (firstLinePos != std::string::npos)
     {
-        if (shaderSource.find("#version", 0, firstLinePos) == std::string::npos)
+        std::string firstLine = shaderSource.substr(0, firstLinePos);
+        if (firstLine.find("#version") == std::string::npos)
         {
             shaderSource = "#version 120\n" + shaderSource;
         }

--- a/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
@@ -2685,6 +2685,14 @@ static bool JSB_glShaderSource(se::State& s) {
     SE_PRECONDITION2(ok, false, "Error processing arguments");
 
 #if CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32
+    size_t firstLinePos = shaderSource.find("\n");
+    if (firstLinePos != std::string::npos)
+    {
+        if (shaderSource.find("#version", 0, firstLinePos) == std::string::npos)
+        {
+            shaderSource = "#version 120\n" + shaderSource;
+        }
+    }
     shaderSource = std::regex_replace(shaderSource, std::regex("precision\\s+(lowp|mediump|highp).*?;"), "");
     shaderSource = std::regex_replace(shaderSource, std::regex("\\s(lowp|mediump|highp)\\s"), " ");
 #endif


### PR DESCRIPTION
Don't use regex match for getting base64 string. Uses string pointer offset instead