### PR TITLE
修正内存池对象在进行Destroy时没有解除jsbinding 的问题

### DIFF
--- a/cocos/scripting/js-bindings/auto/jsb_box2d_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_box2d_auto.cpp
@@ -2367,9 +2367,11 @@ static bool js_box2dclasses_b2Body_DestroyFixture(se::State& s)
     CC_UNUSED bool ok = true;
     if (argc == 1) {
         b2Fixture* arg0 = nullptr;
-        ok &= seval_to_native_ptr(args[0], &arg0);
+        auto& argv0 = args[0];
+        ok &= seval_to_native_ptr(argv0, &arg0);
         SE_PRECONDITION2(ok, false, "js_box2dclasses_b2Body_DestroyFixture : Error processing arguments");
         cobj->DestroyFixture(arg0);
+        argv0.toObject()->clearPrivateData();
         return true;
     }
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
@@ -3571,9 +3573,11 @@ static bool js_box2dclasses_b2World_DestroyJoint(se::State& s)
     CC_UNUSED bool ok = true;
     if (argc == 1) {
         b2Joint* arg0 = 0;
-        ok &= seval_to_native_ptr(args[0], &arg0);
+        auto& argv0 = args[0];
+        ok &= seval_to_native_ptr(argv0, &arg0);
         SE_PRECONDITION2(ok, false, "js_box2dclasses_b2World_DestroyJoint : Error processing arguments");
         cobj->DestroyJoint(arg0);
+        argv0.toObject()->clearPrivateData();
         return true;
     }
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
@@ -3683,9 +3687,11 @@ static bool js_box2dclasses_b2World_DestroyBody(se::State& s)
     CC_UNUSED bool ok = true;
     if (argc == 1) {
         b2Body* arg0 = nullptr;
-        ok &= seval_to_native_ptr(args[0], &arg0);
+        auto& argv0 = args[0];
+        ok &= seval_to_native_ptr(argv0, &arg0);
         SE_PRECONDITION2(ok, false, "js_box2dclasses_b2World_DestroyBody : Error processing arguments");
         cobj->DestroyBody(arg0);
+        argv0.toObject()->clearPrivateData();
         return true;
     }
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);


### PR DESCRIPTION
出现问题是iOS平台，在开发时发现 Fixture对象由于使用了内存池，符合以下条件的话，则出现问题：
1、当Fixture在native端回收，但JSValue没有解除绑定
2、旧的Fixture的地址被新的Fixture使用再绑定到新的JSValue上
3、当旧的 JSValue 被 JSC 进行gc，其JSBinding也被解除，波及了 新的Fixture对象。导致binding消失。

故通过在对其进行回收时，主动调用clearPrivateData进行解除binding.

详见 http://forum.cocos.com/t/undefined-is-not-an-object-evaluating-colliderb-body/60184/12?u=lucky_06