### PR TITLE
修复视频组件适配问题

### DIFF
--- a/cocos/editor-support/creator/CCScale9Sprite.cpp
+++ b/cocos/editor-support/creator/CCScale9Sprite.cpp
@@ -927,7 +927,13 @@ bool Scale9SpriteV2::setSpriteFrame(cocos2d::SpriteFrame* spriteFrame)
     CC_SAFE_RELEASE(this->_spriteFrame);
     this->_spriteFrame = spriteFrame;
     this->_quadsDirty = true;
-    if(!spriteFrame) return true;
+    
+    if(!spriteFrame)
+    {
+        this->setContentSize(cocos2d::Size::ZERO);
+         return true;
+    }
+
     CC_SAFE_RETAIN(spriteFrame);
     if(this->_contentSize.equals(cocos2d::Size::ZERO))
     {

--- a/cocos/editor-support/creator/CCScale9Sprite.cpp
+++ b/cocos/editor-support/creator/CCScale9Sprite.cpp
@@ -923,12 +923,12 @@ bool Scale9SpriteV2::setSpriteFrame(const std::string& sfName)
 }
 
 bool Scale9SpriteV2::setSpriteFrame(cocos2d::SpriteFrame* spriteFrame)
-{
-    if(!spriteFrame) return false;
+{    
     CC_SAFE_RELEASE(this->_spriteFrame);
     this->_spriteFrame = spriteFrame;
-    CC_SAFE_RETAIN(spriteFrame);
     this->_quadsDirty = true;
+    if(!spriteFrame) return true;
+    CC_SAFE_RETAIN(spriteFrame);
     if(this->_contentSize.equals(cocos2d::Size::ZERO))
     {
         this->setContentSize(spriteFrame->getRect().size);

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -486,7 +486,7 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
     std::string sid = "";
     int heartbeat = 0, timeout = 0;
 
-    if (res.at(res.size() - 1) == '}') {
+    if (res.find("sid") != std::string::npos) {
 
         CCLOGINFO("SIOClientImpl::handshake() Socket.IO 1.x detected");
         _version = SocketIOPacket::SocketIOVersion::V10x;
@@ -1037,6 +1037,12 @@ void SIOClient::onOpen()
     if (_path != "/")
     {
         _socket->connectToEndpoint(_path);
+    }
+    
+    if (!_connected)
+    {
+        onConnect();
+        fireEvent("connect", "");
     }
 }
 

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -953,8 +953,8 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
                     CCLOGINFO("event name %s between %i and %i", eventname.c_str(),
                               payloadFirstSlashPos, payloadSecondSlashPos);
 
-                    payload = payload.substr(payloadSecondSlashPos + 5,
-                                             payload.size() - (payloadSecondSlashPos + 7));
+                    payload = payload.substr(payloadSecondSlashPos + 4,
+                                             payload.size() - (payloadSecondSlashPos + 5));
 
                     if (c) c->fireEvent(eventname, payload);
                     if (c) c->getDelegate()->onMessage(c, payload);

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -953,8 +953,8 @@ void SIOClientImpl::onMessage(WebSocket* /*ws*/, const WebSocket::Data& data)
                     CCLOGINFO("event name %s between %i and %i", eventname.c_str(),
                               payloadFirstSlashPos, payloadSecondSlashPos);
 
-                    payload = payload.substr(payloadSecondSlashPos + 4,
-                                             payload.size() - (payloadSecondSlashPos + 5));
+                    payload = payload.substr(payloadSecondSlashPos + 5,
+                                             payload.size() - (payloadSecondSlashPos + 7));
 
                     if (c) c->fireEvent(eventname, payload);
                     if (c) c->getDelegate()->onMessage(c, payload);

--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -486,7 +486,7 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
     std::string sid = "";
     int heartbeat = 0, timeout = 0;
 
-    if (res.find("sid") != std::string::npos) {
+    if (res.at(res.size() - 1) == '}') {
 
         CCLOGINFO("SIOClientImpl::handshake() Socket.IO 1.x detected");
         _version = SocketIOPacket::SocketIOVersion::V10x;
@@ -1037,12 +1037,6 @@ void SIOClient::onOpen()
     if (_path != "/")
     {
         _socket->connectToEndpoint(_path);
-    }
-    
-    if (!_connected)
-    {
-        onConnect();
-        fireEvent("connect", "");
     }
 }
 

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -93,7 +93,6 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     protected int mFullScreenHeight = 0;
 
     private int mViewTag = 0;
-    private int mViewVisible = INVISIBLE;
 
     public Cocos2dxVideoView(Cocos2dxActivity activity,int tag) {
         super(activity);
@@ -106,7 +105,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         if (mVideoWidth == 0 || mVideoHeight == 0) {
-            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            setMeasuredDimension(mViewWidth, mViewHeight);
             Log.i(TAG, ""+mViewWidth+ ":" +mViewHeight);
         }
         else {
@@ -176,14 +175,6 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
                 mSeekWhenPrepared = getCurrentPosition();
             }
         }
-
-        if (mSurfaceHolder == null)
-        {
-            mViewVisible = visibility;
-            super.setVisibility(VISIBLE);
-            return;
-        }
-
         super.setVisibility(visibility);
     }
 
@@ -566,7 +557,6 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
         public void surfaceCreated(SurfaceHolder holder)
         {
             mSurfaceHolder = holder;
-            setVisibility(mViewVisible);
             openVideo();
         }
 
@@ -592,6 +582,9 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
             mMediaPlayer.release();
             mMediaPlayer = null;
             mCurrentState = STATE_IDLE;
+            if (cleartargetstate) {
+                mTargetState  = STATE_IDLE;
+            }
         }
     }
 
@@ -604,15 +597,14 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
             }
 
             mCurrentState = STATE_PLAYING;
-        }
 
