### PR TITLE
[bug] Without using beginPath() in advance, calling stroke() directly will cause the problem to crash

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
@@ -212,6 +212,10 @@ public class CanvasRenderingContext2DImpl {
         if (mLinePaint == null) {
             mLinePaint = new Paint();
         }
+     
+        if(mLinePath == null) {
+            mLinePath = new Path();
+        }
 
         mLinePaint.setARGB(mStrokeStyleA, mStrokeStyleR, mStrokeStyleG, mStrokeStyleB);
         mLinePaint.setStyle(Paint.Style.STROKE);


### PR DESCRIPTION
调用canvas接口画一条线段：如果不实现事先调用beginPath()方法，依次调用moveTo，lineTo和stroke()，运行在浏览器上正常绘制；而在手机上会出现mLinePath空指针异常