### PR TITLE
win32: fix invoke update() multi times with same dt

### DIFF
--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -197,7 +197,7 @@ void Application::start()
             _renderTexture->prepare();
         CAST_VIEW(_view)->pollEvents();
 
-        if (firstUpdate){
+        if (firstUpdate)
         {
             firstUpdate = false;
             _scheduler->update(dt);
@@ -212,7 +212,7 @@ void Application::start()
                 nLast.QuadPart = nNow.QuadPart;
                 dt = (float)interval / freq.QuadPart;
                 _scheduler->update(dt);
-                
+
                 EventDispatcher::dispatchTickEvent(dt);
 
                 if (_isDownsampleEnabled)

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -196,7 +196,13 @@ void Application::start()
         if (_isDownsampleEnabled)
             _renderTexture->prepare();
         CAST_VIEW(_view)->pollEvents();
-        _scheduler->update(dt);
+
+        //block until `dt` is reset, 
+        if(dt >= 0) 
+        {
+            _scheduler->update(dt);
+            dt = -1.0;
+        }
 
         if(_isStarted)
         {

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -170,7 +170,7 @@ void Application::start()
     QueryPerformanceFrequency(&freq);
     
     se::ScriptEngine* se = se::ScriptEngine::getInstance();
-
+    bool firstUpdate = true;
     while (!CAST_VIEW(_view)->windowShouldClose())
     {       
         if (!_isStarted)
@@ -197,11 +197,10 @@ void Application::start()
             _renderTexture->prepare();
         CAST_VIEW(_view)->pollEvents();
 
-        //block until `dt` is reset, 
-        if(dt >= 0) 
+        if (firstUpdate){
         {
+            firstUpdate = false;
             _scheduler->update(dt);
-            dt = -1.0;
         }
 
         if(_isStarted)
@@ -212,6 +211,7 @@ void Application::start()
             {
                 nLast.QuadPart = nNow.QuadPart;
                 dt = (float)interval / freq.QuadPart;
+                _scheduler->update(dt);
                 
                 EventDispatcher::dispatchTickEvent(dt);
 

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -170,7 +170,6 @@ void Application::start()
     QueryPerformanceFrequency(&freq);
     
     se::ScriptEngine* se = se::ScriptEngine::getInstance();
-    bool firstUpdate = true;
     while (!CAST_VIEW(_view)->windowShouldClose())
     {       
         if (!_isStarted)
@@ -196,13 +195,6 @@ void Application::start()
         if (_isDownsampleEnabled)
             _renderTexture->prepare();
         CAST_VIEW(_view)->pollEvents();
-
-        if (firstUpdate)
-        {
-            firstUpdate = false;
-            _scheduler->update(dt);
-        }
-
         if(_isStarted)
         {
             QueryPerformanceCounter(&nNow);


### PR DESCRIPTION
ref http://forum.cocos.com/t/creator2-0-0-bug/64303

`update()` can be invoked multiple times with same `dt`, it leads to `Timer` runs about 5 times faster than the real clock. 