### PR TITLE
fix android text render crash issue

### DIFF
--- a/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
+++ b/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
@@ -223,9 +223,10 @@ void CanvasGradient::addColorStop(float offset, const std::string& color)
 // CanvasRenderingContext2D
 
 CanvasRenderingContext2D::CanvasRenderingContext2D(float width, float height)
-: __width(width)
-, __height(height)
 {
+    // set init canvas width and height as 1.0 x 1.0 if the width and height is invalid.
+    __width = width < 1.0f ? 1.0f : width;
+    __height = height < 1.0f ? 1.0f : height;
     // SE_LOGD("CanvasRenderingContext2D constructor: %p, width: %f, height: %f\n", this, width, height);
     _impl = new CanvasRenderingContext2DImpl();
     recreateBufferIfNeeded();
@@ -347,14 +348,16 @@ void CanvasRenderingContext2D::setCanvasBufferUpdatedCallback(const CanvasBuffer
 void CanvasRenderingContext2D::set__width(float width)
 {
 //    SE_LOGD("CanvasRenderingContext2D::set__width: %f\n", width);
-    __width = width;
+    // set __width as 1.0 if the width is invalid.
+    __width = width < 1.0f ? 1.0f : width;
     _isBufferSizeDirty = true;
 }
 
 void CanvasRenderingContext2D::set__height(float height)
 {
 //    SE_LOGD("CanvasRenderingContext2D::set__height: %f\n", height);
-    __height = height;
+    // set __height as 1.0 if the height is invalid.
+    __height = height < 1.0f ? 1.0f : height;
     _isBufferSizeDirty = true;
 }
 

--- a/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
+++ b/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
@@ -223,10 +223,9 @@ void CanvasGradient::addColorStop(float offset, const std::string& color)
 // CanvasRenderingContext2D
 
 CanvasRenderingContext2D::CanvasRenderingContext2D(float width, float height)
+: __width(width)
+, __height(height)
 {
-    // set init canvas width and height as 1.0 x 1.0 if the width and height is invalid.
-    __width = width < 1.0f ? 1.0f : width;
-    __height = height < 1.0f ? 1.0f : height;
     // SE_LOGD("CanvasRenderingContext2D constructor: %p, width: %f, height: %f\n", this, width, height);
     _impl = new CanvasRenderingContext2DImpl();
     recreateBufferIfNeeded();
@@ -348,16 +347,14 @@ void CanvasRenderingContext2D::setCanvasBufferUpdatedCallback(const CanvasBuffer
 void CanvasRenderingContext2D::set__width(float width)
 {
 //    SE_LOGD("CanvasRenderingContext2D::set__width: %f\n", width);
-    // set __width as 1.0 if the width is invalid.
-    __width = width < 1.0f ? 1.0f : width;
+    __width = width;
     _isBufferSizeDirty = true;
 }
 
 void CanvasRenderingContext2D::set__height(float height)
 {
 //    SE_LOGD("CanvasRenderingContext2D::set__height: %f\n", height);
-    // set __height as 1.0 if the height is invalid.
-    __height = height < 1.0f ? 1.0f : height;
+    __height = height;
     _isBufferSizeDirty = true;
 }
 

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
@@ -224,7 +224,10 @@ public class CanvasRenderingContext2DImpl {
     }
 
     private void restoreContext() {
-        mCanvas.restore();
+        // If there is no saved state, this method should do nothing.
+        if (mCanvas.getSaveCount() > 1){
+            mCanvas.restore();
+        }
     }
 
     private void clearRect(float x, float y, float w, float h) {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
@@ -55,7 +55,7 @@ public class CanvasRenderingContext2DImpl {
     private TextPaint mTextPaint;
     private Paint mLinePaint;
     private Path mLinePath;
-    private Canvas mCanvas;
+    private Canvas mCanvas = new Canvas();
     private Bitmap mBitmap;
     private int mTextAlign = TEXT_ALIGN_LEFT;
     private int mTextBaseline = TEXT_BASELINE_BOTTOM;
@@ -186,7 +186,7 @@ public class CanvasRenderingContext2DImpl {
             mBitmap.recycle();
         }
         mBitmap = Bitmap.createBitmap((int)Math.ceil(w), (int)Math.ceil(h), Bitmap.Config.ARGB_8888);
-        mCanvas = new Canvas(mBitmap);
+        mCanvas.setBitmap(mBitmap);
     }
 
     private void beginPath() {


### PR DESCRIPTION
原逻辑在正常操作时不会 crash

- 正常操作：初始化 canvas -> 设置 canvas 宽高 -> 清空区域 -> 填充字体

在不按规则操作时会 crash，比如

- 异常操作：初始化 canvas (同时不设置有效的宽高值) -> 调用 canvas.save 保存状态。
- crash 原因：JS 初始化 canvas 时，CPP 初始化对应的 canvas 管理对象，Java 侧并没有真正的初始化绘图 canvas，canvas 对象为空。调用成员方法引起 crash

解决

- java 侧类初始化时，new canvas 对象，防止后续调用方法时空指针
- canvas.restore() 时判断是否有可恢复的状态，如果无不进行恢复操作，防止出现异常 ```Underflow in restoreToCount - more restores than saves``` 

> 参考：https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/restore
> restores the most recently saved canvas state by popping the top entry in the drawing state stack. If there is no saved state, this method does nothing.