### PR TITLE
 add v8 optional on macOS

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -235,6 +235,15 @@
 		403ACADB20CE4EB000BB433D /* jsb_module_register.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 403ACAD920CE4EB000BB433D /* jsb_module_register.hpp */; };
 		403ACADC20CE542600BB433D /* jsb_module_register.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 403ACAD820CE4EB000BB433D /* jsb_module_register.cpp */; };
 		403ACADD20CE542900BB433D /* jsb_module_register.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 403ACAD920CE4EB000BB433D /* jsb_module_register.hpp */; };
+		403EE7B12159E8F300B8FD62 /* libv8_base.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7AB2159E8F200B8FD62 /* libv8_base.a */; };
+		403EE7B22159E8F300B8FD62 /* libv8_libplatform.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7AC2159E8F200B8FD62 /* libv8_libplatform.a */; };
+		403EE7B32159E8F300B8FD62 /* libv8_nosnapshot.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7AD2159E8F200B8FD62 /* libv8_nosnapshot.a */; };
+		403EE7B42159E8F300B8FD62 /* libinspector.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7AE2159E8F200B8FD62 /* libinspector.a */; };
+		403EE7B52159E8F300B8FD62 /* libv8_libbase.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7AF2159E8F300B8FD62 /* libv8_libbase.a */; };
+		403EE7B62159E8F300B8FD62 /* libv8_libsampler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7B02159E8F300B8FD62 /* libv8_libsampler.a */; };
+		403EE7B8215A051E00B8FD62 /* libuv_a.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7B7215A051E00B8FD62 /* libuv_a.a */; };
+		403EE7BB215A070B00B8FD62 /* libv8_builtins_setup.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7B9215A070B00B8FD62 /* libv8_builtins_setup.a */; };
+		403EE7BC215A070B00B8FD62 /* libv8_builtins_generators.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 403EE7BA215A070B00B8FD62 /* libv8_builtins_generators.a */; };
 		4043D65E20D2132E00C55611 /* CCGLView-desktop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4043D65C20D2132E00C55611 /* CCGLView-desktop.cpp */; };
 		4043D65F20D2132E00C55611 /* CCGLView-desktop.h in Headers */ = {isa = PBXBuildFile; fileRef = 4043D65D20D2132E00C55611 /* CCGLView-desktop.h */; };
 		40CEAEB120CFC86D007A3281 /* CustomEventTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 40CEAEB020CFC86D007A3281 /* CustomEventTypes.h */; };
@@ -1145,6 +1154,15 @@
 		4037F5CB2108751E001C205C /* CCAsyncTaskPool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CCAsyncTaskPool.cpp; sourceTree = "<group>"; };
 		403ACAD820CE4EB000BB433D /* jsb_module_register.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = jsb_module_register.cpp; sourceTree = "<group>"; };
 		403ACAD920CE4EB000BB433D /* jsb_module_register.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = jsb_module_register.hpp; sourceTree = "<group>"; };
+		403EE7AB2159E8F200B8FD62 /* libv8_base.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libv8_base.a; path = "../../../cocos2d-x-lite-external/mac/libs/libv8_base.a"; sourceTree = "<group>"; };
+		403EE7AC2159E8F200B8FD62 /* libv8_libplatform.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libv8_libplatform.a; path = "../../../cocos2d-x-lite-external/mac/libs/libv8_libplatform.a"; sourceTree = "<group>"; };
+		403EE7AD2159E8F200B8FD62 /* libv8_nosnapshot.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libv8_nosnapshot.a; path = "../../../cocos2d-x-lite-external/mac/libs/libv8_nosnapshot.a"; sourceTree = "<group>"; };
+		403EE7AE2159E8F200B8FD62 /* libinspector.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libinspector.a; path = "../../../cocos2d-x-lite-external/mac/libs/libinspector.a"; sourceTree = "<group>"; };
+		403EE7AF2159E8F300B8FD62 /* libv8_libbase.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libv8_libbase.a; path = "../../../cocos2d-x-lite-external/mac/libs/libv8_libbase.a"; sourceTree = "<group>"; };
+		403EE7B02159E8F300B8FD62 /* libv8_libsampler.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libv8_libsampler.a; path = "../../../cocos2d-x-lite-external/mac/libs/libv8_libsampler.a"; sourceTree = "<group>"; };
+		403EE7B7215A051E00B8FD62 /* libuv_a.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libuv_a.a; path = "../../../cocos2d-x-lite-external/mac/libs/libuv_a.a"; sourceTree = "<group>"; };
+		403EE7B9215A070B00B8FD62 /* libv8_builtins_setup.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libv8_builtins_setup.a; path = "../../../cocos2d-x-lite-external/mac/libs/libv8_builtins_setup.a"; sourceTree = "<group>"; };
+		403EE7BA215A070B00B8FD62 /* libv8_builtins_generators.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libv8_builtins_generators.a; path = "../../../cocos2d-x-lite-external/mac/libs/libv8_builtins_generators.a"; sourceTree = "<group>"; };
 		4043D65C20D2132E00C55611 /* CCGLView-desktop.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "CCGLView-desktop.cpp"; sourceTree = "<group>"; };
 		4043D65D20D2132E00C55611 /* CCGLView-desktop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CCGLView-desktop.h"; sourceTree = "<group>"; };
 		40CEAEB020CFC86D007A3281 /* CustomEventTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomEventTypes.h; sourceTree = "<group>"; };
@@ -1582,6 +1600,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				403EE7BB215A070B00B8FD62 /* libv8_builtins_setup.a in Frameworks */,
+				403EE7BC215A070B00B8FD62 /* libv8_builtins_generators.a in Frameworks */,
+				403EE7B8215A051E00B8FD62 /* libuv_a.a in Frameworks */,
+				403EE7B12159E8F300B8FD62 /* libv8_base.a in Frameworks */,
+				403EE7B22159E8F300B8FD62 /* libv8_libplatform.a in Frameworks */,
+				403EE7B32159E8F300B8FD62 /* libv8_nosnapshot.a in Frameworks */,
+				403EE7B42159E8F300B8FD62 /* libinspector.a in Frameworks */,
+				403EE7B52159E8F300B8FD62 /* libv8_libbase.a in Frameworks */,
+				403EE7B62159E8F300B8FD62 /* libv8_libsampler.a in Frameworks */,
 				40CEAEBA20CFDE19007A3281 /* SystemConfiguration.framework in Frameworks */,
 				A679D0DA1C71D93200620A6C /* libcrypto.a in Frameworks */,
 				A679D0D91C71D90A00620A6C /* libssl.a in Frameworks */,
