### PR TITLE
not output info level log when using NSLog

### DIFF
--- a/cocos/network/CCDownloaderImpl-apple.mm
+++ b/cocos/network/CCDownloaderImpl-apple.mm
@@ -704,7 +704,7 @@ namespace cocos2d { namespace network {
                                        didResumeAtOffset:(int64_t)fileOffset
                                       expectedTotalBytes:(int64_t)expectedTotalBytes
 {
-    NSLog(@"[TODO]DownloaderAppleImpl downloadTask: \"%@\" didResumeAtOffset: %lld", downloadTask.originalRequest.URL, fileOffset);
+    // NSLog(@"[TODO]DownloaderAppleImpl downloadTask: \"%@\" didResumeAtOffset: %lld", downloadTask.originalRequest.URL, fileOffset);
     // 下载失败
 //    self.downloadFail([self getDownloadRespose:XZDownloadFail identifier:self.identifier progress:0.00 downloadUrl:nil downloadSaveFileUrl:nil downloadData:nil downloadResult:@"下载失败"]);
 }

--- a/cocos/network/HttpAsynConnection-apple.m
+++ b/cocos/network/HttpAsynConnection-apple.m
@@ -65,7 +65,7 @@
 - (void) startRequest:(NSURLRequest *)request
 {
 #ifdef COCOS2D_DEBUG
-    NSLog(@"Starting to load %@", srcURL);
+    // NSLog(@"Starting to load %@", srcURL);
 #endif
     
     finish = false;
@@ -97,7 +97,7 @@
 - (void) connection:(NSURLConnection *)connection 
  didReceiveResponse:(NSURLResponse *)response {
 #ifdef COCOS2D_DEBUG
-    NSLog(@"Received response from request to url %@", srcURL);
+    // NSLog(@"Received response from request to url %@", srcURL);
 #endif
     
     NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;

--- a/cocos/network/WebSocket-apple.mm
+++ b/cocos/network/WebSocket-apple.mm
@@ -70,7 +70,7 @@ static std::vector<cocos2d::network::WebSocket*>* __websocketInstances = nullptr
 
 -(void) dealloc
 {
-    NSLog(@"WebSocketImpl-apple dealloc: %p, SRWebSocket ref: %ld", self, CFGetRetainCount((__bridge CFTypeRef)_ws));
+    // NSLog(@"WebSocketImpl-apple dealloc: %p, SRWebSocket ref: %ld", self, CFGetRetainCount((__bridge CFTypeRef)_ws));
 }
 
 -(void) sendString:(NSString*) message
@@ -139,7 +139,7 @@ static std::vector<cocos2d::network::WebSocket*>* __websocketInstances = nullptr
 {
     if (!_isDestroyed)
     {
-        NSLog(@"Websocket Connected");
+        // NSLog(@"Websocket Connected");
         if (webSocket.protocol != nil)
             _selectedProtocol = [webSocket.protocol UTF8String];
         _delegate->onOpen(_ccws);
@@ -247,7 +247,7 @@ WebSocket::WebSocket()
 
 WebSocket::~WebSocket()
 {
-    NSLog(@"In the destructor of WebSocket-apple (%p).", this);
+    // NSLog(@"In the destructor of WebSocket-apple (%p).", this);
 
     if (__websocketInstances != nullptr)
     {


### PR DESCRIPTION
for issues, https://github.com/cocos-creator/fireball/issues/7849

对于提示类的信息，不再输出 NSLog，原因是 NSLog 只会输出信息到错误流，以致在编辑器的控制台中会显示红色报错信息。

> 对于异常情况下，才会输出的 NSLog，不应该注释掉，也没这样做

类似报错

![image](https://user-images.githubusercontent.com/26329291/43711579-cbf4d964-99a5-11e8-92cf-08e48a4b245b.png)