### PR TITLE
add "getSafeAreaEdge" interface to get SafeArea edge insets

### DIFF
--- a/cocos/platform/CCDevice.h
+++ b/cocos/platform/CCDevice.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 
 #include "base/ccMacros.h"
 #include "base/CCData.h"
-#include "renderer/Types.h"
+#include "math/Vec4.h"
 
 NS_CC_BEGIN
 
@@ -130,7 +130,11 @@ public:
 
     static NetworkType getNetworkType();
 
-    static renderer::Rect getSafeAreaRect();
+    /*
+     * Gets the SafeArea edge.
+     * Vec4(x, y, z, w) means Edge(top, left, bottom, right)
+     */
+    static cocos2d::Vec4 getSafeAreaEdge();
 
 private:
 	Device();

--- a/cocos/platform/CCDevice.h
+++ b/cocos/platform/CCDevice.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 
 #include "base/ccMacros.h"
 #include "base/CCData.h"
+#include "math/CCMath.h"
 
 NS_CC_BEGIN
 
@@ -128,6 +129,9 @@ public:
     };
 
     static NetworkType getNetworkType();
+
+    static Vec4 getSafeAreaRect();
+
 private:
 	Device();
 	CC_DISALLOW_COPY_AND_ASSIGN(Device);

--- a/cocos/platform/CCDevice.h
+++ b/cocos/platform/CCDevice.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
 
 #include "base/ccMacros.h"
 #include "base/CCData.h"
-#include "math/CCMath.h"
+#include "renderer/Types.h"
 
 NS_CC_BEGIN
 
@@ -130,7 +130,7 @@ public:
 
     static NetworkType getNetworkType();
 
-    static Vec4 getSafeAreaRect();
+    static renderer::Rect getSafeAreaRect();
 
 private:
 	Device();

--- a/cocos/platform/android/CCDevice-android.cpp
+++ b/cocos/platform/android/CCDevice-android.cpp
@@ -119,6 +119,12 @@ Device::NetworkType Device::getNetworkType()
     return (Device::NetworkType)JniHelper::callStaticIntMethod(JCLS_HELPER, "getNetworkType");
 }
 
+cocos2d::Vec4 Device::getSafeAreaEdge()
+{
+    // no SafeArea concept on android, return ZERO Vec4.
+    return cocos2d::Vec4();
+}
+
 NS_CC_END
 
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID

--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -298,7 +298,7 @@ Device::NetworkType Device::getNetworkType()
     return ret;
 }
 
-Vec4 Device::getSafeAreaRect()
+renderer::Rect Device::getSafeAreaRect()
 {
     UIView* screenView = (UIView*)Application::getInstance()->getView();
     CGSize screenSize = screenView.frame.size;
@@ -339,12 +339,12 @@ Vec4 Device::getSafeAreaRect()
         //        leftBottom = Director::getInstance()->convertToGL(leftBottom);
         //        rightTop = Director::getInstance()->convertToGL(rightTop);
 
-        return Vec4(leftBottom.x, leftBottom.y, rightTop.x - leftBottom.x, rightTop.y - leftBottom.y);
+        return renderer::Rect(leftBottom.x, leftBottom.y, rightTop.x - leftBottom.x, rightTop.y - leftBottom.y);
     }
 #endif
 
     // If running on iOS devices lower than 11.0, return visiable rect instead.
     //    return GLView::getSafeAreaRect();
-    return Vec4(0.0, 0.0, screenSize.width, screenSize.height);
+    return renderer::Rect(0.0, 0.0, screenSize.width, screenSize.height);
 }
 NS_CC_END

--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -298,10 +298,9 @@ Device::NetworkType Device::getNetworkType()
     return ret;
 }
 