-        mTargetState = STATE_PLAYING;
+            mTargetState = STATE_PLAYING;
+        }
     }
 
     public void pause() {
         if (isInPlaybackState()) {
             if (mMediaPlayer.isPlaying()) {
-                mSeekWhenPrepared = mMediaPlayer.getCurrentPosition();
                 mMediaPlayer.pause();
                 mCurrentState = STATE_PAUSED;
                 if (mOnVideoEventListener != null) {
@@ -620,6 +612,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
                 }
             }
         }
+        mTargetState = STATE_PAUSED;
     }
 
     public void stop() {
@@ -645,11 +638,6 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
                     mOnVideoEventListener.onVideoEvent(mViewTag, EVENT_PLAYING);
                 }
             }
-        }
-
-        // mTargetState should not have pause flags, unless the suspend called!
-        if (mTargetState == STATE_PAUSED) {
-            mTargetState = STATE_PLAYING;
         }
     }
 

--- a/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
@@ -507,6 +507,7 @@ static bool JavaScriptJavaBridge_callStaticMethod(se::State& s)
         {
             int count = argc - 3;
             jvalue* jargs = new jvalue[count];
+            std::vector<jobject> toReleaseObjects;
             for (int i = 0; i < count; ++i)
             {
                 int index = i + 3;
@@ -543,10 +544,15 @@ static bool JavaScriptJavaBridge_callStaticMethod(se::State& s)
                         std::string str;
                         seval_to_std_string(args[index], &str);
                         jargs[i].l = call.getEnv()->NewStringUTF(str.c_str());
+                        toReleaseObjects.push_back(jargs[i].l);
                         break;
                 }
             }
             ok = call.executeWithArgs(jargs);
+            for (const auto& obj : toReleaseObjects)
+            {
+                call.getEnv()->DeleteLocalRef(obj);
+            }
             if (jargs)
                 delete[] jargs;
             int errorCode = call.getErrorCode();

--- a/cocos/ui/UIVideoPlayer-ios.mm
+++ b/cocos/ui/UIVideoPlayer-ios.mm
@@ -163,8 +163,9 @@ using namespace cocos2d::experimental::ui;
         self.moviePlayer.movieSourceType = MPMovieSourceTypeStreaming;
         [self.moviePlayer setContentURL:[NSURL URLWithString:@(videoUrl.c_str())]];
     } else {
-        self.moviePlayer = [[[MPMoviePlayerController alloc] initWithContentURL:[NSURL fileURLWithPath:@(videoUrl.c_str())]] autorelease];
+        self.moviePlayer = [[[MPMoviePlayerController alloc] init] autorelease];
         self.moviePlayer.movieSourceType = MPMovieSourceTypeFile;
+        [self.moviePlayer setContentURL:[NSURL fileURLWithPath:@(videoUrl.c_str())]];
     }
     self.moviePlayer.allowsAirPlay = NO;
     self.moviePlayer.controlStyle = MPMovieControlStyleNone;

