### PR TITLE
Declare JSB_WebSocketDelegate in hpp file

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_websocket.hpp
+++ b/cocos/scripting/js-bindings/manual/jsb_websocket.hpp
@@ -25,9 +25,46 @@
 
 #pragma once
 
+#include "cocos/scripting/js-bindings/jswrapper/SeApi.h"
+#include "cocos/network/WebSocket.h"
+
 namespace se {
     class Object;
+    class Value;
 }
 
-bool register_all_websocket(se::Object* obj);
+class JSB_WebSocketDelegate : public cocos2d::Ref, public cocos2d::network::WebSocket::Delegate {
+public:
+    JSB_WebSocketDelegate();
+
+    virtual void onOpen(cocos2d::network::WebSocket *ws) override;
+
+    virtual void onMessage(cocos2d::network::WebSocket *ws,
+                           const cocos2d::network::WebSocket::Data &data) override;
+
+    virtual void onClose(cocos2d::network::WebSocket *ws) override;
+
+    virtual void onError(cocos2d::network::WebSocket *ws,
+                         const cocos2d::network::WebSocket::ErrorCode &error) override;
+
+    void setJSDelegate(const se::Value &jsDelegate);
+
+private:
+    virtual ~JSB_WebSocketDelegate();
+
+    se::Value _JSDelegate;
+};
+
+SE_DECLARE_FINALIZE_FUNC(WebSocket_finalize);
+
+SE_DECLARE_FUNC(WebSocket_constructor);
+
+SE_DECLARE_FUNC(WebSocket_send);
+
+SE_DECLARE_FUNC(WebSocket_close);
+
+void WebSocket_getReadyStateRegistry(v8::Local<v8::Name> _property,
+                                     const v8::PropertyCallbackInfo<v8::Value> &_v8args);
+
+bool register_all_websocket(se::Object *obj);
 


### PR DESCRIPTION
## 修改原因
现在 runtime 需要自定义 jsb_websocket 文件中的一些功能，而类似 JSB_WebSocketDelegate 这个类 runtime 是有使用到，却没有做修改的，所以希望能够直接复用 lite 中的相关代码。

## 修改内容
- 将 JSB_WebSocketDelegate 类定义在 jsb_websocket.hpp 文件中，以供 runtime 使用。
- 将几个绑定函数在 jsb_websocket.hpp 文件中定义。

## 测试说明
分别在 `runtime 环境` 以及 `CocosCreator原生安卓环境` 中测试通过。