### PR TITLE
beauty the "done" confirm button of EditBox

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -102,6 +102,7 @@ public class Cocos2dxEditBox {
         public void show(String defaultValue, int maxLength, boolean isMultiline, boolean confirmHold, String confirmType, String inputType) {
             mIsMultiLine = isMultiline;
             this.setText(defaultValue);
+            this.setSelection(defaultValue.length());
             this.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength) });
             this.setConfirmType(confirmType);
             this.setInputType(inputType, mIsMultiLine);
@@ -238,7 +239,8 @@ public class Cocos2dxEditBox {
         mButton.setVisibility(View.INVISIBLE);
         RelativeLayout.LayoutParams buttonParams = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         buttonParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
-        mButton.setBackgroundColor(Color.GREEN);
+        mButton.setTextColor(Color.WHITE);
+        mButton.setBackgroundColor(Color.parseColor("#1ea014"));
         layout.addView(mButton, buttonParams);
 
         mButton.setOnClickListener(new View.OnClickListener() {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -43,6 +43,10 @@ import android.widget.Button;
 import android.view.inputmethod.InputMethodManager;
 
 public class Cocos2dxEditBox {
+
+    // a color of dark green, was used for confirm button background
+    private static final int DARK_GREEN = Color.parseColor("#1fa014");
+
     private static Cocos2dxEditBox sThis = null;
     private Cocos2dxEditText mEditText = null;
     private Button mButton = null;
@@ -246,7 +250,7 @@ public class Cocos2dxEditBox {
         RelativeLayout.LayoutParams buttonParams = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         buttonParams.addRule(RelativeLayout.ALIGN_PARENT_RIGHT);
         mButton.setTextColor(Color.WHITE);
-        mButton.setBackgroundColor(Color.parseColor("#1ea014"));
+        mButton.setBackgroundColor(DARK_GREEN);
         layout.addView(mButton, buttonParams);
 
         mButton.setOnClickListener(new View.OnClickListener() {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -272,9 +272,9 @@ public class Cocos2dxEditBox {
 
     private void show(String defaultValue, int maxLength, boolean isMultiline, boolean confirmHold, String confirmType, String inputType) {
         mConfirmHold = confirmHold;
+        mButton.setVisibility(View.VISIBLE);
         mEditText.show(defaultValue, maxLength, isMultiline, confirmHold, confirmType, inputType);
         mButton.setText(mButtonName);
-        mButton.setVisibility(View.VISIBLE);
         mActivity.getGLSurfaceView().setStopHandleTouchAndKeyEvents(true);
         this.openKeyboard();
     }

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -46,6 +46,7 @@ public class Cocos2dxEditBox {
     private static Cocos2dxEditBox sThis = null;
     private Cocos2dxEditText mEditText = null;
     private Button mButton = null;
+    private String mButtonName = null;
     private boolean mConfirmHold = true;
     private Cocos2dxActivity mActivity = null;
 
@@ -124,17 +125,22 @@ public class Cocos2dxEditBox {
          **************************************************************************************/
 
         private void setConfirmType(final String confirmType) {
-            if (confirmType.contentEquals("done"))
+            if (confirmType.contentEquals("done")) {
                 this.setImeOptions(EditorInfo.IME_ACTION_DONE | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
-            else if (confirmType.contentEquals("next"))
+                mButtonName = mActivity.getResources().getString(R.string.editbox_confirm_type_done);
+            } else if (confirmType.contentEquals("next")) {
                 this.setImeOptions(EditorInfo.IME_ACTION_NEXT | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
-            else if (confirmType.contentEquals("search"))
+                mButtonName = mActivity.getResources().getString(R.string.editbox_confirm_type_next);
+            } else if (confirmType.contentEquals("search")) {
                 this.setImeOptions(EditorInfo.IME_ACTION_SEARCH | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
-            else if (confirmType.contentEquals("go"))
+                mButtonName = mActivity.getResources().getString(R.string.editbox_confirm_type_search);
+            } else if (confirmType.contentEquals("go")) {
                 this.setImeOptions(EditorInfo.IME_ACTION_GO | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
-            else if (confirmType.contentEquals("send"))
+                mButtonName = mActivity.getResources().getString(R.string.editbox_confirm_type_go);
+            } else if (confirmType.contentEquals("send")) {
                 this.setImeOptions(EditorInfo.IME_ACTION_SEND | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
-            else
+                mButtonName = mActivity.getResources().getString(R.string.editbox_confirm_type_send);
+            } else
                 Log.e(TAG, "unknown confirm type " + confirmType);
         }
 
@@ -266,9 +272,9 @@ public class Cocos2dxEditBox {
 
     private void show(String defaultValue, int maxLength, boolean isMultiline, boolean confirmHold, String confirmType, String inputType) {
         mConfirmHold = confirmHold;
-        mButton.setText(confirmType);
-        mButton.setVisibility(View.VISIBLE);
         mEditText.show(defaultValue, maxLength, isMultiline, confirmHold, confirmType, inputType);
+        mButton.setText(mButtonName);
+        mButton.setVisibility(View.VISIBLE);
         mActivity.getGLSurfaceView().setStopHandleTouchAndKeyEvents(true);
         this.openKeyboard();
     }

--- a/cocos/platform/android/libcocos2dx/src/main/res/values-zh-rCN/strings.xml
+++ b/cocos/platform/android/libcocos2dx/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--EditBox Confirm Button Name-->
+    <string name="editbox_confirm_type_done" translatable="false">完成</string>
+    <string name="editbox_confirm_type_next" translatable="false">下一个</string>
+    <string name="editbox_confirm_type_search" translatable="false">搜索</string>
+    <string name="editbox_confirm_type_go" translatable="false">前往</string>
+    <string name="editbox_confirm_type_send" translatable="false">发送</string>
+</resources>

--- a/cocos/platform/android/libcocos2dx/src/main/res/values/strings.xml
+++ b/cocos/platform/android/libcocos2dx/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--EditBox Confirm Button Name-->
+    <string name="editbox_confirm_type_done" translatable="false">Done</string>
+    <string name="editbox_confirm_type_next" translatable="false">Next</string>
+    <string name="editbox_confirm_type_search" translatable="false">Search</string>
+    <string name="editbox_confirm_type_go" translatable="false">Go</string>
+    <string name="editbox_confirm_type_send" translatable="false">Send</string>
+</resources>


### PR DESCRIPTION
Re: https://github.com/cocos-creator/cocos2d-x-lite/issues/1463

美化 “done” 输入确认键

1. 使用深绿色作为背景，白色作为文字颜色
1. 根据系统语言（中文），显示对应语言的文字（完成）

--
还没最终完成，暂时不需要合并