--- a/cocos/ui/UIVideoPlayer-ios.mm
+++ b/cocos/ui/UIVideoPlayer-ios.mm
@@ -68,8 +68,9 @@ using namespace cocos2d::experimental::ui;
     int _top;
     int _width;
     int _height;
+    bool _fullscreen;
     bool _keepRatioEnabled;
-
+    CGRect _restoreRect;
     VideoPlayer* _videoPlayer;
 }
 
@@ -126,21 +127,36 @@ using namespace cocos2d::experimental::ui;
     _top = top;
     _height = height;
     if (self.moviePlayer != nullptr) {
-        [self.moviePlayer.view setFrame:CGRectMake(left, top, width, height)];
+        _restoreRect = self.moviePlayer.view.frame;
+        
+        if (_fullscreen)
+            [self.moviePlayer.view setFrame:[[UIScreen mainScreen] bounds]];
+        else
+            [self.moviePlayer.view setFrame:CGRectMake(left, top, width, height)];
     }
 }
 
 -(void) setFullScreenEnabled:(BOOL) enabled
 {
     if (self.moviePlayer != nullptr) {
-        [self.moviePlayer setFullscreen:enabled animated:NO];
+        if (enabled)
+        {
+            _fullscreen = enabled;
+            self.moviePlayer.scalingMode = MPMovieScalingModeFill;
+            [self.moviePlayer.view setFrame:[[UIScreen mainScreen] bounds]];
+        }
+        else
+        {
+            [self setKeepRatioEnabled:_keepRatioEnabled];
+            [self.moviePlayer.view setFrame:_restoreRect];
+        }
     }
 }
 
 -(BOOL) isFullScreenEnabled
 {
     if (self.moviePlayer != nullptr) {
-        return [self.moviePlayer isFullscreen];
+        return _fullscreen;
     }
 
     return false;
@@ -168,6 +184,7 @@ using namespace cocos2d::experimental::ui;
         [self.moviePlayer setContentURL:[NSURL fileURLWithPath:@(videoUrl.c_str())]];
     }
     self.moviePlayer.allowsAirPlay = NO;
+    self.moviePlayer.shouldAutoplay = NO;
     self.moviePlayer.controlStyle = MPMovieControlStyleNone;
     self.moviePlayer.view.userInteractionEnabled = YES;
 
@@ -213,6 +230,7 @@ using namespace cocos2d::experimental::ui;
     UITapGestureRecognizer *singleFingerTap =
     [[UITapGestureRecognizer alloc] initWithTarget:self
                                             action:@selector(handleSingleTap:)];
+    singleFingerTap.cancelsTouchesInView = YES;
 
     [self.moviePlayer.view addGestureRecognizer:singleFingerTap];
 
