### PR TITLE
fix default template android lib path error

### DIFF
--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/app/build.gradle
@@ -120,6 +120,6 @@ android.applicationVariants.all { variant ->
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation fileTree(dir: "${COCOS_X_ROOT}/cocos/platform/android/java/libs", include: ['*.jar'])
+    implementation fileTree(dir: "../../../cocos2d-x/cocos/platform/android/java/libs", include: ['*.jar'])
     implementation project(':libcocos2dx')
 }


### PR DESCRIPTION
`${COCOS_X_ROOT}` is used at link template, relative path is used in default template

@minggo please merge