### PR TITLE
resume View Menu for simulator on mac & win32

### DIFF
--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "platform/CCPlatformConfig.h"
 #include "platform/CCPlatformDefine.h"
 #include "base/CCRenderTexture.h"
+#include "scripting/js-bindings/jswrapper/SeApi.h"
 
 NS_CC_BEGIN
 
@@ -136,7 +137,33 @@ public:
      @return Current language iso 639-1 code.
      */
     std::string getCurrentLanguageCode() const;
-    
+
+    /**
+     @brief Get current display stats.
+     @return bool, is displaying stats or not.
+     */
+    bool isDisplayStats()
+    {
+        se::AutoHandleScope hs;
+
+        se::Value ret;
+        char commandBuf[100] = "cc.debug.isDisplayStats();";
+        se::ScriptEngine::getInstance()->evalString(commandBuf, 100, &ret);
+        return ret.toBoolean();
+    }
+
+    /**
+     @brief set display stats information.
+     */
+    void setDisplayStats(bool isShow)
+    {
+        se::AutoHandleScope hs;
+
+        char commandBuf[100] = {0};
+        sprintf(commandBuf, "cc.debug.setDisplayStats(%s);", isShow ? "true" : "false");
+        se::ScriptEngine::getInstance()->evalString(commandBuf);
+    }
+
     void setDevicePixelRatio(uint8_t ratio)
     {
         if (ratio <= 1)

--- a/cocos/platform/desktop/CCGLView-desktop.cpp
+++ b/cocos/platform/desktop/CCGLView-desktop.cpp
@@ -443,10 +443,7 @@ void GLView::onGLFWWindowIconifyCallback(GLFWwindow* /*window*/, int iconified)
 
 void GLView::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int height)
 {
-    if (width && height)
-    {
-        EventDispatcher::dispatchResizeEvent(width, height);
-    }
+    EventDispatcher::dispatchResizeEvent(width, height);
 }
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)

--- a/cocos/scripting/js-bindings/event/EventDispatcher.cpp
+++ b/cocos/scripting/js-bindings/event/EventDispatcher.cpp
@@ -420,10 +420,9 @@ void EventDispatcher::removeAllCustomEventListeners(const std::string& eventName
     }
 }
 
