### PR TITLE
improve text texture RGB value on win32

### DIFF
--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -554,7 +554,7 @@ private:
                         g = _fillStyle.g * dirtyValue;
                         b = _fillStyle.b * dirtyValue;
                         COLORREF textColor = (b << 16 | g << 8 | r) & 0x00ffffff;
-                        clr = ((BYTE)(0xff * alpha) << 24) | textColor;
+                        clr = ((BYTE)(dirtyValue * alpha) << 24) | textColor;
                     }
                     ++pPixel;
                 }

--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -535,10 +535,8 @@ private:
             GetDIBits(_DC, _bmp, 0, _bufferHeight, dataBuf,
                       (LPBITMAPINFO)&bi, DIB_RGB_COLORS);
 
-            uint8_t r = _fillStyle.r * 255.0f;
-            uint8_t g = _fillStyle.g * 255.0f;
-            uint8_t b = _fillStyle.b * 255.0f;
-            COLORREF textColor = (b << 16 | g << 8 | r) & 0x00ffffff;
+
+            uint8_t r, g, b;
             float alpha = 1.0f;
             COLORREF * pPixel = nullptr;
             for (int y = 0; y < _bufferHeight; ++y)
@@ -551,7 +549,12 @@ private:
                     // "dirtyValue > 0" means pixel was covered when drawing text
                     if (dirtyValue > 0)
                     {
-                        clr = ((BYTE)(dirtyValue * alpha) << 24) | textColor;
+                        // r = _fillStyle.r * 255 * (dirtyValue / 255);
+                        r = _fillStyle.r * dirtyValue;
+                        g = _fillStyle.g * dirtyValue;
+                        b = _fillStyle.b * dirtyValue;
+                        COLORREF textColor = (b << 16 | g << 8 | r) & 0x00ffffff;
+                        clr = ((BYTE)(0xff * alpha) << 24) | textColor;
                     }
                     ++pPixel;
                 }


### PR DESCRIPTION
上半部分是改动前效果，下半部分是改动后效果

![win32-text](https://user-images.githubusercontent.com/26329291/44517897-6cf81580-a6fb-11e8-8fe4-4f7eb1f57877.png)

---
![text-compare-2](https://user-images.githubusercontent.com/26329291/44518240-57372000-a6fc-11e8-8f8a-f125d3243652.png)
