### PR TITLE
fix random red text error when draw multi line text on win32

### DIFF
--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -545,7 +545,7 @@ private:
                 for (int x = 0; x < _bufferWidth; ++x)
                 {
                     COLORREF& clr = *pPixel;
-                    uint8_t dirtyValue = GetGValue(clr);
+                    uint8_t dirtyValue = GetRValue(clr);
                     // "dirtyValue > 0" means pixel was covered when drawing text
                     if (dirtyValue > 0)
                     {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/8253

修复 win32 平台在渲染多行文本时，非第一行的文本可能会显示为红色的问题