-void EventDispatcher::dispatchCustomEvent(struct CustomEvent* event)
+void EventDispatcher::dispatchCustomEvent(const CustomEvent& event)
 {
-    assert(event);
-    auto iter = _listeners.find(event->name);
+    auto iter = _listeners.find(event.name);
     if (iter != _listeners.end())
     {
         Node* next = nullptr;

--- a/cocos/scripting/js-bindings/event/EventDispatcher.h
+++ b/cocos/scripting/js-bindings/event/EventDispatcher.h
@@ -91,8 +91,9 @@ struct KeyboardEvent
     bool shiftKeyActive = false;
 };
 
-struct CustomEvent
+class CustomEvent
 {
+public:
     std::string name;
     union {
         void* ptrVal;
@@ -102,6 +103,9 @@ struct CustomEvent
         char charVal;
         bool boolVal;
     } args[10];
+
+    CustomEvent(){};
+    virtual ~CustomEvent(){};
 };
 
 class EventDispatcher
@@ -118,11 +122,11 @@ public:
     static void dispatchEnterBackgroundEvent();
     static void dispatchEnterForegroundEvent();
 
-    using CustomEventListener = std::function<void(struct CustomEvent*)>;
+    using CustomEventListener = std::function<void(const CustomEvent&)>;
     static uint32_t addCustomEventListener(const std::string& eventName, const CustomEventListener& listener);
     static void removeCustomEventListener(const std::string& eventName, uint32_t listenerID);
     static void removeAllCustomEventListeners(const std::string& eventName);
-    static void dispatchCustomEvent(struct CustomEvent* event);
+    static void dispatchCustomEvent(const CustomEvent& event);
 
 private:
     struct Node

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -98,17 +98,17 @@ bool AppDelegate::applicationDidFinishLaunching()
 // This function will be called when the app is inactive. When comes a phone call,it's be invoked too
 void AppDelegate::applicationDidEnterBackground()
 {
-    struct CustomEvent event;
+    CustomEvent event;
     event.name = EVENT_COME_TO_BACKGROUND;
-    EventDispatcher::dispatchCustomEvent(&event);
+    EventDispatcher::dispatchCustomEvent(event);
     EventDispatcher::dispatchEnterBackgroundEvent();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
-    struct CustomEvent event;
+    CustomEvent event;
     event.name = EVENT_COME_TO_FOREGROUND;
-    EventDispatcher::dispatchCustomEvent(&event);
+    EventDispatcher::dispatchCustomEvent(event);
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -98,17 +98,17 @@ bool AppDelegate::applicationDidFinishLaunching()
 // This function will be called when the app is inactive. When comes a phone call,it's be invoked too
 void AppDelegate::applicationDidEnterBackground()
 {
-    struct CustomEvent event;
+    CustomEvent event;
     event.name = EVENT_COME_TO_BACKGROUND;
-    EventDispatcher::dispatchCustomEvent(&event);
+    EventDispatcher::dispatchCustomEvent(event);
     EventDispatcher::dispatchEnterBackgroundEvent();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
-    struct CustomEvent event;
+    CustomEvent event;
     event.name = EVENT_COME_TO_FOREGROUND;
-    EventDispatcher::dispatchCustomEvent(&event);
+    EventDispatcher::dispatchCustomEvent(event);
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -64,15 +64,15 @@ bool AppDelegate::applicationDidFinishLaunching()
 // This function will be called when the app is inactive. When comes a phone call,it's be invoked too
 void AppDelegate::applicationDidEnterBackground()
 {
-    struct CustomEvent event;
+    CustomEvent event;
     event.name = EVENT_COME_TO_BACKGROUND;
-    EventDispatcher::dispatchCustomEvent(&event);
+    EventDispatcher::dispatchCustomEvent(event);
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
-    struct CustomEvent event;
+    CustomEvent event;
     event.name = EVENT_COME_TO_FOREGROUND;
-    EventDispatcher::dispatchCustomEvent(&event);
+    EventDispatcher::dispatchCustomEvent(event);
 }

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.h
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.h
@@ -41,6 +41,7 @@
     AppDelegate *_app;
     ProjectConfig _project;
     int _debugLogFile;
+    bool _isShowFPS;
     std::string _entryPath;
     
     //log file

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.h
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.h
@@ -41,7 +41,6 @@
     AppDelegate *_app;
     ProjectConfig _project;
     int _debugLogFile;
-    bool _isShowFPS;
     std::string _entryPath;
     
     //log file

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm
@@ -281,7 +281,7 @@ std::string getCurAppName(void)
 {
     NSURL *url = [NSURL fileURLWithPath:[[NSBundle mainBundle] bundlePath]];
     NSMutableDictionary *configuration = [NSMutableDictionary dictionaryWithObject:args forKey:NSWorkspaceLaunchConfigurationArguments];
-    NSError *error = [[[NSError alloc] init] autorelease];
+    NSError *error = nil;
     [[NSWorkspace sharedWorkspace] launchApplicationAtURL:url
                                                   options:NSWorkspaceLaunchNewInstance
                                             configuration:configuration

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm
@@ -466,8 +466,8 @@ std::string getCurAppName(void)
 
     menuBar->addItem("VIEW_SCALE_MENU_SEP", "-", "VIEW_MENU");
 
-    _isShowFPS = true; // assume creator default show FPS
-    string fpsItemName = _isShowFPS ? tr("Hide FPS") : tr("Show FPS");
+    bool displayStats = true; // asume creator default show FPS
+    string fpsItemName = displayStats ? tr("Hide FPS") : tr("Show FPS");
     menuBar->addItem("VIEW_SHOW_FPS", fpsItemName, "VIEW_MENU");
 
     menuBar->addItem("VIEW_SHOW_FPS_SEP", "-", "VIEW_MENU");
@@ -585,9 +585,9 @@ std::string getCurAppName(void)
                     }
                     else if (data == "VIEW_SHOW_FPS")
                     {
-                        _isShowFPS = !_app->isDisplayStats();
-                        _app->setDisplayStats(_isShowFPS);
-                        menuItem->setTitle(_isShowFPS ? tr("Hide FPS") : tr("Show FPS"));
+                        bool displayStats = !_app->isDisplayStats();
+                        _app->setDisplayStats(displayStats);
+                        menuItem->setTitle(displayStats ? tr("Hide FPS") : tr("Show FPS"));
                     }
 
                 }

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/mac/SimulatorApp.mm
@@ -466,6 +466,12 @@ std::string getCurAppName(void)
 
     menuBar->addItem("VIEW_SCALE_MENU_SEP", "-", "VIEW_MENU");
 
+    _isShowFPS = true; // assume creator default show FPS
+    string fpsItemName = _isShowFPS ? tr("Hide FPS") : tr("Show FPS");
+    menuBar->addItem("VIEW_SHOW_FPS", fpsItemName, "VIEW_MENU");
+
+    menuBar->addItem("VIEW_SHOW_FPS_SEP", "-", "VIEW_MENU");
+
     std::vector<player::PlayerMenuItem*> scaleMenuVector;
     auto scale100Menu = menuBar->addItem("VIEW_SCALE_MENU_100", tr("Zoom Out").append(" (100%)"), "VIEW_MENU");
     scale100Menu->setShortcut("super+0");
@@ -511,7 +517,7 @@ std::string getCurAppName(void)
 
     ProjectConfig &project = _project;
 
-    EventDispatcher::CustomEventListener listener = [self, &project, scaleMenuVector](const CustomEvent& event) mutable{
+    EventDispatcher::CustomEventListener listener = [self, &project, scaleMenuVector](const CustomEvent& event){
         auto menuEvent = dynamic_cast<const AppEvent&>(event);
         rapidjson::Document dArgParse;
         dArgParse.Parse<0>(menuEvent.getDataString().c_str());
@@ -577,6 +583,13 @@ std::string getCurAppName(void)
                         project.changeFrameOrientationToLandscape();
                         [SIMULATOR relaunch];
                     }
+                    else if (data == "VIEW_SHOW_FPS")
+                    {
+                        _isShowFPS = !_app->isDisplayStats();
+                        _app->setDisplayStats(_isShowFPS);
+                        menuItem->setTitle(_isShowFPS ? tr("Hide FPS") : tr("Show FPS"));
+                    }
+
                 }
             }
         }

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -183,10 +183,11 @@ void SimulatorWin::quit()
 
 void SimulatorWin::relaunch()
 {
+	quit();
+	CC_SAFE_DELETE(_app);
+
     _project.setWindowOffset(Vec2(getPositionX(), getPositionY()));
     openNewPlayerWithProjectConfig(_project);
-
-    quit();
 }
 
 void SimulatorWin::openNewPlayer()
@@ -240,8 +241,8 @@ void SimulatorWin::openNewPlayerWithProjectConfig(const ProjectConfig &config)
 
 void SimulatorWin::openProjectWithProjectConfig(const ProjectConfig &config)
 {
+	quit();
     openNewPlayerWithProjectConfig(config);
-    quit();
 }
 
 int SimulatorWin::getPositionX()
@@ -358,7 +359,7 @@ int SimulatorWin::run()
 
     // check scale
     Size frameSize = _project.getFrameSize();
-    float frameScale = 1.0f;
+	float frameScale = _project.getFrameScale();
     if (_project.isRetinaDisplay())
     {
         frameSize.width *= screenScale;
@@ -366,7 +367,7 @@ int SimulatorWin::run()
     }
     else
     {
-        frameScale = screenScale;
+        frameScale *= screenScale;
     }
 
     // check screen workarea
@@ -498,33 +499,13 @@ void SimulatorWin::setupUI()
 
     menuBar->addItem("VIEW_SCALE_MENU_SEP", "-", "VIEW_MENU");
     std::vector<player::PlayerMenuItem*> scaleMenuVector;
-    auto scale200Menu = menuBar->addItem("VIEW_SCALE_MENU_200", tr("Zoom Out").append(" (200%)"), "VIEW_MENU");
-    auto scale175Menu = menuBar->addItem("VIEW_SCALE_MENU_175", tr("Zoom Out").append(" (175%)"), "VIEW_MENU");
-    auto scale150Menu = menuBar->addItem("VIEW_SCALE_MENU_150", tr("Zoom Out").append(" (150%)"), "VIEW_MENU");
-    auto scale125Menu = menuBar->addItem("VIEW_SCALE_MENU_125", tr("Zoom Out").append(" (125%)"), "VIEW_MENU");
     auto scale100Menu = menuBar->addItem("VIEW_SCALE_MENU_100", tr("Zoom Out").append(" (100%)"), "VIEW_MENU");
     auto scale75Menu = menuBar->addItem("VIEW_SCALE_MENU_75", tr("Zoom Out").append(" (75%)"), "VIEW_MENU");
     auto scale50Menu = menuBar->addItem("VIEW_SCALE_MENU_50", tr("Zoom Out").append(" (50%)"), "VIEW_MENU");
     auto scale25Menu = menuBar->addItem("VIEW_SCALE_MENU_25", tr("Zoom Out").append(" (25%)"), "VIEW_MENU");
     int frameScale = int(_project.getFrameScale() * 100);
 
-    if (frameScale == 200)
-    {
-        scale200Menu->setChecked(true);
-    }
-    else if (frameScale == 175)
-    {
-        scale175Menu->setChecked(true);
-    }
-    else if (frameScale == 150)
-    {
-        scale150Menu->setChecked(true);
-    }
-    else if (frameScale == 125)
-    {
-        scale125Menu->setChecked(true);
-    }
-    else if (frameScale == 100)
+	if (frameScale == 100)
     {
         scale100Menu->setChecked(true);
     }
@@ -545,10 +526,6 @@ void SimulatorWin::setupUI()
         scale100Menu->setChecked(true);
     }
 