@@ -1657,6 +1684,15 @@
 		1551A341158F2AB200E66CFE /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				403EE7BA215A070B00B8FD62 /* libv8_builtins_generators.a */,
+				403EE7B9215A070B00B8FD62 /* libv8_builtins_setup.a */,
+				403EE7B7215A051E00B8FD62 /* libuv_a.a */,
+				403EE7AE2159E8F200B8FD62 /* libinspector.a */,
+				403EE7AB2159E8F200B8FD62 /* libv8_base.a */,
+				403EE7AF2159E8F300B8FD62 /* libv8_libbase.a */,
+				403EE7AC2159E8F200B8FD62 /* libv8_libplatform.a */,
+				403EE7B02159E8F300B8FD62 /* libv8_libsampler.a */,
+				403EE7AD2159E8F200B8FD62 /* libv8_nosnapshot.a */,
 				40CEAEB920CFDE19007A3281 /* SystemConfiguration.framework */,
 				1A9A4C6D1F98B1C000C14552 /* libcocosanalytics.a */,
 				1ACF6A3A1E4AFDC80033C137 /* libcrypto.a */,

--- a/cocos/scripting/js-bindings/jswrapper/config.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/config.hpp
@@ -30,8 +30,13 @@
 #define SCRIPT_ENGINE_JSC            3
 #define SCRIPT_ENGINE_CHAKRACORE     4
 
-#if defined(__APPLE__) // macOS and iOS use JavaScriptCore
-    #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_JSC
+#if defined(__APPLE__)
+    #include <TargetConditionals.h>
+    #if TARGET_OS_OSX
+        #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_JSC // SCRIPT_ENGINE_V8 optional on macOS
+    #elif TARGET_OS_IPHONE
+        #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_JSC // only SCRIPT_ENGINE_JSC on iPhone
+    #endif
 #elif defined(ANDROID) || (defined(_WIN32) && defined(_WINDOWS)) // Windows and Android use V8
     #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_V8
 #else

