### PR TITLE
fix win32 simulator compile/link error, no fix when running

### DIFF
--- a/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/cocos/ui/edit-box/EditBox-win32.cpp
@@ -37,4 +37,8 @@ void EditBox::hide()
     
 }
 
+void EditBox::complete()
+{
+    
+}
 NS_CC_END

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -1,4 +1,4 @@
-﻿/****************************************************************************
+/****************************************************************************
  Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 
  http://www.cocos.com
@@ -53,6 +53,7 @@
 #include "runtime/ConfigParser.h"
 #include "runtime/Runtime.h"
 
+#include "platform/CCApplication.h"
 #include "platform/win32/PlayerWin.h"
 #include "platform/win32/PlayerMenuServiceWin.h"
 
@@ -92,6 +93,7 @@ INT_PTR CALLBACK AboutDialogCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
     }
     return (INT_PTR)FALSE;
 }
+/*
 void onHelpAbout()
 {
     DialogBox(GetModuleHandle(NULL),
@@ -99,12 +101,13 @@ void onHelpAbout()
               Director::getInstance()->getOpenGLView()->getWin32Window(),
               AboutDialogCallback);
 }
+*/
 
 void shutDownApp()
 {
-    auto glview = dynamic_cast<GLViewImpl*> (Director::getInstance()->getOpenGLView());
-    HWND hWnd = glview->getWin32Window();
-    ::SendMessage(hWnd, WM_CLOSE, NULL, NULL);
+    // TODO
+    //HWND hWnd = glview->getWin32Window();
+    //::SendMessage(hWnd, WM_CLOSE, NULL, NULL);
 }
 
 std::string getCurAppPath(void)
@@ -139,15 +142,6 @@ static bool stringEndWith(const std::string str, const std::string needle)
     return false;
 }
 
-static void initGLContextAttrs()
-{
-    //set OpenGL context attributions,now can only set six attributions:
-    //red,green,blue,alpha,depth,stencil
-    GLContextAttrs glContextAttrs = {8, 8, 8, 8, 24, 8};
-
-    GLView::setGLContextAttrs(glContextAttrs);
-}
-
 SimulatorWin *SimulatorWin::_instance = nullptr;
 
 SimulatorWin *SimulatorWin::getInstance()
@@ -178,7 +172,8 @@ SimulatorWin::~SimulatorWin()
 
 void SimulatorWin::quit()
 {
-    Director::getInstance()->end();
+    delete _app;
+    _app = nullptr;
 }
 
 void SimulatorWin::relaunch()
@@ -289,7 +284,6 @@ int SimulatorWin::run()
     }
 
     // create the application instance
-    _app = new AppDelegate();
     RuntimeEngine::getInstance()->setProjectConfig(_project);
 
     // create console window
@@ -404,7 +398,12 @@ int SimulatorWin::run()
     const bool isResize = _project.isResizeWindow();
     std::stringstream title;
     title << "Cocos Simulator (" << _project.getFrameScale() * 100 << "%)";
-    initGLContextAttrs();
+
+    // create opengl view, and init app
+    _app = new AppDelegate(title.str(), _project.getFrameScale() * frameSize.width, _project.getFrameScale() * frameSize.height);
+    _app->start();
+    return true;
+    /*
     auto glview = GLViewImpl::createWithRect(title.str(), frameRect, frameScale, true);
     _hwnd = glview->getWin32Window();
     player::PlayerWin::createWithHwnd(_hwnd);
@@ -456,10 +455,11 @@ int SimulatorWin::run()
     int ret = app->run();
     CC_SAFE_DELETE(_app);
     return ret;
+    */
 }
 
 // services
-
+/*
 void SimulatorWin::setupUI()
 {
     auto menuBar = player::PlayerProtocol::getInstance()->getMenuService();
@@ -1020,6 +1020,7 @@ void SimulatorWin::onOpenFile(const std::string &filePath)
         msgBox->showMessageBox(title, msg);
     }
 }
+*/
 
 /*
 1. find @folderPath/config.json
@@ -1027,6 +1028,8 @@ void SimulatorWin::onOpenFile(const std::string &filePath)
 3. find @folderPath/cocosstudio/MainScene.csd
 4. find @folderPath/cocosstudio/MainScene.csb
 */
+
+/*
 void SimulatorWin::onOpenProjectFolder(const std::string &folderPath)
 {
     string path = folderPath;
@@ -1120,3 +1123,4 @@ void SimulatorWin::onDrop(const std::string &path)
         onOpenFile(path);
     }
 }
+*/

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -56,6 +56,7 @@
 #include "platform/CCApplication.h"
 #include "platform/win32/PlayerWin.h"
 #include "platform/win32/PlayerMenuServiceWin.h"