-    scaleMenuVector.push_back(scale200Menu);
-    scaleMenuVector.push_back(scale175Menu);
-    scaleMenuVector.push_back(scale150Menu);
-    scaleMenuVector.push_back(scale125Menu);
     scaleMenuVector.push_back(scale100Menu);
     scaleMenuVector.push_back(scale75Menu);
     scaleMenuVector.push_back(scale50Menu);
@@ -593,32 +570,7 @@ void SimulatorWin::setupUI()
                             float scale = atof(tmp.c_str()) / 100.0f;
                             project.setFrameScale(scale);
 
-                            _instance->setZoom(scale);
-
-							_instance->relaunch();
-
-							/*
-                            // update scale menu state
-                            for (auto &it : scaleMenuVector)
-                            {
-                                it->setChecked(false);
-                            }
-                            menuItem->setChecked(true);
-
-                            // update window title
-                            _instance->updateWindowTitle();
-
-                            // update window size
-                            RECT rect;
-                            GetWindowRect(hwnd, &rect);
-                            MoveWindow(hwnd, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top + GetSystemMetrics(SM_CYMENU), FALSE);
-
-                            // fix: can not update window on some windows system
-                            ::SendMessage(hwnd, WM_MOVE, NULL, NULL);
-
-							_instance->relaunch();
-							*/
-
+							_instance->openProjectWithProjectConfig(project);
                         }
                         else if (data.find("VIEWSIZE_ITEM_MENU_") == 0) // begin with VIEWSIZE_ITEM_MENU_
                         {

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -170,7 +170,7 @@ SimulatorWin::SimulatorWin()
 
 SimulatorWin::~SimulatorWin()
 {
-	if (_writeDebugLogFile)
+    if (_writeDebugLogFile)
     {
         fclose(_writeDebugLogFile);
     }
@@ -178,13 +178,13 @@ SimulatorWin::~SimulatorWin()
 
 void SimulatorWin::quit()
 {
-	_app->end();
+    _app->end();
 }
 
 void SimulatorWin::relaunch()
 {
-	quit();
-	CC_SAFE_DELETE(_app);
+    quit();
+    CC_SAFE_DELETE(_app);
 
     _project.setWindowOffset(Vec2(getPositionX(), getPositionY()));
     openNewPlayerWithProjectConfig(_project);
@@ -241,7 +241,7 @@ void SimulatorWin::openNewPlayerWithProjectConfig(const ProjectConfig &config)
 
 void SimulatorWin::openProjectWithProjectConfig(const ProjectConfig &config)
 {
-	quit();
+    quit();
     openNewPlayerWithProjectConfig(config);
 }
 
@@ -359,7 +359,7 @@ int SimulatorWin::run()
 
     // check scale
     Size frameSize = _project.getFrameSize();
-	float frameScale = _project.getFrameScale();
+    float frameScale = _project.getFrameScale();
     if (_project.isRetinaDisplay())
     {
         frameSize.width *= screenScale;
@@ -441,7 +441,7 @@ int SimulatorWin::run()
     // init player services
     setupUI();
     BOOL isSuccess = DrawMenuBar(_hwnd);
-	CCLOG("DRAW AFTER setupUI, SUCCESS? %d:\n", isSuccess);
+    CCLOG("DRAW AFTER setupUI, SUCCESS? %d:\n", isSuccess);
 
     // prepare
     FileUtils::getInstance()->setPopupNotify(false);
@@ -452,8 +452,8 @@ int SimulatorWin::run()
     // update window title
     updateWindowTitle();
 
-	_app->start();
-	CC_SAFE_DELETE(_app);
+    _app->start();
+    CC_SAFE_DELETE(_app);
     return true;
 }
 
@@ -465,9 +465,6 @@ void SimulatorWin::setupUI()
 
     // FILE
     menuBar->addItem("FILE_MENU", tr("File"));
-    menuBar->addItem("OPEN_FILE_MENU", tr("Open File") + "...", "FILE_MENU");
-    menuBar->addItem("OPEN_PROJECT_MENU", tr("Open Project") + "...", "FILE_MENU");
-    menuBar->addItem("FILE_MENU_SEP1", "-", "FILE_MENU");
     menuBar->addItem("EXIT_MENU", tr("Exit"), "FILE_MENU");
 
     // VIEW
@@ -487,10 +484,10 @@ void SimulatorWin::setupUI()
         }
     }
 
-	// show FPs 
-	bool displayStats = true; // asume creator default show FPS
-	string fpsItemName = displayStats ? tr("Hide FPS") : tr("Show FPS");
-	menuBar->addItem("FPS_MENU", fpsItemName);
+    // show FPs 
+    bool displayStats = true; // asume creator default show FPS
+    string fpsItemName = displayStats ? tr("Hide FPS") : tr("Show FPS");
+    menuBar->addItem("FPS_MENU", fpsItemName);
 
     // About
     menuBar->addItem("HELP_MENU", tr("Help"));
@@ -510,7 +507,7 @@ void SimulatorWin::setupUI()
     auto scale25Menu = menuBar->addItem("VIEW_SCALE_MENU_25", tr("Zoom Out").append(" (25%)"), "VIEW_MENU");
     int frameScale = int(_project.getFrameScale() * 100);
 
-	if (frameScale == 100)
+    if (frameScale == 100)
     {
         scale100Menu->setChecked(true);
     }
@@ -541,8 +538,8 @@ void SimulatorWin::setupUI()
 
     HWND &hwnd = _hwnd;
     ProjectConfig &project = _project;
-	EventDispatcher::CustomEventListener listener = [this, &hwnd, &project, scaleMenuVector](const CustomEvent& event) {
-		auto menuEvent = dynamic_cast<const AppEvent&>(event);
+    EventDispatcher::CustomEventListener listener = [this, &hwnd, &project, scaleMenuVector](const CustomEvent& event) {
+        auto menuEvent = dynamic_cast<const AppEvent&>(event);
             rapidjson::Document dArgParse;
             dArgParse.Parse<0>(menuEvent.getDataString().c_str());
             if (dArgParse.HasMember("name"))
@@ -575,7 +572,7 @@ void SimulatorWin::setupUI()
                             float scale = atof(tmp.c_str()) / 100.0f;
                             project.setFrameScale(scale);
 
-							_instance->openProjectWithProjectConfig(project);
+                            _instance->openProjectWithProjectConfig(project);
                         }
                         else if (data.find("VIEWSIZE_ITEM_MENU_") == 0) // begin with VIEWSIZE_ITEM_MENU_
                         {
@@ -602,33 +599,21 @@ void SimulatorWin::setupUI()
                             project.changeFrameOrientationToLandscape();
                             _instance->openProjectWithProjectConfig(project);
                         }
-                        else if (data == "OPEN_FILE_MENU")
-                        {
-                            auto fileDialog = player::PlayerProtocol::getInstance()->getFileDialogService();
-                            stringstream extensions;
-                            extensions << "All Support File|config.json,*.csd,*csd;"
-                                << "Project Config File|config.json;"
-                                << "Cocos Studio File|*.csd;"
-                                << "Cocos Studio Binary File|*.csb";
-                            auto entry = fileDialog->openFile(tr("Choose File"), "", extensions.str());
-
-                            _instance->onOpenFile(entry);
-                        }
                         else if (data == "ABOUT_MENUITEM")
                         {
                             onHelpAbout();
                         }
-						else if (data == "FPS_MENU")
-						{
-							bool displayStats = !_app->isDisplayStats();
-							_app->setDisplayStats(displayStats);
-							menuItem->setTitle(displayStats ? tr("Hide FPS") : tr("Show FPS"));
-						}
+                        else if (data == "FPS_MENU")
+                        {
+                            bool displayStats = !_app->isDisplayStats();
+                            _app->setDisplayStats(displayStats);
+                            menuItem->setTitle(displayStats ? tr("Hide FPS") : tr("Show FPS"));
+                        }
                     }
                 }
             }
     };