-renderer::Rect Device::getSafeAreaRect()
+cocos2d::Vec4 Device::getSafeAreaEdge()
 {
     UIView* screenView = (UIView*)Application::getInstance()->getView();
-    CGSize screenSize = screenView.frame.size;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
     float version = [[UIDevice currentDevice].systemVersion floatValue];
@@ -309,42 +308,21 @@ renderer::Rect Device::getSafeAreaRect()
     {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
-        UIEdgeInsets safeAreaInsets = screenView.safeAreaInsets;
+        UIEdgeInsets safeAreaEdge = screenView.safeAreaInsets;
 #pragma clang diagnostic pop
 
         // Multiply contentScaleFactor since safeAreaInsets return points.
-        safeAreaInsets.left *= screenView.contentScaleFactor;
-        safeAreaInsets.right *= screenView.contentScaleFactor;
-        safeAreaInsets.top *= screenView.contentScaleFactor;
-        safeAreaInsets.bottom *= screenView.contentScaleFactor;
+        uint8_t scale = screenView.contentScaleFactor;
+        safeAreaEdge.left *= scale;
+        safeAreaEdge.right *= scale;
+        safeAreaEdge.top *= scale;
+        safeAreaEdge.bottom *= scale;
 
-        // Get leftBottom and rightTop point in UI coordinates
-        cocos2d::Vec2 leftBottom = Vec2(safeAreaInsets.left, screenSize.height - safeAreaInsets.bottom);
-        cocos2d::Vec2 rightTop = Vec2(screenSize.width - safeAreaInsets.right, safeAreaInsets.top);
-
-        // CHECK THIS
-        //        // Convert a point from UI coordinates to which in design resolution coordinate.
-        //        leftBottom.x = (leftBottom.x - _viewPortRect.origin.x) / _scaleX,
-        //        leftBottom.y = (leftBottom.y - _viewPortRect.origin.y) / _scaleY;
-        //        rightTop.x = (rightTop.x - _viewPortRect.origin.x) / _scaleX,
-        //        rightTop.y = (rightTop.y - _viewPortRect.origin.y) / _scaleY;
-        //
-        //        // Adjust points to make them inside design resolution
-        //        leftBottom.x = MAX(leftBottom.x, 0);
-        //        leftBottom.y = MIN(leftBottom.y, _designResolutionSize.height);
-        //        rightTop.x = MIN(rightTop.x, _designResolutionSize.width);
-        //        rightTop.y = MAX(rightTop.y, 0);
-        //
-        //        // Convert to GL coordinates
-        //        leftBottom = Director::getInstance()->convertToGL(leftBottom);
-        //        rightTop = Director::getInstance()->convertToGL(rightTop);
-
-        return renderer::Rect(leftBottom.x, leftBottom.y, rightTop.x - leftBottom.x, rightTop.y - leftBottom.y);
+        return cocos2d::Vec4(safeAreaEdge.top, safeAreaEdge.left, safeAreaEdge.bottom, safeAreaEdge.right);
     }
 #endif
 
-    // If running on iOS devices lower than 11.0, return visiable rect instead.
-    //    return GLView::getSafeAreaRect();
-    return renderer::Rect(0.0, 0.0, screenSize.width, screenSize.height);
+    // If running on iOS devices lower than 11.0, return ZERO Vec4.
+    return cocos2d::Vec4();
 }
 NS_CC_END

--- a/cocos/platform/mac/CCDevice-mac.mm
+++ b/cocos/platform/mac/CCDevice-mac.mm
@@ -117,6 +117,12 @@ Device::NetworkType Device::getNetworkType()
     return ret;
 }
 
+cocos2d::Vec4 Device::getSafeAreaEdge()
+{
+    // no SafeArea concept on mac, return ZERO Vec4.
+    return cocos2d::Vec4();
+}
+
 NS_CC_END
 
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_MAC

--- a/cocos/platform/win32/CCDevice-win32.cpp
+++ b/cocos/platform/win32/CCDevice-win32.cpp
@@ -90,6 +90,12 @@ Device::NetworkType Device::getNetworkType()
     return Device::NetworkType::LAN;
 }
 
+cocos2d::Vec4 Device::getSafeAreaEdge()
+{
+    // no SafeArea concept on win32, return ZERO Vec4.
+    return cocos2d::Vec4();
+}
+
 NS_CC_END
 
 #endif // CC_TARGET_PLATFORM == CC_PLATFORM_WIN32

--- a/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
+++ b/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
@@ -598,13 +598,13 @@ getDPI : function (
 },
 
 /**
- * @method getSafeAreaRect
- * @return {cc.renderer::Rect}
+ * @method getSafeAreaEdge
+ * @return {vec4_object}
  */
-getSafeAreaRect : function (
+getSafeAreaEdge : function (
 )
 {
-    return cc.renderer::Rect;
+    return cc.Vec4;
 },
 
 /**

--- a/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
+++ b/cocos/scripting/js-bindings/auto/api/jsb_cocos2dx_auto_api.js
@@ -598,6 +598,16 @@ getDPI : function (
 },
 
 /**
+ * @method getSafeAreaRect
+ * @return {cc.renderer::Rect}
+ */
+getSafeAreaRect : function (
+)
+{
+    return cc.renderer::Rect;
+},
+
+/**
  * @method getDeviceModel
  * @return {String}
  */

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
@@ -1125,6 +1125,22 @@ static bool js_engine_Device_getDPI(se::State& s)
 }
 SE_BIND_FUNC(js_engine_Device_getDPI)
 
+static bool js_engine_Device_getSafeAreaRect(se::State& s)
+{
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        cocos2d::renderer::Rect result = cocos2d::Device::getSafeAreaRect();
+        ok &= Rect_to_seval(result, &s.rval());
+        SE_PRECONDITION2(ok, false, "js_engine_Device_getSafeAreaRect : Error processing arguments");
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_engine_Device_getSafeAreaRect)
+
 static bool js_engine_Device_getDeviceModel(se::State& s)
 {
     const auto& args = s.args();
@@ -1156,6 +1172,7 @@ bool js_register_engine_Device(se::Object* obj)
     cls->defineStaticFunction("getBatteryLevel", _SE(js_engine_Device_getBatteryLevel));
     cls->defineStaticFunction("getDeviceRotation", _SE(js_engine_Device_getDeviceRotation));
     cls->defineStaticFunction("getDPI", _SE(js_engine_Device_getDPI));
+    cls->defineStaticFunction("getSafeAreaRect", _SE(js_engine_Device_getSafeAreaRect));
     cls->defineStaticFunction("getDeviceModel", _SE(js_engine_Device_getDeviceModel));
     cls->install();
     JSBClassType::registerClass<cocos2d::Device>(cls);

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
@@ -1125,21 +1125,21 @@ static bool js_engine_Device_getDPI(se::State& s)
 }
 SE_BIND_FUNC(js_engine_Device_getDPI)
 
