### PR TITLE
fix video play error, on android.

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -177,12 +177,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
             super.setVisibility(VISIBLE);
             return;
         }
-		
-        if (visibility == INVISIBLE) {
-            if(getCurrentPosition() > 0 && mSeekWhenPrepared == 0) {
-                mSeekWhenPrepared = getCurrentPosition();
-            }
-        }
+
         super.setVisibility(visibility);
     }
 
@@ -587,16 +582,18 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
      */
     private void release(boolean cleartargetstate) {
         if (mMediaPlayer != null) {
+            if (mTargetState == STATE_PLAYING) {
+                mSeekWhenPrepared = mMediaPlayer.getCurrentPosition();
+                mTargetState = STATE_PLAYING;
+            }
             mMediaPlayer.reset();
             mMediaPlayer.release();
             mMediaPlayer = null;
             mCurrentState = STATE_IDLE;
-            if (cleartargetstate) {
-                mTargetState  = STATE_IDLE;
-            }
         }
     }
 
+    @Override
     public void start() {
         if (isInPlaybackState()) {
             mMediaPlayer.start();
@@ -606,14 +603,16 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
             }
 
             mCurrentState = STATE_PLAYING;
-
-            mTargetState = STATE_PLAYING;
         }
+
+        mTargetState = STATE_PLAYING;
     }
 
+    @Override
     public void pause() {
         if (isInPlaybackState()) {
             if (mMediaPlayer.isPlaying()) {
+                mSeekWhenPrepared = mMediaPlayer.getCurrentPosition();
                 mMediaPlayer.pause();
                 mCurrentState = STATE_PAUSED;
                 if (mOnVideoEventListener != null) {
@@ -658,7 +657,8 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
             mTargetState = STATE_PLAYING;
         }
     }
-    // cache duration as mDuration for faster access
+
+    @Override
     public int getDuration() {
         if (isInPlaybackState()) {
             if (mDuration > 0) {
@@ -671,6 +671,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
         return mDuration;
     }
 
+    @Override
     public int getCurrentPosition() {
         if (isInPlaybackState()) {
             return mMediaPlayer.getCurrentPosition();
@@ -679,6 +680,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
         }
     }
 
+    @Override
     public void seekTo(int msec) {
         if (isInPlaybackState()) {
             mMediaPlayer.seekTo(msec);
@@ -688,10 +690,12 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
         }
     }
 
+    @Override
     public boolean isPlaying() {
         return isInPlaybackState() && mMediaPlayer.isPlaying();
     }
 
+    @Override
     public int getBufferPercentage() {
         if (mMediaPlayer != null) {
             return mCurrentBufferPercentage;
@@ -722,6 +726,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
         return true;
     }
 
+    @Override
     public int getAudioSessionId () {
        return mMediaPlayer.getAudioSessionId();
     }

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -93,6 +93,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     protected int mFullScreenHeight = 0;
 
     private int mViewTag = 0;
+    private int mViewVisible = INVISIBLE;
 
     public Cocos2dxVideoView(Cocos2dxActivity activity,int tag) {
         super(activity);
@@ -105,7 +106,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         if (mVideoWidth == 0 || mVideoHeight == 0) {
-            setMeasuredDimension(mViewWidth, mViewHeight);
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
             Log.i(TAG, ""+mViewWidth+ ":" +mViewHeight);
         }
         else {
@@ -170,6 +171,13 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
 
     @Override
     public void setVisibility(int visibility) {
+        if (mSurfaceHolder == null)
+        {
+            mViewVisible = visibility;
+            super.setVisibility(VISIBLE);
+            return;
+        }
+		
         if (visibility == INVISIBLE) {
             if(getCurrentPosition() > 0 && mSeekWhenPrepared == 0) {
                 mSeekWhenPrepared = getCurrentPosition();
@@ -557,6 +565,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
         public void surfaceCreated(SurfaceHolder holder)
         {
             mSurfaceHolder = holder;
+            setVisibility(mViewVisible);
             openVideo();
         }
 


### PR DESCRIPTION
安卓下面的媒体播放器依赖于Surface渲染，如果Surface没有初始化，会导致媒体播放器无法正常工作。Surface的初始化，需要保证Surface的显示区域可见且大小有效。目前的代码逻辑会出现Surface无法正常工作的情况，上述2种情况都可能发生，详见代码注释。顺便修复了，切换后台后，播放状态的还原。