### PR TITLE
addRegisterCallback should done before script engine start

### DIFF
--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -77,12 +77,12 @@ bool AppDelegate::applicationDidFinishLaunching()
 
     jsb_register_all_modules();
 
-    se->start();
-
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && PACKAGE_AS
    se->addRegisterCallback(register_all_anysdk_framework);
    se->addRegisterCallback(register_all_anysdk_manual);
 #endif
+
+    se->start();
 
     se::AutoHandleScope hs;
     jsb_run_script("jsb-adapter/jsb-builtin.js");

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -77,12 +77,12 @@ bool AppDelegate::applicationDidFinishLaunching()
 
     jsb_register_all_modules();
 
-    se->start();
-
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && PACKAGE_AS
    se->addRegisterCallback(register_all_anysdk_framework);
    se->addRegisterCallback(register_all_anysdk_manual);
 #endif
+
+    se->start();
 
     se::AutoHandleScope hs;
     jsb_run_script("jsb-adapter/jsb-builtin.js");


### PR DESCRIPTION
change `addRegisterCallback` order

from
```
se->start()
se->addRegisterCallback(register_all_anysdk_framework);
```
to 
```
se->addRegisterCallback(register_all_anysdk_framework);
se->start()
```