### PR TITLE
add macro to support custom v8 debug option for creator

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/config.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/config.hpp
@@ -30,12 +30,16 @@
 #define SCRIPT_ENGINE_JSC            3
 #define SCRIPT_ENGINE_CHAKRACORE     4
 
+#define SCRIPT_ENGINE_V8_ON_MAC      1 // default using v8 on macOS, set 0 to disable
+#define V8_DEBUG_WAIT_FOR_CONNECT    0 // the program will be hung up until debug attach if you enable it, set 1 to enable
+#define JSB_DEFAULT_DEBUGGER_PORT    5086
+
 #if defined(__APPLE__)
     #include <TargetConditionals.h>
-    #if TARGET_OS_OSX
-        #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_JSC // SCRIPT_ENGINE_V8 optional on macOS
-    #elif TARGET_OS_IPHONE
-        #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_JSC // only SCRIPT_ENGINE_JSC on iPhone
+    #if TARGET_OS_OSX && SCRIPT_ENGINE_V8_ON_MAC
+        #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_V8
+    #else
+        #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_JSC
     #endif
 #elif defined(ANDROID) || (defined(_WIN32) && defined(_WINDOWS)) // Windows and Android use V8
     #define SCRIPT_ENGINE_TYPE           SCRIPT_ENGINE_V8

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -562,7 +562,7 @@ namespace se {
             _env = node::CreateEnvironment(_isolateData, _context.Get(_isolate), 0, nullptr, 0, nullptr);
 
             node::DebugOptions options;
-            options.set_wait_for_connect(false); // Don't wait for connect, otherwise, the program will be hung up.
+            options.set_wait_for_connect(V8_DEBUG_WAIT_FOR_CONNECT);
             options.set_inspector_enabled(true);
             options.set_port((int)_debuggerServerPort);
             options.set_host_name(_debuggerServerAddr.c_str());

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "next-4",
+    "version": "next-5",
     "zip_file_size": "137556825",
     "repo_name": "cocos2d-x-lite-external",
     "repo_parent": "https://github.com/cocos-creator/"

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -66,7 +66,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     // Enable debugger here
-    jsb_enable_debugger("127.0.0.1", JSB_DEFAULT_DEBUGGER_PORT);
+    jsb_enable_debugger("0.0.0.0", JSB_DEFAULT_DEBUGGER_PORT);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -66,7 +66,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     // Enable debugger here
-    jsb_enable_debugger("0.0.0.0", 5086);
+    jsb_enable_debugger("127.0.0.1", JSB_DEFAULT_DEBUGGER_PORT);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -66,7 +66,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     // Enable debugger here
-    jsb_enable_debugger("127.0.0.1", JSB_DEFAULT_DEBUGGER_PORT);
+    jsb_enable_debugger("0.0.0.0", JSB_DEFAULT_DEBUGGER_PORT);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -66,7 +66,7 @@ bool AppDelegate::applicationDidFinishLaunching()
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     // Enable debugger here
-    jsb_enable_debugger("0.0.0.0", 5086);
+    jsb_enable_debugger("127.0.0.1", JSB_DEFAULT_DEBUGGER_PORT);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){

--- a/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/ide-support/RuntimeJsImpl.cpp
@@ -172,7 +172,7 @@ bool RuntimeJsImpl::initJsEnv()
 
 #if defined(COCOS2D_DEBUG) && (COCOS2D_DEBUG > 0)
     // Enable debugger here
-    jsb_enable_debugger("0.0.0.0", 5086);
+    jsb_enable_debugger("127.0.0.1", JSB_DEFAULT_DEBUGGER_PORT);
 #endif
 
     se->setExceptionCallback([](const char* location, const char* message, const char* stack){


### PR DESCRIPTION
增加三个宏定义，便于 creator 在构建阶段修改 debug 行为

```
#define SCRIPT_ENGINE_V8_ON_MAC      1 // default using v8 on macOS, set 0 to disable
#define V8_DEBUG_WAIT_FOR_CONNECT    0 // the program will be hung up until debug attach if you enable it, set 1 to enable
#define JSB_DEFAULT_DEBUGGER_PORT    5086
```