-	EventDispatcher::addCustomEventListener(kAppEventName, listener);
+    EventDispatcher::addCustomEventListener(kAppEventName, listener);
 }
 
 void SimulatorWin::setZoom(float frameScale)
@@ -846,8 +831,8 @@ LRESULT CALLBACK SimulatorWin::windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 buf << "{\"data\":\"" << menuItem->getMenuId().c_str() << "\"";
                 buf << ",\"name\":" << "\"menuClicked\"" << "}";
                 event.setDataString(buf.str());
-				event.args[0].ptrVal = (void*)menuItem;
-				cocos2d::EventDispatcher::dispatchCustomEvent(event);
+                event.args[0].ptrVal = (void*)menuItem;
+                cocos2d::EventDispatcher::dispatchCustomEvent(event);
             }
 
             if (menuId == ID_HELP_ABOUT)

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -170,7 +170,6 @@ SimulatorWin::SimulatorWin()
 
 SimulatorWin::~SimulatorWin()
 {
-    CC_SAFE_DELETE(_app);
 	if (_writeDebugLogFile)
     {
         fclose(_writeDebugLogFile);
@@ -179,8 +178,7 @@ SimulatorWin::~SimulatorWin()
 
 void SimulatorWin::quit()
 {
-    delete _app;
-    _app = nullptr;
+	_app->end();
 }
 
 void SimulatorWin::relaunch()
@@ -422,11 +420,6 @@ int SimulatorWin::run()
     // path for looking Lang file, Studio Default images
     FileUtils::getInstance()->addSearchPath(getApplicationPath().c_str());
 
-    // auto director = Director::getInstance();
-    // director->setOpenGLView(glview);
-
-    // director->setAnimationInterval(1.0 / 60.0);
-
     // set window position
     if (_project.getProjectDir().length())
     {
@@ -452,7 +445,6 @@ int SimulatorWin::run()
     // prepare
     FileUtils::getInstance()->setPopupNotify(false);
     _project.dump();
-    // auto app = Application::getInstance();
 
     g_oldWindowProc = (WNDPROC)SetWindowLong(_hwnd, GWL_WNDPROC, (LONG)SimulatorWin::windowProc);
 
@@ -460,7 +452,7 @@ int SimulatorWin::run()
     updateWindowTitle();
 
 	_app->start();
-	//CC_SAFE_DELETE(_app);
+	CC_SAFE_DELETE(_app);
     return true;
 }
 
@@ -603,6 +595,9 @@ void SimulatorWin::setupUI()
 
                             _instance->setZoom(scale);
 
+							_instance->relaunch();
+
+							/*
                             // update scale menu state
                             for (auto &it : scaleMenuVector)
                             {
@@ -620,6 +615,10 @@ void SimulatorWin::setupUI()
 
                             // fix: can not update window on some windows system
                             ::SendMessage(hwnd, WM_MOVE, NULL, NULL);
+
+							_instance->relaunch();
+							*/
+
                         }
                         else if (data.find("VIEWSIZE_ITEM_MENU_") == 0) // begin with VIEWSIZE_ITEM_MENU_
                         {
@@ -672,7 +671,6 @@ void SimulatorWin::setupUI()
 void SimulatorWin::setZoom(float frameScale)
 {
     _project.setFrameScale(frameScale);
-	// relaunch or resize
 }
 
 void SimulatorWin::updateWindowTitle()

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -440,8 +440,7 @@ int SimulatorWin::run()
 
     // init player services
     setupUI();
-    BOOL isSuccess = DrawMenuBar(_hwnd);
-    CCLOG("DRAW AFTER setupUI, SUCCESS? %d:\n", isSuccess);
+    DrawMenuBar(_hwnd);
 
     // prepare
     FileUtils::getInstance()->setPopupNotify(false);

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -487,6 +487,11 @@ void SimulatorWin::setupUI()
         }
     }
 
