### PR TITLE
Fix the problem of there is no callback when playing audio with an error.

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -649,16 +649,7 @@ void AudioEngineImpl::update(float dt)
         alSource = player->_alSource;
         alGetSourcei(alSource, AL_SOURCE_STATE, &sourceState);
 
-        if (player->_removeByAudioEngine)
-        {
-            AudioEngine::remove(audioID);
-            _threadMutex.lock();
-            it = _audioPlayers.erase(it);
-            _threadMutex.unlock();
-            delete player;
-            _unusedSourcesPool.push_back(alSource);
-        }
-        else if (player->_ready && sourceState == AL_STOPPED) {
+        if (player->_removeByAudioEngine || (player->_ready && sourceState == AL_STOPPED)) {
 
             std::string filePath;
             if (player->_finishCallbak) {


### PR DESCRIPTION
I get an error in the native code of `alSourcePlay()` with `A004` when I played a sound, but I can't know that in the javascript. I need to get the finish callback when the error happened.