### PR TITLE
avoid a NullPointerException when domain is null

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
@@ -327,6 +327,9 @@ public class Cocos2dxDownloader {
                     catch (URISyntaxException e) {
                         break;
                     }
+                    if (domain == null) {
+                        break;
+                    }
                     final String host = domain.startsWith("www.") ? domain.substring(4) : domain;
                     Boolean supportResuming = false;
                     Boolean requestHeader = true;

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
@@ -327,7 +327,7 @@ public class Cocos2dxDownloader {
                     catch (URISyntaxException e) {
                         break;
                     }
-                    if (domain == null) {
+                    catch (NullPointerException e) {
                         break;
                     }
                     final String host = domain.startsWith("www.") ? domain.substring(4) : domain;


### PR DESCRIPTION
We occasionally come across such NullPointerExceptions in our app:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.startsWith(java.lang.String)' on a null object reference
org.cocos2dx.lib.Cocos2dxDownloader$3.run(Cocos2dxDownloader.java:306)
android.os.Handler.handleCallback(Handler.java:790)
android.os.Handler.dispatchMessage(Handler.java:99)
android.os.Looper.loop(Looper.java:164)
android.app.ActivityThread.main(ActivityThread.java:6494)
java.lang.reflect.Method.invoke(Native Method)
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```

Since domain can be null, I think we'd better to check whether domain is null before calling `startsWith`.