### PR TITLE
fix: can not use italic font in canvas

### DIFF
--- a/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
+++ b/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
@@ -128,9 +128,9 @@ public:
         return JniHelper::callObjectFloatMethod(_obj, JCLS_CANVASIMPL, "measureText", text);
     }
 
-    void updateFont(const std::string& fontName, float fontSize, bool bold)
+    void updateFont(const std::string& fontName, float fontSize, bool bold, bool italic)
     {
-        JniHelper::callObjectVoidMethod(_obj, JCLS_CANVASIMPL, "updateFont", fontName, fontSize, bold);
+        JniHelper::callObjectVoidMethod(_obj, JCLS_CANVASIMPL, "updateFont", fontName, fontSize, bold, italic);
     }
 
     void setTextAlign(CanvasTextAlign align)
@@ -381,7 +381,7 @@ void CanvasRenderingContext2D::set_font(const std::string& font)
         std::string fontSizeStr = "30";
 
         // support get font name from `60px American` or `60px "American abc-abc_abc"`
-        std::regex re("(bold)?\\s*(\\d+)px\\s+([\\w-]+|\"[\\w -]+\"$)");
+        std::regex re("(bold|italic|bold italic|italic bold)?\\s*(\\d+)px\\s+([\\w-]+|\"[\\w -]+\"$)");
         std::match_results<std::string::const_iterator> results;
         if (std::regex_search(_font.cbegin(), _font.cend(), results, re))
         {
@@ -391,7 +391,9 @@ void CanvasRenderingContext2D::set_font(const std::string& font)
         }
 
         float fontSize = atof(fontSizeStr.c_str());
-        _impl->updateFont(fontName, fontSize, !boldStr.empty());
+        bool isBold = boldStr.find("bold", 0) != std::string::npos;
+        bool isItalic = boldStr.find("italic", 0) != std::string::npos;
+        _impl->updateFont(fontName, fontSize, isBold, isItalic);
     }
 }
 

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
@@ -73,6 +73,7 @@ public class CanvasRenderingContext2DImpl {
     private float mFontSize = 40.0f;
     private float mLineWidth = 0.0f;
     private boolean mIsBoldFont = false;
+    private boolean mIsItalicFont = false;
 
     private class Size {
         Size(float w, float h) {
@@ -151,7 +152,7 @@ public class CanvasRenderingContext2DImpl {
         sTypefaceCache.clear();
     }
 
-    private static TextPaint newPaint(String fontName, int fontSize, boolean enableBold) {
+    private static TextPaint newPaint(String fontName, int fontSize, boolean enableBold, boolean enableItalic) {
         TextPaint paint = new TextPaint();
         paint.setTextSize(fontSize);
         paint.setAntiAlias(true);
@@ -160,16 +161,23 @@ public class CanvasRenderingContext2DImpl {
         if (enableBold) {
             key += "-Bold";
         }
-        
+        if (enableItalic) {
+            key += "-Italic";
+        }
+
         Typeface typeFace;
         if (sTypefaceCache.containsKey(key)) {
             typeFace = sTypefaceCache.get(key);
         } else {
-            if (enableBold) {
-                typeFace = Typeface.create(fontName, Typeface.BOLD);
-            } else {
-                typeFace = Typeface.create(fontName, Typeface.NORMAL);
+            int style = Typeface.NORMAL;
+            if (enableBold && enableItalic) {
+                style = Typeface.BOLD_ITALIC;
+            } else if (enableBold) {
+                style = Typeface.BOLD;
+            } else if (enableItalic) {
+                style = Typeface.ITALIC;
             }
+            typeFace = Typeface.create(fontName, style);
         }
 
         paint.setTypeface(typeFace);
@@ -212,7 +220,7 @@ public class CanvasRenderingContext2DImpl {
         if (mLinePaint == null) {
             mLinePaint = new Paint();
         }
-     
+
         if(mLinePath == null) {
             mLinePath = new Path();
         }
@@ -248,7 +256,7 @@ public class CanvasRenderingContext2DImpl {
 
     private void createTextPaintIfNeeded() {
         if (mTextPaint == null) {
-            mTextPaint = newPaint(mFontName, (int) mFontSize, mIsBoldFont);
+            mTextPaint = newPaint(mFontName, (int) mFontSize, mIsBoldFont, mIsItalicFont);
         }
     }
 
@@ -296,11 +304,12 @@ public class CanvasRenderingContext2DImpl {
         return new Size(measureText(text), fm.descent - fm.ascent);
     }
 
-    private void updateFont(String fontName, float fontSize, boolean bold) {
+    private void updateFont(String fontName, float fontSize, boolean bold, boolean italic) {
         // Log.d(TAG, "updateFont: " + fontName + ", " + fontSize);
         mFontName = fontName;
         mFontSize = fontSize;
         mIsBoldFont = bold;
+        mIsItalicFont = italic;
         mTextPaint = null; // Reset paint to re-create paint object in createTextPaintIfNeeded
     }
 


### PR DESCRIPTION
## 问题描述
使用以下代码无法使用斜体字

```JS
    var surface = document.createElement('canvas');
    var context = surface.getContext('2d');
    //设置 italic，没有斜体效果
    context.font = "italic 140px serif";
    context.fillText("ABCDE", 20, 600);
```
原因是没有对 italic 参数进行处理。
