### PR TITLE
fix : can not listen to onKeyUp event for Android

### DIFF
--- a/cocos/platform/android/jni/JniImp.cpp
+++ b/cocos/platform/android/jni/JniImp.cpp
@@ -429,7 +429,7 @@ extern "C"
         }
         KeyboardEvent event;
         event.key = keyInWeb;
-        event.action = KeyboardEvent::Action::PRESS;
+        event.action = isPressed ? KeyboardEvent::Action::PRESS : KeyboardEvent::Action::RELEASE;
         EventDispatcher::dispatchKeyboardEvent(event);
 
         return JNI_TRUE;


### PR DESCRIPTION
这里 event.action 强制写死成了 PRESS 是有问题的。根据之后逻辑：
```C++
    const char* eventName = nullptr;
    switch (keyboardEvent.action) {
        case KeyboardEvent::Action::PRESS:
        case KeyboardEvent::Action::REPEAT:
            eventName = "onKeyDown";
            break;
        case KeyboardEvent::Action::RELEASE:
            eventName = "onKeyUp";
            break;
        default:
            assert(false);
            break;
    }
```
 eventName 就一直是onKeyDown，无法监听onKeyUp。