### PR TITLE
add getCurrentStackTrace interface for v8 script engine

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -671,7 +671,12 @@ namespace se {
         return success;
     }
 
-    std::string ScriptEngine::getCurrentStackTrace(){
+    std::string ScriptEngine::getCurrentStackTrace()
+    {
+        if (!_isValid)
+            return std::string();
+
+        v8::HandleScope hs(_isolate);
         v8::Local<v8::StackTrace> stack = v8::StackTrace::CurrentStackTrace(_isolate, __jsbStackFrameLimit, v8::StackTrace::kOverview);
         return stackTraceToString(stack);
     }

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -39,6 +39,7 @@
 #endif
 
 uint32_t __jsbInvocationCount = 0;
+uint32_t __jsbStackFrameLimit = 20;
 
 #define RETRUN_VAL_IF_FAIL(cond, val) \
     if (!(cond)) return val
@@ -381,7 +382,7 @@ namespace se {
         v8::HandleScope hs(_isolate);
         _isolate->Enter();
 
-        _isolate->SetCaptureStackTraceForUncaughtExceptions(true, 20, v8::StackTrace::kOverview);
+        _isolate->SetCaptureStackTraceForUncaughtExceptions(true, __jsbStackFrameLimit, v8::StackTrace::kOverview);
 
         _isolate->SetFatalErrorHandler(onFatalErrorCallback);
         _isolate->SetOOMErrorHandler(onOOMErrorCallback);
@@ -668,6 +669,11 @@ namespace se {
 
 //        assert(success);
         return success;
+    }
+
+    std::string ScriptEngine::getCurrentStackTrace(){
+        v8::Local<v8::StackTrace> stack = v8::StackTrace::CurrentStackTrace(_isolate, __jsbStackFrameLimit, v8::StackTrace::kOverview);
+        return stackTraceToString(stack);
     }
 
     void ScriptEngine::setFileOperationDelegate(const FileOperationDelegate& delegate)

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.hpp
@@ -161,6 +161,12 @@ namespace se {
         bool evalString(const char* scriptStr, ssize_t length = -1, Value* rval = nullptr, const char* fileName = nullptr);
 
         /**
+         * @brief Grab a snapshot of the current JavaScript execution stack.
+         * @return current stack trace string
+         */
+        std::string getCurrentStackTrace();
+
+        /**
          *  Delegate class for file operation
          */
         class FileOperationDelegate


### PR DESCRIPTION
对于 android 平台，现在可以通过
```
se::ScriptEngine::getInstance()->getCurrentStackTrace();
```
获取当前的 JS 堆栈信息，这个接口在 debug 时想在 native 方法中反向了解，当前 js 执行情况时非常有用。

> 也可以用来在 crash 时获取堆栈信息（需要集成第三方的 breakpad 之类，去卡崩溃状态）

---
获取的堆栈信息，类似这样

```
    [0]end@src/cocos2d-jsb.js:6902
    [1]restart@src/project.dev.js:2999
    [2]emit@src/cocos2d-jsb.js:12618
    [3]emitEvents@src/cocos2d-jsb.js:12603
    [4]_onTouchEnded@src/cocos2d-jsb.js:12219
    [5]168.CallbacksInvoker.invoke@src/cocos2d-jsb.js:27136
    [6]_doDispatchEvent@src/cocos2d-jsb.js:7376
    [7]dispatchEvent@src/cocos2d-jsb.js:7991
    [8]_touchEndHandler@src/cocos2d-jsb.js:7268
    [9]_onTouchEventCallback@src/cocos2d-jsb.js:18599
    [10]_dispatchEventToListeners@src/cocos2d-jsb.js:18683
    [11]_dispatchTouchEvent@src/cocos2d-jsb.js:18632
    [12]dispatchEvent@src/cocos2d-jsb.js:18905
    [13]handleTouchesEnd@src/cocos2d-jsb.js:25225
    [14]touchend@src/cocos2d-jsb.js:25466
    [15]anonymous@src/cocos2d-jsb.js:25499
    [16]dispatchEvent@jsb-adapter/jsb-builtin.js:2997
    [17]anonymous@jsb-adapter/jsb-builtin.js:3036
```