+	// show FPs 
+	bool displayStats = true; // asume creator default show FPS
+	string fpsItemName = displayStats ? tr("Hide FPS") : tr("Show FPS");
+	menuBar->addItem("FPS_MENU", fpsItemName);
+
     // About
     menuBar->addItem("HELP_MENU", tr("Help"));
     menuBar->addItem("ABOUT_MENUITEM", tr("About"), "HELP_MENU");
@@ -536,7 +541,7 @@ void SimulatorWin::setupUI()
 
     HWND &hwnd = _hwnd;
     ProjectConfig &project = _project;
-	EventDispatcher::CustomEventListener listener = [&hwnd, &project, scaleMenuVector](const CustomEvent& event) {
+	EventDispatcher::CustomEventListener listener = [this, &hwnd, &project, scaleMenuVector](const CustomEvent& event) {
 		auto menuEvent = dynamic_cast<const AppEvent&>(event);
             rapidjson::Document dArgParse;
             dArgParse.Parse<0>(menuEvent.getDataString().c_str());
@@ -613,6 +618,12 @@ void SimulatorWin::setupUI()
                         {
                             onHelpAbout();
                         }
+						else if (data == "FPS_MENU")
+						{
+							bool displayStats = !_app->isDisplayStats();
+							_app->setDisplayStats(displayStats);
+							menuItem->setTitle(displayStats ? tr("Hide FPS") : tr("Show FPS"));
+						}
                     }
                 }
             }