+#include "platform/desktop/CCGLView-desktop.h"
 
 #include "resource.h"
 
@@ -93,21 +94,27 @@ INT_PTR CALLBACK AboutDialogCallback(HWND hDlg, UINT message, WPARAM wParam, LPA
     }
     return (INT_PTR)FALSE;
 }
-/*
+
+HWND getWin32Window()
+{
+  auto glfwWindow = ((cocos2d::GLView*)cocos2d::Application::getInstance()->getView())->getGLFWWindow();
+  return glfwGetWin32Window(glfwWindow);
+}
+
+
 void onHelpAbout()
 {
     DialogBox(GetModuleHandle(NULL),
               MAKEINTRESOURCE(IDD_DIALOG_ABOUT),
-              Director::getInstance()->getOpenGLView()->getWin32Window(),
+              getWin32Window(),
               AboutDialogCallback);
 }
-*/
+
 
 void shutDownApp()
 {
-    // TODO
-    //HWND hWnd = glview->getWin32Window();
-    //::SendMessage(hWnd, WM_CLOSE, NULL, NULL);
+    
+    ::SendMessage(getWin32Window(), WM_CLOSE, NULL, NULL);
 }
 
 std::string getCurAppPath(void)
@@ -402,6 +409,11 @@ int SimulatorWin::run()
     // create opengl view, and init app
     _app = new AppDelegate(title.str(), _project.getFrameScale() * frameSize.width, _project.getFrameScale() * frameSize.height);
     _app->start();
+    CC_SAFE_DELETE(_app);
+
+    // path for looking Lang file, Studio Default images
+    FileUtils::getInstance()->addSearchPath(getApplicationPath().c_str());
+
     return true;
     /*
     auto glview = GLViewImpl::createWithRect(title.str(), frameRect, frameScale, true);

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -733,7 +733,7 @@ void SimulatorWin::writeDebugLog(const char *log)
     fputc('\n', _writeDebugLogFile);
     fflush(_writeDebugLogFile);
 }
-
+*/
 void SimulatorWin::parseCocosProjectConfig(ProjectConfig &config)
 {
     // get project directory
@@ -901,7 +901,7 @@ std::string SimulatorWin::getApplicationPath()
 
     return workdir;
 }
-
+/*
 LRESULT CALLBACK SimulatorWin::windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     if (!_instance) return 0;
@@ -988,7 +988,7 @@ LRESULT CALLBACK SimulatorWin::windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     }
     return g_oldWindowProc(hWnd, uMsg, wParam, lParam);
 }
-
+*/
 void SimulatorWin::onOpenFile(const std::string &filePath)
 {
     string entry = filePath;
@@ -1020,7 +1020,7 @@ void SimulatorWin::onOpenFile(const std::string &filePath)
         msgBox->showMessageBox(title, msg);
     }
 }
-*/
+
 
 /*
 1. find @folderPath/config.json

--- a/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
@@ -236,6 +236,9 @@ xcopy /Y /Q "$(OutDir)lang" "$(ProjectDir)..\..\..\runtime\win32"
     <Image Include="res\game.ico" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\build\libcocos2d.vcxproj">
+      <Project>{98a51ba8-fc3a-415b-ac8f-8c7bd464e93e}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\libsimulator\proj.win32\libsimulator.vcxproj">
       <Project>{001b324a-bb91-4e83-875c-c92f75c40857}</Project>
     </ProjectReference>

--- a/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
@@ -81,7 +81,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;_USRLUASTATIC;_USRJSSTATIC;_USRLIBSIMSTATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;_USRLUASTATIC;_USRJSSTATIC;_USRLIBSIMSTATIC;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4267;4251;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>

--- a/tools/simulator/libsimulator/lib/platform/win32/PlayerTaskServiceWin.cpp
+++ b/tools/simulator/libsimulator/lib/platform/win32/PlayerTaskServiceWin.cpp
@@ -139,7 +139,7 @@ bool PlayerTaskWin::run()
     _outputBuffWide = new WCHAR[BUFF_SIZE];
     _state = STATE_RUNNING;
 
-    cocos2d::Director::getInstance()->getScheduler()->scheduleUpdate(this, 0, false);
+    // cocos2d::Director::getInstance()->getScheduler()->scheduleUpdate(this, 0, false);
     return true;
 }
 
@@ -207,7 +207,7 @@ void PlayerTaskWin::update(float dt)
         _resultCode = (int)GetLastError();
     }
 
-    cocos2d::Director::getInstance()->getScheduler()->unscheduleAllForTarget(this);
+    // cocos2d::Director::getInstance()->getScheduler()->unscheduleAllForTarget(this);
     cleanup();
 }
 
@@ -236,7 +236,7 @@ void PlayerTaskWin::cleanup()
 
     CCLOG("CMD: %s", _output.c_str());
 
-    cocos2d::Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(_name);
+    // cocos2d::Director::getInstance()->getEventDispatcher()->dispatchCustomEvent(_name);
 }
 
 std::u16string PlayerTaskWin::makeCommandLine() const

--- a/tools/simulator/libsimulator/lib/runtime/Runtime.cpp
+++ b/tools/simulator/libsimulator/lib/runtime/Runtime.cpp
@@ -321,7 +321,7 @@ void RuntimeEngine::trackEvent(const std::string &eventName)
 #else
     const char *platform = "UNKNOWN";
 #endif
-
+    /*
     char cidBuf[64] = {0};
     auto guid = player::DeviceEx::getInstance()->getUserGUID();
     snprintf(cidBuf, sizeof(cidBuf), "%x", XXH32(guid.c_str(), (int)guid.length(), 0));
@@ -340,7 +340,7 @@ void RuntimeEngine::trackEvent(const std::string &eventName)
     request->addPOSTValue("ea", eventName.c_str());
 
     request->start();
-
+    */
 #endif // ((CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC))
 }
 