--- a/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/HelloJavascript.xcodeproj/project.pbxproj
+++ b/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/HelloJavascript.xcodeproj/project.pbxproj
@@ -618,10 +618,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../cocos2d-x $(SRCROOT)/../../cocos2d-x/cocos $(SRCROOT)/../../cocos2d-x/cocos/base $(SRCROOT)/../../cocos2d-x/cocos/physics $(SRCROOT)/../../cocos2d-x/cocos/math/kazmath $(SRCROOT)/../../cocos2d-x/cocos/2d $(SRCROOT)/../../cocos2d-x/cocos/gui $(SRCROOT)/../../cocos2d-x/cocos/network $(SRCROOT)/../../cocos2d-x/cocos/audio/include $(SRCROOT)/../../cocos2d-x/cocos/editor-support $(SRCROOT)/../../cocos2d-x/extensions $(SRCROOT)/../../cocos2d-x/external $(SRCROOT)/../../cocos2d-x/external/sources $(SRCROOT)/../../cocos2d-x/external/chipmunk/include/chipmunk $(SRCROOT)/../../cocos2d-x/cocos/scripting/js-bindings/auto $(SRCROOT)/../../cocos2d-x/cocos/scripting/js-bindings/manual";
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../cocos2d-x $(SRCROOT)/../../cocos2d-x/cocos $(SRCROOT)/../../cocos2d-x/cocos/base $(SRCROOT)/../../cocos2d-x/cocos/physics $(SRCROOT)/../../cocos2d-x/cocos/math/kazmath $(SRCROOT)/../../cocos2d-x/cocos/2d $(SRCROOT)/../../cocos2d-x/cocos/gui $(SRCROOT)/../../cocos2d-x/cocos/network $(SRCROOT)/../../cocos2d-x/cocos/audio/include $(SRCROOT)/../../cocos2d-x/cocos/editor-support $(SRCROOT)/../../cocos2d-x/extensions $(SRCROOT)/../../cocos2d-x/external $(SRCROOT)/../../cocos2d-x/external/sources $(SRCROOT)/../../cocos2d-x/external/chipmunk/include/chipmunk $(SRCROOT)/../../cocos2d-x/cocos/scripting/js-bindings/auto $(SRCROOT)/../../cocos2d-x/cocos/scripting/js-bindings/manual $(SRCROOT)/../../cocos2d-x/external/mac/include/v8";
 			};
 			name = Debug;
 		};
@@ -641,10 +641,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../cocos2d-x $(SRCROOT)/../../cocos2d-x/cocos $(SRCROOT)/../../cocos2d-x/cocos/base $(SRCROOT)/../../cocos2d-x/cocos/physics $(SRCROOT)/../../cocos2d-x/cocos/math/kazmath $(SRCROOT)/../../cocos2d-x/cocos/2d $(SRCROOT)/../../cocos2d-x/cocos/gui $(SRCROOT)/../../cocos2d-x/cocos/network $(SRCROOT)/../../cocos2d-x/cocos/audio/include $(SRCROOT)/../../cocos2d-x/cocos/editor-support $(SRCROOT)/../../cocos2d-x/extensions $(SRCROOT)/../../cocos2d-x/external $(SRCROOT)/../../cocos2d-x/external/sources $(SRCROOT)/../../cocos2d-x/external/chipmunk/include/chipmunk $(SRCROOT)/../../cocos2d-x/cocos/scripting/js-bindings/auto $(SRCROOT)/../../cocos2d-x/cocos/scripting/js-bindings/manual";
+				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/../../cocos2d-x $(SRCROOT)/../../cocos2d-x/cocos $(SRCROOT)/../../cocos2d-x/cocos/base $(SRCROOT)/../../cocos2d-x/cocos/physics $(SRCROOT)/../../cocos2d-x/cocos/math/kazmath $(SRCROOT)/../../cocos2d-x/cocos/2d $(SRCROOT)/../../cocos2d-x/cocos/gui $(SRCROOT)/../../cocos2d-x/cocos/network $(SRCROOT)/../../cocos2d-x/cocos/audio/include $(SRCROOT)/../../cocos2d-x/cocos/editor-support $(SRCROOT)/../../cocos2d-x/extensions $(SRCROOT)/../../cocos2d-x/external $(SRCROOT)/../../cocos2d-x/external/sources $(SRCROOT)/../../cocos2d-x/external/chipmunk/include/chipmunk $(SRCROOT)/../../cocos2d-x/cocos/scripting/js-bindings/auto $(SRCROOT)/../../cocos2d-x/cocos/scripting/js-bindings/manual $(SRCROOT)/../../cocos2d-x/external/mac/include/v8";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -675,9 +675,9 @@
 					"$(SRCROOT)/ios/anysdk",
 				);
 				OTHER_LDFLAGS = (
-                                    "-ObjC",
-                                    "$(inherited)",
-                                );
+					"-ObjC",
+					"$(inherited)",
+				);
 				SDKROOT = iphoneos;
 				STRIP_PNG_TEXT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -711,9 +711,9 @@
 					"$(SRCROOT)/ios/anysdk",
 				);
 				OTHER_LDFLAGS = (
-                                    "-ObjC",
-                                    "$(inherited)",
-                                );
+					"-ObjC",
+					"$(inherited)",
+				);
 				SDKROOT = iphoneos;
 				STRIP_PNG_TEXT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/templates/js-template-link/frameworks/runtime-src/proj.ios_mac/HelloJavascript.xcodeproj/project.pbxproj