--- a/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/SimulatorWin.cpp
@@ -171,7 +171,7 @@ SimulatorWin::SimulatorWin()
 SimulatorWin::~SimulatorWin()
 {
     CC_SAFE_DELETE(_app);
-	if (_writeDebugLogFile)
+    if (_writeDebugLogFile)
     {
         fclose(_writeDebugLogFile);
     }
@@ -408,24 +408,29 @@ int SimulatorWin::run()
 
     // create opengl view, and init app
     _app = new AppDelegate(title.str(), _project.getFrameScale() * frameSize.width, _project.getFrameScale() * frameSize.height);
+    _app->start();
+    CC_SAFE_DELETE(_app);
 
     // path for looking Lang file, Studio Default images
     FileUtils::getInstance()->addSearchPath(getApplicationPath().c_str());
-    
-    _hwnd = getWin32Window();
+
+    return true;
+    /*
+    auto glview = GLViewImpl::createWithRect(title.str(), frameRect, frameScale, true);
+    _hwnd = glview->getWin32Window();
     player::PlayerWin::createWithHwnd(_hwnd);
     DragAcceptFiles(_hwnd, TRUE);
-    // SendMessage(_hwnd, WM_SETICON, ICON_BIG, (LPARAM)icon);
-    // SendMessage(_hwnd, WM_SETICON, ICON_SMALL, (LPARAM)icon);
-    // FreeResource(icon);
+    //SendMessage(_hwnd, WM_SETICON, ICON_BIG, (LPARAM)icon);
+    //SendMessage(_hwnd, WM_SETICON, ICON_SMALL, (LPARAM)icon);
+    //FreeResource(icon);
 
     // path for looking Lang file, Studio Default images
     FileUtils::getInstance()->addSearchPath(getApplicationPath().c_str());
 
-    // auto director = Director::getInstance();
-    // director->setOpenGLView(glview);
+    auto director = Director::getInstance();
+    director->setOpenGLView(glview);
 
-    // director->setAnimationInterval(1.0 / 60.0);
+    director->setAnimationInterval(1.0 / 60.0);
 
     // set window position
     if (_project.getProjectDir().length())
@@ -446,26 +451,27 @@ int SimulatorWin::run()
 
     // init player services
     setupUI();
-    BOOL isSuccess = DrawMenuBar(_hwnd);
-	CCLOG("DRAW AFTER setupUI, SUCCESS? %d:\n", isSuccess);
+    DrawMenuBar(_hwnd);
 
     // prepare
     FileUtils::getInstance()->setPopupNotify(false);
     _project.dump();
-    // auto app = Application::getInstance();
+    auto app = Application::getInstance();
 
     g_oldWindowProc = (WNDPROC)SetWindowLong(_hwnd, GWL_WNDPROC, (LONG)SimulatorWin::windowProc);
 
     // update window title
     updateWindowTitle();
 
-	_app->start();
-	//CC_SAFE_DELETE(_app);
-    return true;
+    // startup message loop
+    int ret = app->run();
+    CC_SAFE_DELETE(_app);
+    return ret;
+    */
 }
 
 // services
