### PR TITLE
fix ttf vertical alignment bug when Line Height is different from Font Size

### DIFF
--- a/cocos/2d/CCLabelTextFormatter.cpp
+++ b/cocos/2d/CCLabelTextFormatter.cpp
@@ -63,10 +63,10 @@ void Label::computeAlignmentOffset()
         _letterOffsetY = _contentSize.height;
         break;
     case cocos2d::TextVAlignment::CENTER:
-        _letterOffsetY = (_contentSize.height + _textDesiredHeight) / 2.f;
+        _letterOffsetY = (_contentSize.height + _originalFontSize + (_numberOfLines - 1) * _lineHeight) / 2.f;
         break;
     case cocos2d::TextVAlignment::BOTTOM:
-        _letterOffsetY = _textDesiredHeight;
+        _letterOffsetY = _originalFontSize + (_numberOfLines - 1) * _lineHeight;
         break;
     default:
         break;


### PR DESCRIPTION
Re: cocos-creator/cocos2d-x-lite#1403

修复 label 组件，在带有 ttf 字体情况下，vertical alignment  位置偏移量的计算错误。

@cocos-creator/admins 