### PR TITLE
correct wrong mTargetState in video player start() method

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -596,11 +596,9 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
             if (mCurrentState != STATE_PLAYING && mOnVideoEventListener != null) {
                 mOnVideoEventListener.onVideoEvent(mViewTag, EVENT_PLAYING);
             }
-
             mCurrentState = STATE_PLAYING;
-
-            mTargetState = STATE_PLAYING;
         }
+        mTargetState = STATE_PLAYING;
     }
 
     public void pause() {


### PR DESCRIPTION
for issue, https://github.com/cocos-creator/fireball/issues/8004

example-02/09_fullscreenVideo没有播放音频和图像

原因

* 设置视频资源时，由于节点不可见，SurfaceView 未初始化。实际上并没有进行视频资源的准备，在后续点击播放时，设置节点可见，资源开始准备，并调用开始播放视频的方法。
* 此时视频的播放状态未就绪（视频资源的准备过程是异步的），造成当前无法播放。后续资源准备好了，没有再次调用播放的方法。

解决

* 实际在资源准备好的回调中，有根据目标状态（mTargetState）决定是否重新调用 start() 的逻辑。

```
    MediaPlayer.OnPreparedListener mPreparedListener = new MediaPlayer.OnPreparedListener() {
        public void onPrepared(MediaPlayer mp) {
            mCurrentState = STATE_PREPARED;

            ...

            if (mTargetState == STATE_PLAYING) {
                start();
            }
        }
    };
```

* 纠正在 start（）方法中关于 mTargetState 的错误设置，自测，问题解决。