### PR TITLE
Do not reset ContentSize to cocos2d::Size::ZERO when SpriteFrame is null.Because js need the state!

### DIFF
--- a/cocos/editor-support/creator/CCScale9Sprite.cpp
+++ b/cocos/editor-support/creator/CCScale9Sprite.cpp
@@ -931,8 +931,7 @@ bool Scale9SpriteV2::setSpriteFrame(cocos2d::SpriteFrame* spriteFrame)
     
     if(!spriteFrame)
     {
-        this->setContentSize(cocos2d::Size::ZERO);
-         return true;
+        return true;
     }
 
     CC_SAFE_RETAIN(spriteFrame);


### PR DESCRIPTION
Do not reset ContentSize to cocos2d::Size::ZERO when SpriteFrame is null.Because js need the state!