### PR TITLE
fix setDataSource parameters error for video player

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -291,7 +291,7 @@ public class Cocos2dxVideoView extends SurfaceView implements MediaPlayerControl
                 AssetFileDescriptor afd = mCocos2dxActivity.getAssets().openFd(mVideoFilePath);
                 mMediaPlayer.setDataSource(afd.getFileDescriptor(),afd.getStartOffset(),afd.getLength());
             } else {
-                mMediaPlayer.setDataSource(mCocos2dxActivity, mVideoUri);
+                mMediaPlayer.setDataSource(mVideoUri.toString());
             }
 
             mMediaPlayer.prepareAsync();


### PR DESCRIPTION
- 修复设置远程视频 url 时， android 报出的一个警告信息：

```
W/MediaPlayer: java.io.FileNotFoundException: No content provider: http://benchmark.cocos2d-x.org/cocosvideo.mp4
```

- 参考

https://stackoverflow.com/questions/42106294/android-media-stream-error-java-io-filenotfoundexception-no-content-provider

> The problem is that void setDataSource (String path) Sets the data source (file-path or http/rtsp URL) to use.

> path String: the path of the file, or the http/rtsp URL of the stream you want to play

> the github code uses void setDataSource (Context context, Uri uri) which assumes uri to be of some form of ContentProvider

---
查问题 https://github.com/cocos-creator/fireball/issues/8006 时遇到的