### PR TITLE
assign particle texture after init

### DIFF
--- a/cocos/2d/CCParticleSystem.cpp
+++ b/cocos/2d/CCParticleSystem.cpp
@@ -522,9 +522,6 @@ bool ParticleSystem::initWithDictionary(ValueMap& dictionary, const std::string&
                 }
 
                 _yCoordFlipped = dictionary.find("yCoordFlipped") == dictionary.end() ? 1 : dictionary.at("yCoordFlipped").asInt();
-
-                if( !this->_texture)
-                    CCLOGWARN("cocos2d: Warning: ParticleSystemQuad system without a texture");
             }
             ret = true;
         }


### PR DESCRIPTION
for https://github.com/cocos-creator/fireball/issues/6914
remove warning since we need to assign particle texture in JS after particle initialized