### PR TITLE
close audio device when destruct Application

### DIFF
--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -70,7 +70,6 @@ Application::Application(const std::string& name, int width, int height)
 
 Application::~Application()
 {
-    // TODO: destroy DeviceGraphics
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
 

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -30,6 +30,9 @@ THE SOFTWARE.
 #include "platform/Android/CCGL-android.h"
 #include "base/CCScheduler.h"
 #include "base/CCConfiguration.h"
+#include "audio/include/AudioEngine.h"
+#include "scripting/js-bindings/jswrapper/SeApi.h"
+#include "scripting/js-bindings/event/EventDispatcher.h"
 
 #define  LOG_TAG    "CCApplication_android Debug"
 #define  LOGD(...)  __android_log_print(ANDROID_LOG_DEBUG,LOG_TAG,__VA_ARGS__)

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -67,6 +67,13 @@ Application::Application(const std::string& name, int width, int height)
 
 Application::~Application()
 {
+    // TODO: destroy DeviceGraphics
+    EventDispatcher::destroy();
+    se::ScriptEngine::destroyInstance();
+
+    // close audio device
+    cocos2d::experimental::AudioEngine::end();
+    
     delete _scheduler;
     _scheduler = nullptr;
 

--- a/cocos/platform/android/jni/JniImp.cpp
+++ b/cocos/platform/android/jni/JniImp.cpp
@@ -165,10 +165,8 @@ extern "C"
     {
         g_isGameFinished = true;
         LOGD("CocosRenderer.nativeFinish");
-        g_app->getScheduler()->removeAllFunctionsToBePerformedInCocosThread();
-        EventDispatcher::destroy();
-        se::ScriptEngine::getInstance()->cleanup();
-        cocos2d::experimental::AudioEngine::end();
+
+        g_app->end();
         JniHelper::callObjectVoidMethod(thiz, Cocos2dxRendererClassName, "onGameFinished");
     }
 

--- a/cocos/platform/android/jni/JniImp.cpp
+++ b/cocos/platform/android/jni/JniImp.cpp
@@ -35,7 +35,6 @@
 #include "platform/android/CCFileUtils-android.h"
 #include "base/CCScheduler.h"
 #include "base/CCAutoreleasePool.h"
-#include "audio/include/AudioEngine.h"
 #include "base/CCGLUtils.h"
 
 #define  JNI_IMP_LOG_TAG    "JniImp"

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -228,7 +228,6 @@ Application::~Application()
     delete _scheduler;
     _scheduler = nullptr;
     
-    // TODO: destroy DeviceGraphics
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
 

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -34,6 +34,8 @@
 #include "scripting/js-bindings/event/EventDispatcher.h"
 #include "CCEAGLView-ios.h"
 #include "base/CCGLUtils.h"
+#include "audio/include/AudioEngine.h"
+
 
 namespace
 {
@@ -229,6 +231,9 @@ Application::~Application()
     // TODO: destroy DeviceGraphics
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
+
+    // close audio device
+    cocos2d::experimental::AudioEngine::end();
     
     // stop main loop
     [(MainLoop*)_delegate stopMainLoop];

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "scripting/js-bindings/event/EventDispatcher.h"
 #include "scripting/js-bindings/jswrapper/SeApi.h"
 #include "base/CCGLUtils.h"
+#include "audio/include/AudioEngine.h"
 
 NS_CC_BEGIN
 
@@ -84,6 +85,9 @@ Application::~Application()
     // TODO: destroy DeviceGraphics
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
+
+    // close audio device
+    cocos2d::experimental::AudioEngine::end();
     
     delete CAST_VIEW(_view);
     _view = nullptr;

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -82,7 +82,6 @@ Application::Application(const std::string& name, int width, int height)
 
 Application::~Application()
 {
-    // TODO: destroy DeviceGraphics
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
 

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -117,7 +117,6 @@ Application::Application(const std::string& name, int width, int height)
 
 Application::~Application()
 {
-    // TODO: destroy DeviceGraphics
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
 

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include "base/CCScheduler.h"
 #include "base/CCAutoreleasePool.h"
 #include "base/CCGLUtils.h"
+#include "audio/include/AudioEngine.h"
 
 #define CAST_VIEW(view)    ((GLView*)view)
 
@@ -117,11 +118,14 @@ Application::Application(const std::string& name, int width, int height)
 Application::~Application()
 {
     // TODO: destroy DeviceGraphics
-    
+    EventDispatcher::destroy();
+    se::ScriptEngine::destroyInstance();
+
+    //close audio device
+    cocos2d::experimental::AudioEngine::end();
+
     delete _scheduler;
     _scheduler = nullptr;
-
-    se::ScriptEngine::destroyInstance();
     
     delete CAST_VIEW(_view);
     _view = nullptr;

--- a/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
@@ -93,7 +93,7 @@
       <TargetMachine>MachineX86</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OutDir);$(EngineRoot)external\win32\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libcurl.lib;websockets.lib;libSpine.lib;libDragonBones.lib;v8.dll.lib;v8_libbase.dll.lib;v8_libplatform.dll.lib;libuv.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurl.lib;websockets.lib;v8.dll.lib;v8_libbase.dll.lib;v8_libplatform.dll.lib;libuv.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>$(OutDir)$(TargetName).pdb</ProgramDatabaseFile>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <IgnoreSpecificDefaultLibraries>libcmt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -162,7 +162,7 @@ if exist "$(ProjectDir)..\..\..\..\..\simulator\win32\config.json" copy "$(Proje
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalLibraryDirectories>$(OutDir);$(EngineRoot)external\spidermonkey\prebuilt\win32;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>libcurl.lib;websockets.lib;libSpine.lib;libDragonBones.lib;v8.dll.lib;v8_libbase.dll.lib;v8_libplatform.dll.lib;libuv.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurl.lib;websockets.lib;v8.dll.lib;v8_libbase.dll.lib;v8_libplatform.dll.lib;libuv.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>
       <IgnoreSpecificDefaultLibraries>libcmt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>


### PR DESCRIPTION
for https://github.com/cocos-creator/fireball/issues/8094

修复:
 
在声音播放的过程中，如果用户直接关闭窗口，`AudioEngine::end()` 不会被调用，造成申请的 audio device 未关闭。

报错信息:

```
AL lib: (EE) alc_cleanup: 1 device not closed error
```
> 问题只在 win32 模拟器的时候通过 creator 的编辑器 console 被发现，但是这个问题应该是公共的，于是也修改了 mac / ios