+++ b/templates/js-template-link/frameworks/runtime-src/proj.ios_mac/HelloJavascript.xcodeproj/project.pbxproj
@@ -601,10 +601,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "/Applications/CocosCreator.app/Contents/Resources/cocos2d-x /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/base /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/physics /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/math/kazmath /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/2d /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/gui /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/network /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/audio/include /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/editor-support /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/extensions /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/sources /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/chipmunk/include/chipmunk /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/scripting/js-bindings/auto /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/scripting/js-bindings/manual /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/renderer";
+				USER_HEADER_SEARCH_PATHS = "/Applications/CocosCreator.app/Contents/Resources/cocos2d-x /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/base /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/physics /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/math/kazmath /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/2d /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/gui /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/network /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/audio/include /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/editor-support /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/extensions /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/sources /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/chipmunk/include/chipmunk /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/mac/include/v8 /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/scripting/js-bindings/auto /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/scripting/js-bindings/manual /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/renderer";
 			};
 			name = Debug;
 		};
@@ -624,10 +624,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				USER_HEADER_SEARCH_PATHS = "/Applications/CocosCreator.app/Contents/Resources/cocos2d-x /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/base /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/physics /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/math/kazmath /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/2d /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/gui /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/network /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/audio/include /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/editor-support /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/extensions /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/sources /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/chipmunk/include/chipmunk /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/scripting/js-bindings/auto /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/scripting/js-bindings/manual /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/renderer";
+				USER_HEADER_SEARCH_PATHS = "/Applications/CocosCreator.app/Contents/Resources/cocos2d-x /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/base /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/physics /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/math/kazmath /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/2d /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/gui /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/network /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/audio/include /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/editor-support /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/extensions /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/sources /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/chipmunk/include/chipmunk /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/external/mac/include/v8 /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/scripting/js-bindings/auto /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/scripting/js-bindings/manual /Applications/CocosCreator.app/Contents/Resources/cocos2d-x/cocos/renderer";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -658,9 +658,9 @@
 					"$(SRCROOT)/ios/anysdk",
 				);
 				OTHER_LDFLAGS = (
-                                    "-ObjC",
-                                    "$(inherited)",
-                                );
+					"-ObjC",
+					"$(inherited)",
+				);
 				SDKROOT = iphoneos;
 				STRIP_PNG_TEXT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -694,9 +694,9 @@
 					"$(SRCROOT)/ios/anysdk",
 				);
 				OTHER_LDFLAGS = (
-                                    "-ObjC",
-                                    "$(inherited)",
-                                );
+					"-ObjC",
+					"$(inherited)",
+				);
 				SDKROOT = iphoneos;
 				STRIP_PNG_TEXT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/simulator.xcodeproj/project.pbxproj
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/simulator.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 				);
 				PRODUCT_NAME = Simulator;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../../../../../cocos/platform/mac $(SRCROOT)/../../../../../external/mac/include $(SRCROOT)/../../../../../external/mac/include/glfw3 $(SRCROOT)/../../../../../external/mac/include/spidermonkey $(SRCROOT)/../../../../../external/sources";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../../../../../cocos/platform/mac $(SRCROOT)/../../../../../external/mac/include $(SRCROOT)/../../../../../external/mac/include/glfw3 $(SRCROOT)/../../../../../external/mac/include/spidermonkey $(SRCROOT)/../../../../../external/sources $(SRCROOT)/../../../../../external/mac/include/v8";
 				VALID_ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 			};
 			name = Debug;
@@ -740,7 +740,7 @@
 				);
 				PRODUCT_NAME = Simulator;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../../../../../cocos/platform/mac $(SRCROOT)/../../../../../external/mac/include $(SRCROOT)/../../../../../external/mac/include/glfw3 $(SRCROOT)/../../../../../external/mac/include/spidermonkey $(SRCROOT)/../../../../../external/sources";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../../../../../cocos/platform/mac $(SRCROOT)/../../../../../external/mac/include $(SRCROOT)/../../../../../external/mac/include/glfw3 $(SRCROOT)/../../../../../external/mac/include/spidermonkey $(SRCROOT)/../../../../../external/sources $(SRCROOT)/../../../../../external/mac/include/v8";
 				VALID_ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 			};
 			name = Release;


### PR DESCRIPTION
__为 mac 平台 ScriptEngine 增加 v8 可选__ , for https://github.com/cocos-creator/2d-tasks/issues/418

目前默认依旧为 JSC，通过改变 `js-bindings/jswrapper/config.hpp` 中的宏定义，可将引擎切换为 v8。

- 依赖：第三方库更改：https://github.com/cocos-creator/cocos2d-x-lite-external/pull/60
- 测试：使用 creator 2.1 在 mac 上切换为 v8，可以正常跑起来
- 存在问题：在 chrome 上 debug 无法命中断点，（通过 debugger 方式可以命中）

```
#if defined(__APPLE__)
    #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_JSC	    #include <TargetConditionals.h>
    #if TARGET_OS_OSX
        #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_JSC // SCRIPT_ENGINE_V8 optional on 
        ...
```