### PR TITLE
Sync 1.9 changes, se::Object::clearPrivateData takes a parameter 'clearMapping' to indicate whether to clearMapping in this function.

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/chakracore/Object.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/chakracore/Object.cpp
@@ -662,12 +662,12 @@ namespace se {
         _privateData = data;
     }
 
-    void Object::clearPrivateData()
+    void Object::clearPrivateData(bool clearMapping)
     {
         if (_privateData != nullptr)
         {
-            void* data = getPrivateData();
-            NativePtrToObjectMap::erase(data);
+            if (clearMapping)
+                NativePtrToObjectMap::erase(_privateData);
             internal::clearPrivate(_obj);
             _privateData = nullptr;
         }

--- a/cocos/scripting/js-bindings/jswrapper/chakracore/Object.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/chakracore/Object.hpp
@@ -255,11 +255,10 @@ namespace se {
         void* getPrivateData() const;
 
         /**
-         *  @brief Roots an object from garbage collection.
-         *  @note Use this method when you want to store an object in a global or on the heap, where the garbage collector will not be able to discover your reference to it.
-         *        An object may be rooted multiple times and must be unrooted an equal number of times before becoming eligible for garbage collection.
+         *  @brief Clears private data of an object.
+         *  @param clearMapping Whether to clear the mapping of native object & se::Object.
          */
-        void clearPrivateData();
+        void clearPrivateData(bool clearMapping = true);
 
         /**
          *  @brief Roots an object from garbage collection.

--- a/cocos/scripting/js-bindings/jswrapper/jsc/Object.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/Object.hpp
@@ -257,8 +257,9 @@ namespace se {
 
         /**
          *  @brief Clears private data of an object.
+         *  @param clearMapping Whether to clear the mapping of native object & se::Object.
          */
-        void clearPrivateData();
+        void clearPrivateData(bool clearMapping = true);
 
         /**
          *  @brief Roots an object from garbage collection.

--- a/cocos/scripting/js-bindings/jswrapper/jsc/Object.mm
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/Object.mm
@@ -949,12 +949,12 @@ namespace se {
         _privateData = data;
     }
 
-    void Object::clearPrivateData()
+    void Object::clearPrivateData(bool clearMapping)
     {
         if (_privateData != nullptr)
         {
-            void* data = getPrivateData();
-            NativePtrToObjectMap::erase(data);
+            if (clearMapping)
+                NativePtrToObjectMap::erase(_privateData);
             internal::clearPrivate(_obj);
             _privateData = nullptr;
         }

--- a/cocos/scripting/js-bindings/jswrapper/sm/Object.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/sm/Object.cpp
@@ -487,12 +487,12 @@ namespace se {
         _privateData = data;
     }
 
-    void Object::clearPrivateData()
+    void Object::clearPrivateData(bool clearMapping)
     {
         if (_privateData != nullptr)
         {
-            void* data = getPrivateData();
-            NativePtrToObjectMap::erase(data);
+            if (clearMapping)
+                NativePtrToObjectMap::erase(_privateData);
             JS::RootedObject obj(__cx, _getJSObject());
             internal::clearPrivate(__cx, obj);
             _privateData = nullptr;

--- a/cocos/scripting/js-bindings/jswrapper/sm/Object.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/sm/Object.hpp
@@ -257,8 +257,9 @@ namespace se {
 
         /**
          *  @brief Clears private data of an object.
+         *  @param clearMapping Whether to clear the mapping of native object & se::Object.
          */
-        void clearPrivateData();
+        void clearPrivateData(bool clearMapping = true);
 
         /**
          *  @brief Roots an object from garbage collection.

--- a/cocos/scripting/js-bindings/jswrapper/v8/Object.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/Object.cpp
@@ -451,12 +451,12 @@ namespace se {
         return _privateData;
     }
 
-    void Object::clearPrivateData()
+    void Object::clearPrivateData(bool clearMapping)
     {
         if (_privateData != nullptr)
         {
-            void* data = getPrivateData();
-            NativePtrToObjectMap::erase(data);
+            if (clearMapping)
+                NativePtrToObjectMap::erase(_privateData);
             internal::clearPrivate(__isolate, _obj);
             _privateData = nullptr;
         }

--- a/cocos/scripting/js-bindings/jswrapper/v8/Object.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/Object.hpp
@@ -262,8 +262,9 @@ namespace se {
 
         /**
          *  @brief Clears private data of an object.
+         *  @param clearMapping Whether to clear the mapping of native object & se::Object.
          */
-        void clearPrivateData();
+        void clearPrivateData(bool clearMapping = true);
 
         /**
          *  @brief Roots an object from garbage collection.

--- a/cocos/scripting/js-bindings/manual/jsb_conversions.hpp
+++ b/cocos/scripting/js-bindings/manual/jsb_conversions.hpp
@@ -266,32 +266,6 @@ bool std_vector_TechniqueParameter_to_seval(const std::vector<cocos2d::renderer:
 bool std_vector_EffectDefine_to_seval(const std::vector<cocos2d::ValueMap>& v, se::Value* ret);
 
 template<typename T>
-bool recreate_seval_by_native_ptr(typename std::enable_if<!std::is_base_of<cocos2d::Ref,T>::value,T>::type* v, se::Class* cls, se::Value* ret)
-{
-    assert(ret != nullptr);
-    assert(cls != nullptr);
-    if (v == nullptr)
-    {
-        ret->setNull();
-        return true;
-    }
-
-    auto iter = se::NativePtrToObjectMap::find(v);
-    if (iter != se::NativePtrToObjectMap::end())
-    {
-        se::Object* seObj = iter->second;
-        seObj->clearPrivateData();
-        seObj->decRef();
-    }
-
-    se::Object* obj = se::Object::createObjectWithClass(cls);
-    ret->setObject(obj, true);
-    obj->setPrivateData(v);
-
-    return true;
-}
-
-template<typename T>
 bool native_ptr_to_seval(typename std::enable_if<!std::is_base_of<cocos2d::Ref,T>::value,T>::type* v, se::Value* ret, bool* isReturnCachedValue = nullptr)
 {
     assert(ret != nullptr);

--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -558,6 +558,7 @@ SE_BIND_FUNC(JSB_cleanScript)
 
 static bool JSB_core_restartVM(se::State& s)
 {
+    //TODO: release AudioEngine, waiting HttpClient & WebSocket threads to exit.
     Application::getInstance()->restart();
     return true;
 }


### PR DESCRIPTION
Sync from https://github.com/cocos-creator/cocos2d-x-lite/pull/1264