### PR TITLE
fix fireball/issues/7726

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -322,4 +322,35 @@ public class Cocos2dxEditBox extends EditText {
 
         this.setInputType(this.mInputFlagConstraints | this.mInputModeConstraints);
     }
+
+    private String updateDomTextCases (final String text) {
+        String newText = text;
+        switch (this.mInputFlagConstraints) {
+            case InputType.TYPE_TEXT_FLAG_CAP_SENTENCES:
+                char[] charArray = text.toCharArray();
+                charArray[0] -= 32;
+                newText = String.valueOf(charArray);
+                break;
+            case InputType.TYPE_TEXT_FLAG_CAP_WORDS:
+                StringBuffer stringbf = new StringBuffer();
+                Matcher m = Pattern.compile("([a-z])([a-z]*)", Pattern.CASE_INSENSITIVE).matcher(text);
+                while (m.find()) {
+                    m.appendReplacement(stringbf,m.group(1).toUpperCase() + m.group(2).toLowerCase());
+                }
+                newText = m.appendTail(stringbf).toString();
+                break;
+            case InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS:
+                newText = text.toUpperCase();
+                break;
+            default:
+                break;
+        }
+        return newText;
+    }
+
+    public void setText(String text) {
+        String newText = updateDomTextCases(text);
+        super.setText(newText);
+        this.setSelection(newText.length());// 让光标定位最后位置。
+    }
 }

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBoxHelper.java
@@ -132,6 +132,14 @@ public class Cocos2dxEditBoxHelper {
                     @Override
                     public void afterTextChanged(final Editable s) {
                         if (!editBox.getChangedTextProgrammatically()) {
+
+                            // fix fireball/issues/7726
+                            // 先移除当前监听，避免死循环。
+                            editBox.removeTextChangedListener(this);
+                            editBox.setText(editBox.getText().toString());
+                            //操作完当前显示内容之后，再添加监听。
+                            editBox.addTextChangedListener(this);
+
                             if((Boolean)editBox.getTag()) {
                                 mCocos2dxActivity.runOnGLThread(new Runnable() {
                                     @Override


### PR DESCRIPTION
由于安卓 editortext 的 inputflag 有的不支持，所以根据 web 的方式来设置 text 的样式

修复的相关 pr：https://github.com/cocos-creator/fireball/issues/7726