--- a/tools/simulator/libsimulator/proj.win32/libsimulator.vcxproj
+++ b/tools/simulator/libsimulator/proj.win32/libsimulator.vcxproj
@@ -65,7 +65,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;%(PreprocessorDefinitions);_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;_USRLIBSIMSTATIC</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;%(PreprocessorDefinitions);_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS;_USRLIBSIMSTATIC;_WINSOCKAPI_;_USRDLL</PreprocessorDefinitions>
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\lib\protobuf-lite;$(ProjectDir)..\lib;$(EngineRoot)external\win32-specific\zlib\include;$(EngineRoot)cocos\scripting\lua-bindings\auto;$(EngineRoot)cocos\scripting\lua-bindings\manual;$(EngineRoot)cocos\audio\include;$(EngineRoot)external;$(EngineRoot)external\lua\lua;$(EngineRoot)external\lua\tolua;$(EngineRoot)external\chipmunk\include\chipmunk;$(EngineRoot)external\curl\include\win32;$(EngineRoot)extensions;$(EngineRoot);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
compile and link success ,running with error, logs.
```
2018-06-22T08:26:40.009Z - normal: Simulator: E/jswrapper (4297): [ERROR] (c:\career\fireball\cocos2d-x\cocos\scripting\js-bindings\manual\jsb_opengl_manual.cpp, 4297): ccViewport((GLint)p[1], (GLint)p[2], (GLsizei)p[3], (GLsizei)p[4]); GL error 0x501: GL_INVALID_VALUE

2018-06-22T08:26:40.013Z - normal: Simulator: E/jswrapper (4297): [ERROR] (c:\career\fireball\cocos2d-x\cocos\scripting\js-bindings\manual\jsb_opengl_manual.cpp, 4297): ccViewport((GLint)p[1], (GLint)p[2], (GLsizei)p[3], (GLsizei)p[4]); GL error 0x501: GL_INVALID_VALUE

2018-06-22T08:26:40.013Z - normal: Simulator: E/jswrapper (4297): [ERROR] (c:\career\fireball\cocos2d-x\cocos\scripting\js-bindings\manual\jsb_opengl_manual.cpp, 4297): ccViewport((GLint)p[1], (GLint)p[2], (GLsizei)p[3], (GLsizei)p[4]); GL error 0x501: GL_INVALID_VALUE

2018-06-22T08:26:40.049Z - normal: Simulator: E/jswrapper (4297): [ERROR] (c:\career\fireball\cocos2d-x\cocos\scripting\js-bindings\manual\jsb_opengl_manual.cpp, 4297): ccViewport((GLint)p[1], (GLint)p[2], (GLsizei)p[3], (GLsizei)p[4]); GL error 0x501: GL_INVALID_VALUE

2018-06-22T08:26:40.131Z - normal: Simulator: E/jswrapper (4297): [ERROR] (c:\career\fireball\cocos2d-x\cocos\scripting\js-bindings\manual\jsb_opengl_manual.cpp, 4297): ccViewport((GLint)p[1], (GLint)p[2], (GLsizei)p[3], (GLsizei)p[4]); GL error 0x501: GL_INVALID_VALUE
```