### PR TITLE
copy jsb-adapter folder on win32

### DIFF
--- a/templates/js-template-default/frameworks/runtime-src/proj.win32/HelloJavascript.vcxproj
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win32/HelloJavascript.vcxproj
@@ -127,6 +127,7 @@
       <Command>xcopy "$(ProjectDir)..\..\cocos2d-x\cocos\scripting\js-bindings\script" "$(OutDir)\script" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\..\src" "$(OutDir)\src" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\..\res" "$(OutDir)\res" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\jsb-adapter" "$(OutDir)\jsb-adapter" /D /E /I /F /Y
 copy "$(ProjectDir)..\..\..\main.js" "$(OutDir)\" /Y
 copy "$(ProjectDir)..\..\..\project.json" "$(OutDir)\" /Y</Command>
       <Outputs>$(TargetName).cab</Outputs>

--- a/templates/js-template-link/frameworks/runtime-src/proj.win32/HelloJavascript.vcxproj
+++ b/templates/js-template-link/frameworks/runtime-src/proj.win32/HelloJavascript.vcxproj
@@ -126,6 +126,7 @@
     <CustomBuildStep>
       <Command>xcopy "$(ProjectDir)..\..\..\src" "$(OutDir)\src" /D /E /I /F /Y
 xcopy "$(ProjectDir)..\..\..\res" "$(OutDir)\res" /D /E /I /F /Y
+xcopy "$(ProjectDir)..\..\..\jsb-adapter" "$(OutDir)\jsb-adapter" /D /E /I /F /Y
 copy "$(ProjectDir)..\..\..\main.js" "$(OutDir)\" /Y
 copy "$(ProjectDir)..\..\..\project.json" "$(OutDir)\" /Y</Command>
       <Outputs>$(TargetName).cab</Outputs>


### PR DESCRIPTION
修复了win32 平台的报错问题

Android平台报错信息： 
![](https://user-images.githubusercontent.com/17872773/41955293-0868d386-7a12-11e8-8300-208e3b1ee7ad.jpg)

iOS 平台还未验证

麻烦@drelaptop 看一下 android 的问题 