### PR TITLE
Fix JSB_showInputBox crash

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -905,7 +905,7 @@ static bool JSB_showInputBox(se::State& s)
 
         se::Value confirmHoldValue;
         obj->getProperty("confirmHold", &confirmHoldValue);
-        SE_PRECONDITION2((!confirmHoldValue.isNullOrUndefined() && confirmHoldValue.isBoolean()),
+        SE_PRECONDITION2((confirmHoldValue.isNullOrUndefined() && confirmHoldValue.isBoolean()),
                          false, "confirmHold is invalid!");
         if (confirmHoldValue.isBoolean())
             showInfo.confirmHold = confirmHoldValue.toBoolean();

--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -885,48 +885,58 @@ static bool JSB_showInputBox(se::State& s)
     CC_UNUSED bool ok = true;
     if (argc == 1)
     {
-        se::Value tmp;
         const auto& obj = args[0].toObject();
-        
         cocos2d::EditBox::ShowInfo showInfo;
+
+        se::Value defaultValue;
+        obj->getProperty("defaultValue", &defaultValue);
+        SE_PRECONDITION2(defaultValue.isString(), false, "defaultValue is invalid!");
+        showInfo.defaultValue = defaultValue.toString();
         
-        obj->getProperty("defaultValue", &tmp);
-        showInfo.defaultValue = tmp.toString();
-        
-        
-        obj->getProperty("maxLength", &tmp);
-        showInfo.maxLength = tmp.toInt32();
-        
-        obj->getProperty("multiple", &tmp);
-        showInfo.isMultiline = tmp.toBoolean();
-        
-        obj->getProperty("confirmHold", &tmp);
-        if (! tmp.isUndefined())
-            showInfo.confirmHold = tmp.toBoolean();
-        
-        obj->getProperty("confirmType", &tmp);
-        if (! tmp.isUndefined())
-            showInfo.confirmType = tmp.toString();
-        
-        obj->getProperty("inputType", &tmp);
-        if (! tmp.isUndefined())
-            showInfo.inputType = tmp.toString();
-        
-        obj->getProperty("originX", &tmp);
-        if (! tmp.isUndefined())
-            showInfo.x = tmp.toInt32();
-        
-        obj->getProperty("originY", &tmp);
-        if (! tmp.isUndefined())
-            showInfo.y = tmp.toInt32();
-        
-        obj->getProperty("width", &tmp);
-        if (! tmp.isUndefined())
-            showInfo.width = tmp.toInt32();
-        
-        obj->getProperty("height", &tmp);
-        if (! tmp.isUndefined())
-            showInfo.height = tmp.toInt32();
+        se::Value maxLengthValue;
+        obj->getProperty("maxLength", &maxLengthValue);
+        SE_PRECONDITION2(maxLengthValue.isNumber(), false, "maxLength is invalid!");
+        showInfo.maxLength = maxLengthValue.toInt32();
+
+        se::Value multipleValue;
+        obj->getProperty("multiple", &multipleValue);
+        SE_PRECONDITION2(multipleValue.isBoolean(), false, "multiple is invalid!");
+        showInfo.isMultiline = multipleValue.toBoolean();
+
+        se::Value confirmHoldValue;
+        obj->getProperty("confirmHold", &confirmHoldValue);
+        if (confirmHoldValue.isBoolean())
+            showInfo.confirmHold = confirmHoldValue.toBoolean();
+
+        se::Value confirmTypeValue;
+        obj->getProperty("confirmType", &confirmTypeValue);
+        if (confirmTypeValue.isString())
+            showInfo.confirmType = confirmTypeValue.toString();
+
+        se::Value inputTypeValue;
+        obj->getProperty("inputType", &inputTypeValue);
+        if (inputTypeValue.isString())
+            showInfo.inputType = inputTypeValue.toString();
+
+        se::Value originXValue;
+        obj->getProperty("originX", &originXValue);
+        if (originXValue.isNumber())
+            showInfo.x = originXValue.toInt32();
+
+        se::Value originYValue;
+        obj->getProperty("originY", &originYValue);
+        if (originYValue.isNumber())
+            showInfo.y = originYValue.toInt32();
+
+        se::Value widthValue;
+        obj->getProperty("width", &widthValue);
+        if (widthValue.isNumber())
+            showInfo.width = widthValue.toInt32();
+
+        se::Value heightValue;
+        obj->getProperty("height", &heightValue);
+        if (heightValue.isNumber())
+            showInfo.height = heightValue.toInt32();
         
         EditBox::show(showInfo);
         

--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -905,36 +905,50 @@ static bool JSB_showInputBox(se::State& s)
 
         se::Value confirmHoldValue;
         obj->getProperty("confirmHold", &confirmHoldValue);
+        SE_PRECONDITION2((!confirmHoldValue.isNullOrUndefined() && confirmHoldValue.isBoolean()),
+                         false, "confirmHold is invalid!");
         if (confirmHoldValue.isBoolean())
             showInfo.confirmHold = confirmHoldValue.toBoolean();
 
         se::Value confirmTypeValue;
         obj->getProperty("confirmType", &confirmTypeValue);
+        SE_PRECONDITION2((confirmTypeValue.isNullOrUndefined() || confirmTypeValue.isString()),
+                         false, "confirmType is invalid!");
         if (confirmTypeValue.isString())
             showInfo.confirmType = confirmTypeValue.toString();
 
         se::Value inputTypeValue;
         obj->getProperty("inputType", &inputTypeValue);
+        SE_PRECONDITION2((inputTypeValue.isNullOrUndefined() || inputTypeValue.isString()),
+                         false, "inputType is invalid!");
         if (inputTypeValue.isString())
             showInfo.inputType = inputTypeValue.toString();
 
         se::Value originXValue;
         obj->getProperty("originX", &originXValue);
+        SE_PRECONDITION2((originXValue.isNullOrUndefined() || originXValue.isNumber()),
+                         false, "originX is invalid!");
         if (originXValue.isNumber())
             showInfo.x = originXValue.toInt32();
 
         se::Value originYValue;
         obj->getProperty("originY", &originYValue);
+        SE_PRECONDITION2((originYValue.isNullOrUndefined() || originYValue.isNumber()),
+                         false, "originY is invalid!");
         if (originYValue.isNumber())
             showInfo.y = originYValue.toInt32();
 
         se::Value widthValue;
         obj->getProperty("width", &widthValue);
+        SE_PRECONDITION2((widthValue.isNullOrUndefined() || widthValue.isNumber()),
+                         false, "width is invalid!");
         if (widthValue.isNumber())
             showInfo.width = widthValue.toInt32();
 
         se::Value heightValue;
         obj->getProperty("height", &heightValue);
+        SE_PRECONDITION2((heightValue.isNullOrUndefined() || heightValue.isNumber()),
+                         false, "height is invalid!");
         if (heightValue.isNumber())
             showInfo.height = heightValue.toInt32();
         

--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -905,7 +905,7 @@ static bool JSB_showInputBox(se::State& s)
 
         se::Value confirmHoldValue;
         obj->getProperty("confirmHold", &confirmHoldValue);
-        SE_PRECONDITION2((confirmHoldValue.isNullOrUndefined() && confirmHoldValue.isBoolean()),
+        SE_PRECONDITION2((confirmHoldValue.isNullOrUndefined() || confirmHoldValue.isBoolean()),
                          false, "confirmHold is invalid!");
         if (confirmHoldValue.isBoolean())
             showInfo.confirmHold = confirmHoldValue.toBoolean();


### PR DESCRIPTION
# 调用一下代码会崩溃:

```
jsb.showInputBox({defaultValue: 'test', maxLength: 100, multiple: true, confirmHold: true, confirmType: 'done',inputType: 'text'});
```
由于在做参数解析的时候,共用了同一个变量,上一个参数未清空,在解析下一个参数的时候,如果参数没有传值,则解析参数是复用了上一个参数的结果,导致在转换类型的时候出错.
    
# 修复

为每个参数添加一个临时变量,并且在转换类型之前,判断参数类型.