@@ -314,7 +332,7 @@ using namespace cocos2d::experimental::ui;
 {
     _keepRatioEnabled = enabled;
     if (self.moviePlayer != NULL) {
-        if (enabled) {
+        if (_keepRatioEnabled) {
             self.moviePlayer.scalingMode = MPMovieScalingModeAspectFit;
         } else {
             self.moviePlayer.scalingMode = MPMovieScalingModeFill;
@@ -325,7 +343,17 @@ using namespace cocos2d::experimental::ui;
 -(void) play
 {
     if (self.moviePlayer != NULL) {
-        [self.moviePlayer.view setFrame:CGRectMake(_left, _top, _width, _height)];
+        if (_fullscreen)
+        {
+            self.moviePlayer.scalingMode = MPMovieScalingModeFill;
+            [self.moviePlayer.view setFrame:[[UIScreen mainScreen] bounds]];
+        }
+        else
+        {
+            [self setKeepRatioEnabled:_keepRatioEnabled];
+            [self.moviePlayer.view setFrame:CGRectMake(_left, _top, _width, _height)];
+        }
+        
         [self.moviePlayer play];
     }
 }
@@ -353,9 +381,9 @@ using namespace cocos2d::experimental::ui;
 
 -(void) stop
 {
-    if (self.moviePlayer != NULL) {
-        [self.moviePlayer pause];
-        [self seekTo:0];
+    if (self.moviePlayer != NULL)
+    {
+        [self.moviePlayer stop];
         _videoPlayer->onPlayEvent((int)VideoPlayer::EventType::STOPPED);
     }
 }

--- a/cocos/ui/UIVideoPlayer-ios.mm
+++ b/cocos/ui/UIVideoPlayer-ios.mm
@@ -68,9 +68,8 @@ using namespace cocos2d::experimental::ui;
     int _top;
     int _width;
     int _height;
-    bool _fullscreen;
     bool _keepRatioEnabled;
-    CGRect _restoreRect;
+
     VideoPlayer* _videoPlayer;
 }
 
@@ -127,36 +126,21 @@ using namespace cocos2d::experimental::ui;
     _top = top;
     _height = height;
     if (self.moviePlayer != nullptr) {
-        _restoreRect = self.moviePlayer.view.frame;
-        
-        if (_fullscreen)
-            [self.moviePlayer.view setFrame:[[UIScreen mainScreen] bounds]];
-        else
-            [self.moviePlayer.view setFrame:CGRectMake(left, top, width, height)];
+        [self.moviePlayer.view setFrame:CGRectMake(left, top, width, height)];
     }
 }
 
 -(void) setFullScreenEnabled:(BOOL) enabled
 {
     if (self.moviePlayer != nullptr) {
-        if (enabled)
-        {
-            _fullscreen = enabled;
-            self.moviePlayer.scalingMode = MPMovieScalingModeFill;
-            [self.moviePlayer.view setFrame:[[UIScreen mainScreen] bounds]];
-        }
-        else
-        {
-            [self setKeepRatioEnabled:_keepRatioEnabled];
-            [self.moviePlayer.view setFrame:_restoreRect];
-        }
+        [self.moviePlayer setFullscreen:enabled animated:NO];
     }
 }
 
 -(BOOL) isFullScreenEnabled
 {
     if (self.moviePlayer != nullptr) {
-        return _fullscreen;
+        return [self.moviePlayer isFullscreen];
     }
 
     return false;
@@ -184,7 +168,6 @@ using namespace cocos2d::experimental::ui;
         [self.moviePlayer setContentURL:[NSURL fileURLWithPath:@(videoUrl.c_str())]];
     }
     self.moviePlayer.allowsAirPlay = NO;
-    self.moviePlayer.shouldAutoplay = NO;
     self.moviePlayer.controlStyle = MPMovieControlStyleNone;
     self.moviePlayer.view.userInteractionEnabled = YES;
 
@@ -230,7 +213,6 @@ using namespace cocos2d::experimental::ui;
     UITapGestureRecognizer *singleFingerTap =
     [[UITapGestureRecognizer alloc] initWithTarget:self
                                             action:@selector(handleSingleTap:)];
-    singleFingerTap.cancelsTouchesInView = YES;
 
     [self.moviePlayer.view addGestureRecognizer:singleFingerTap];
 
@@ -332,7 +314,7 @@ using namespace cocos2d::experimental::ui;
 {
     _keepRatioEnabled = enabled;
     if (self.moviePlayer != NULL) {
-        if (_keepRatioEnabled) {
+        if (enabled) {
             self.moviePlayer.scalingMode = MPMovieScalingModeAspectFit;
         } else {
             self.moviePlayer.scalingMode = MPMovieScalingModeFill;
@@ -343,17 +325,7 @@ using namespace cocos2d::experimental::ui;
 -(void) play
 {
     if (self.moviePlayer != NULL) {
-        if (_fullscreen)
-        {
-            self.moviePlayer.scalingMode = MPMovieScalingModeFill;
-            [self.moviePlayer.view setFrame:[[UIScreen mainScreen] bounds]];
-        }
-        else
-        {
-            [self setKeepRatioEnabled:_keepRatioEnabled];
-            [self.moviePlayer.view setFrame:CGRectMake(_left, _top, _width, _height)];
-        }
-        
+        [self.moviePlayer.view setFrame:CGRectMake(_left, _top, _width, _height)];
         [self.moviePlayer play];
     }
 }
@@ -381,9 +353,9 @@ using namespace cocos2d::experimental::ui;
 
 -(void) stop
 {
-    if (self.moviePlayer != NULL)
-    {
-        [self.moviePlayer stop];
+    if (self.moviePlayer != NULL) {
+        [self.moviePlayer pause];
+        [self seekTo:0];
         _videoPlayer->onPlayEvent((int)VideoPlayer::EventType::STOPPED);
     }
 }


### PR DESCRIPTION
1. IOS 
1.1 视频全屏无法点击问题
1.2 第一次暂停视频会变成播放。

2. 安卓
1.1 立即加载视频无法播放
1.2 后台切换到前台白屏
1.3 后台切换到前台无法继续播放
