### PR TITLE
add return value for main method

### DIFF
--- a/templates/js-template-default/frameworks/runtime-src/proj.win32/main.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/proj.win32/main.cpp
@@ -53,4 +53,6 @@ int APIENTRY _tWinMain(HINSTANCE hInstance,
 #ifdef USE_WIN32_CONSOLE
     FreeConsole();
 #endif
+
+    return 0;
 }

--- a/templates/js-template-link/frameworks/runtime-src/proj.ios_mac/mac/main.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/proj.ios_mac/mac/main.cpp
@@ -30,4 +30,5 @@ int main(int argc, char *argv[])
 {
     AppDelegate app(960, 640);
     app.start();
+    return 0;
 }

--- a/templates/js-template-link/frameworks/runtime-src/proj.win32/main.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/proj.win32/main.cpp
@@ -53,4 +53,6 @@ int APIENTRY _tWinMain(HINSTANCE hInstance,
 #ifdef USE_WIN32_CONSOLE
     FreeConsole();
 #endif
+
+    return 0;
 }


### PR DESCRIPTION
for issue https://github.com/cocos-creator/fireball/issues/7829

编辑器会检测子进程的返回值，返回非零值，认定运行失败，在控制台输出 error 日志。

> 模拟器工程有返回值，mac 的 default 模板，当时 @minggo 适配的有返回值，后续适配的时候，以为返回值没用，就没做返回。