-
+/*
 void SimulatorWin::setupUI()
 {
     auto menuBar = player::PlayerProtocol::getInstance()->getMenuService();
@@ -493,6 +499,11 @@ void SimulatorWin::setupUI()
             menuItem->setChecked(true);
         }
     }
+
+    // show FPs
+    bool displayStats = cocos2d::Director::getInstance()->isDisplayStats();
+    string fpsItemName = displayStats ? tr("Hide FPS") : tr("Show FPS");
+    menuBar->addItem("FPS_MENU", fpsItemName);
 
     // About
     menuBar->addItem("HELP_MENU", tr("Help"));
@@ -567,17 +578,20 @@ void SimulatorWin::setupUI()
 
     HWND &hwnd = _hwnd;
     ProjectConfig &project = _project;
-	EventDispatcher::CustomEventListener listener = [&hwnd, &project, scaleMenuVector](const CustomEvent& event) {
-		auto menuEvent = dynamic_cast<const AppEvent&>(event);
+    auto dispatcher = Director::getInstance()->getEventDispatcher();
+    dispatcher->addEventListenerWithFixedPriority(EventListenerCustom::create("APP.EVENT", [&project, &hwnd, scaleMenuVector](EventCustom* event){
+        auto menuEvent = dynamic_cast<AppEvent*>(event);
+        if (menuEvent)
+        {
             rapidjson::Document dArgParse;
-            dArgParse.Parse<0>(menuEvent.getDataString().c_str());
+            dArgParse.Parse<0>(menuEvent->getDataString().c_str());
             if (dArgParse.HasMember("name"))
             {
                 string strcmd = dArgParse["name"].GetString();
 
                 if (strcmd == "menuClicked")
                 {
-                    player::PlayerMenuItem *menuItem = static_cast<player::PlayerMenuItem*>(menuEvent.args[0].ptrVal);
+                    player::PlayerMenuItem *menuItem = static_cast<player::PlayerMenuItem*>(menuEvent->getUserData());
                     if (menuItem)
                     {
                         if (menuItem->isChecked())
@@ -658,21 +672,59 @@ void SimulatorWin::setupUI()
 
                             _instance->onOpenFile(entry);
                         }
+                        else if (data == "OPEN_PROJECT_MENU")
+                        {
+                            auto fileDialog = player::PlayerProtocol::getInstance()->getFileDialogService();
+                            auto path = fileDialog->openDirectory(tr("Choose Folder"), "");
+
+                            _instance->onOpenProjectFolder(path);
+                        }
                         else if (data == "ABOUT_MENUITEM")
                         {
                             onHelpAbout();
                         }
+                        else if (data == "FPS_MENU")
+                        {
+                           auto director = cocos2d::Director::getInstance();
+                           director->setDisplayStats(director->isDisplayStats() == false);
+                           menuItem->setTitle(director->isDisplayStats() ? tr("Hide FPS") : tr("Show FPS"));
+                        }
                     }
                 }
             }
-    };
-	EventDispatcher::addCustomEventListener(kAppEventName, listener);
+        }
+    }), 1);
+
+    AppDelegate *app = _app;
+    auto listener = EventListenerCustom::create(kAppEventDropName, [&project, app](EventCustom* event)
+    {
+        AppEvent *dropEvent = dynamic_cast<AppEvent*>(event);
+        if (dropEvent)
+        {
+            string dirPath = dropEvent->getDataString() + "/";
+            string configFilePath = dirPath + CONFIG_FILE;
+
+            if (FileUtils::getInstance()->isDirectoryExist(dirPath) &&
+                FileUtils::getInstance()->isFileExist(configFilePath))
+            {
+                // parse config.json
+                ConfigParser::getInstance()->readConfig(configFilePath);
+
+                project.setProjectDir(dirPath);
+                project.setScriptFile(ConfigParser::getInstance()->getEntryFile());
+                project.setWritablePath(dirPath);
+
+                RuntimeEngine::getInstance()->setProjectConfig(project);
+            }
+        }
+    });
+    dispatcher->addEventListenerWithFixedPriority(listener, 1);
 }
 
 void SimulatorWin::setZoom(float frameScale)
 {
     _project.setFrameScale(frameScale);
-	// relaunch or resize
+    cocos2d::Director::getInstance()->getOpenGLView()->setFrameZoomFactor(frameScale);
 }
 
 void SimulatorWin::updateWindowTitle()
@@ -693,7 +745,7 @@ void SimulatorWin::writeDebugLog(const char *log)
     fputc('\n', _writeDebugLogFile);
     fflush(_writeDebugLogFile);
 }
-
+*/
 void SimulatorWin::parseCocosProjectConfig(ProjectConfig &config)
 {
     // get project directory
@@ -861,7 +913,7 @@ std::string SimulatorWin::getApplicationPath()
 
     return workdir;
 }
-
+/*
 LRESULT CALLBACK SimulatorWin::windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     if (!_instance) return 0;
@@ -879,14 +931,14 @@ LRESULT CALLBACK SimulatorWin::windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             auto menuItem = menuService->getItemByCommandId(menuId);
             if (menuItem)
             {
-                AppEvent event(kAppEventName, APP_EVENT_MENU);
+                AppEvent event("APP.EVENT", APP_EVENT_MENU);
 
                 std::stringstream buf;
                 buf << "{\"data\":\"" << menuItem->getMenuId().c_str() << "\"";
                 buf << ",\"name\":" << "\"menuClicked\"" << "}";
                 event.setDataString(buf.str());
-				event.args[0].ptrVal = (void*)menuItem;
-				cocos2d::EventDispatcher::dispatchCustomEvent(event);
+                event.setUserData(menuItem);
+                Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
             }
 
             if (menuId == ID_HELP_ABOUT)
@@ -922,10 +974,33 @@ LRESULT CALLBACK SimulatorWin::windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         break;
     }
 
+    case WM_DROPFILES:
+    {
+        HDROP hDrop = (HDROP)wParam;
+
+        const int count = DragQueryFileW(hDrop, 0xffffffff, NULL, 0);
+
+        if (count > 0)
+        {
+            int fileIndex = 0;
+
+            const UINT length = DragQueryFileW(hDrop, fileIndex, NULL, 0);
+            WCHAR* buffer = (WCHAR*)calloc(length + 1, sizeof(WCHAR));
+
+            DragQueryFileW(hDrop, fileIndex, buffer, length + 1);
+            char *utf8 = SimulatorWin::convertTCharToUtf8(buffer);
+            std::string firstFile(utf8);
+            CC_SAFE_FREE(utf8);
+            DragFinish(hDrop);
+
+            _instance->onDrop(firstFile);
+        }
+    }   // WM_DROPFILES
+
     }
     return g_oldWindowProc(hWnd, uMsg, wParam, lParam);
 }
-
+*/
 void SimulatorWin::onOpenFile(const std::string &filePath)
 {
     string entry = filePath;
@@ -958,3 +1033,106 @@ void SimulatorWin::onOpenFile(const std::string &filePath)
     }
 }
 