-static bool js_engine_Device_getSafeAreaRect(se::State& s)
+static bool js_engine_Device_getSafeAreaEdge(se::State& s)
 {
     const auto& args = s.args();
     size_t argc = args.size();
     CC_UNUSED bool ok = true;
     if (argc == 0) {
-        cocos2d::renderer::Rect result = cocos2d::Device::getSafeAreaRect();
-        ok &= Rect_to_seval(result, &s.rval());
-        SE_PRECONDITION2(ok, false, "js_engine_Device_getSafeAreaRect : Error processing arguments");
+        cocos2d::Vec4 result = cocos2d::Device::getSafeAreaEdge();
+        ok &= Vec4_to_seval((cocos2d::Vec4)result, &s.rval());
+        SE_PRECONDITION2(ok, false, "js_engine_Device_getSafeAreaEdge : Error processing arguments");
         return true;
     }
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
     return false;
 }
-SE_BIND_FUNC(js_engine_Device_getSafeAreaRect)
+SE_BIND_FUNC(js_engine_Device_getSafeAreaEdge)
 
 static bool js_engine_Device_getDeviceModel(se::State& s)
 {
@@ -1172,7 +1172,7 @@ bool js_register_engine_Device(se::Object* obj)
     cls->defineStaticFunction("getBatteryLevel", _SE(js_engine_Device_getBatteryLevel));
     cls->defineStaticFunction("getDeviceRotation", _SE(js_engine_Device_getDeviceRotation));
     cls->defineStaticFunction("getDPI", _SE(js_engine_Device_getDPI));
-    cls->defineStaticFunction("getSafeAreaRect", _SE(js_engine_Device_getSafeAreaRect));
+    cls->defineStaticFunction("getSafeAreaEdge", _SE(js_engine_Device_getSafeAreaEdge));
     cls->defineStaticFunction("getDeviceModel", _SE(js_engine_Device_getDeviceModel));
     cls->install();
     JSBClassType::registerClass<cocos2d::Device>(cls);

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.cpp
@@ -1132,7 +1132,7 @@ static bool js_engine_Device_getSafeAreaEdge(se::State& s)
     CC_UNUSED bool ok = true;
     if (argc == 0) {
         cocos2d::Vec4 result = cocos2d::Device::getSafeAreaEdge();
-        ok &= Vec4_to_seval((cocos2d::Vec4)result, &s.rval());
+        ok &= Vec4_to_seval(result, &s.rval());
         SE_PRECONDITION2(ok, false, "js_engine_Device_getSafeAreaEdge : Error processing arguments");
         return true;
     }

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp
@@ -65,7 +65,7 @@ SE_DECLARE_FUNC(js_engine_Device_setKeepScreenOn);
 SE_DECLARE_FUNC(js_engine_Device_getBatteryLevel);
 SE_DECLARE_FUNC(js_engine_Device_getDeviceRotation);
 SE_DECLARE_FUNC(js_engine_Device_getDPI);
-SE_DECLARE_FUNC(js_engine_Device_getSafeAreaRect);
+SE_DECLARE_FUNC(js_engine_Device_getSafeAreaEdge);
 SE_DECLARE_FUNC(js_engine_Device_getDeviceModel);
 
 extern se::Object* __jsb_cocos2d_SAXParser_proto;

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_auto.hpp
@@ -65,6 +65,7 @@ SE_DECLARE_FUNC(js_engine_Device_setKeepScreenOn);
 SE_DECLARE_FUNC(js_engine_Device_getBatteryLevel);
 SE_DECLARE_FUNC(js_engine_Device_getDeviceRotation);
 SE_DECLARE_FUNC(js_engine_Device_getDPI);
+SE_DECLARE_FUNC(js_engine_Device_getSafeAreaRect);
 SE_DECLARE_FUNC(js_engine_Device_getDeviceModel);
 
 extern se::Object* __jsb_cocos2d_SAXParser_proto;


### PR DESCRIPTION
增加接口 `jsb.Device.getSafeAreaEdge()` 获取 SafeArea 的边界信息（通过屏幕分辨率度量的边界信息）

> 参考 creator 1.x 的实现 https://github.com/cocos-creator/cocos2d-x-lite/pull/1008 ，主要区别是 “坐标转换” 从 native 移动到了 adapter