+
+/*
+1. find @folderPath/config.json
+2. get project name from file: @folderPath/folderName.ccs
+3. find @folderPath/cocosstudio/MainScene.csd
+4. find @folderPath/cocosstudio/MainScene.csb
+*/
+
+/*
+void SimulatorWin::onOpenProjectFolder(const std::string &folderPath)
+{
+    string path = folderPath;
+    if (!path.empty())
+    {
+        replaceAll(path, "\\", "/");
+
+        auto fileUtils = FileUtils::getInstance();
+        bool foundProjectFile = false;
+        // 1. check config.json
+        auto configPath = path + "/" + CONFIG_FILE;
+        if (fileUtils->isFileExist(configPath))
+        {
+            ConfigParser::getInstance()->readConfig(configPath);
+            _project.setProjectDir(path);
+            _project.setScriptFile(ConfigParser::getInstance()->getEntryFile());
+            foundProjectFile = true;
+        }
+        // check ccs project
+        else
+        {
+            // 2.
+            if (path.at(path.size() - 1) == '/') path.erase(path.size() - 1);
+            ssize_t pos = path.find_last_of('/');
+            if (pos != std::string::npos)
+            {
+                auto folderName = path.substr(path.find_last_of('/'), path.size());
+                auto ccsFilePath = path + folderName + ".ccs";
+                if (fileUtils->isFileExist(ccsFilePath))
+                {
+                    auto fileContent = fileUtils->getStringFromFile(ccsFilePath);
+
+                    string matchString("<Project Name=\"");
+                    pos = fileContent.find(matchString);
+                    // get project file name
+                    if (pos != std::string::npos)
+                    {
+                        fileContent = fileContent.substr(pos + matchString.size(), fileContent.size());
+                        ssize_t posEnd = fileContent.find_first_of('"');
+                        auto projectFileName = path + "/cocosstudio/" + fileContent.substr(0, posEnd);
+                        _project.setProjectDir(path);
+                        _project.setScriptFile(projectFileName);
+                        foundProjectFile = true;
+                    }
+                }
+            }
+
+            if (!foundProjectFile)
+            {
+                auto csdFilePath = path + "/cocosstudio/MainScene.csd";
+                auto csbFilePath = path + "/cocosstudio/MainScene.csb";
+                // 3.
+                if (fileUtils->isFileExist(csdFilePath))
+                {
+                    _project.setProjectDir(path);
+                    _project.setScriptFile(csdFilePath);
+                    foundProjectFile = true;
+                }
+                // 4.
+                else if (fileUtils->isFileExist(csbFilePath))
+                {
+                    _project.setProjectDir(path);
+                    _project.setScriptFile(csbFilePath);
+                    foundProjectFile = true;
+                }
+            }
+        }
+
+        if (foundProjectFile)
+        {
+            openProjectWithProjectConfig(_project);
+        }
+        else
+        {
+            auto title = tr("Open Project") + tr("Error");
+            auto msgBox = player::PlayerProtocol::getInstance()->getMessageBoxService();
+            msgBox->showMessageBox(title, tr("Can not find project"));
+        }
+    }
+}
+
+void SimulatorWin::onDrop(const std::string &path)
+{
+    auto fileUtils = FileUtils::getInstance();
+    if (fileUtils->isDirectoryExist(path))
+    {
+        onOpenProjectFolder(path);
+    }
+    else if (fileUtils->isFileExist(path))
+    {
+        onOpenFile(path);
+    }
+}
+*/

--- a/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
+++ b/tools/simulator/frameworks/runtime-src/proj.win32/simulator.vcxproj
@@ -81,7 +81,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;_USRLUASTATIC;_USRLIBSIMSTATIC;_WINSOCKAPI_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;STRICT;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS_DEBUG;COCOS2D_DEBUG=1;GLFW_EXPOSE_NATIVE_WIN32;GLFW_EXPOSE_NATIVE_WGL;_USRLUASTATIC;_USRLIBSIMSTATIC;_WINSOCKAPI_;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4267;4251;4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>

--- a/tools/simulator/libsimulator/lib/AppEvent.h
+++ b/tools/simulator/libsimulator/lib/AppEvent.h
@@ -50,7 +50,6 @@ enum
     APP_EVENT_DROP = 2
 };
 
-#define kAppEventDropName "APP.EVENT.DROP"
 #define kAppEventName     "APP.EVENT"
 
 class CC_LIBSIM_DLL AppEvent : public cocos2d::CustomEvent

--- a/tools/simulator/libsimulator/lib/platform/mac/PlayerMenuServiceMac.mm
+++ b/tools/simulator/libsimulator/lib/platform/mac/PlayerMenuServiceMac.mm
@@ -115,8 +115,8 @@ static bool __G_IS_MENUBAR_ENABLED__ = true;    // WTF
     buf << "{\"data\":\"" << self.macMenuItem->getMenuId().c_str() << "\"";
     buf << ",\"name\":" << "\"menuClicked\"" << "}";
     event.setDataString(buf.str());
-//    event.setUserData((void*)self.macMenuItem);
-//    cocos2d::Director::getInstance()->getEventDispatcher()->dispatchEvent(&event);
+    event.args[0].ptrVal = (void*)self.macMenuItem;
+    cocos2d::EventDispatcher::dispatchCustomEvent(event);
 }
 
 -(BOOL) validateMenuItem:(NSMenuItem *)menuItem


### PR DESCRIPTION
为模拟器恢复 view 菜单，重新支持在菜单栏动态调整界面尺寸

> 时间原因，2.0 发布前，模拟器适配没来得及恢复这个功能