### PR TITLE
fix wrong namespace on Device.getDeviceMotionValue

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_cocos2dx_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_cocos2dx_manual.cpp
@@ -489,12 +489,7 @@ SE_BIND_FUNC(JSB_getDeviceMotionValue)
 static bool register_device(se::Object* obj)
 {
     se::Value device;
-    if (!obj->getProperty("Device", &device))
-    {
-        se::HandleObject deviceObj(se::Object::createPlainObject());
-        obj->setProperty("Device", se::Value(deviceObj));
-        device.setObject(deviceObj);
-    }
+    __jsbObj->getProperty("Device", &device);
 
     device.toObject()->defineFunction("getDeviceMotionValue", _SE(JSB_getDeviceMotionValue));
 


### PR DESCRIPTION
Fix https://github.com/cocos-creator/2d-tasks/issues/351   测试例：creator 的重力感应无效

配合：https://github.com/cocos-creator/engine/pull/3332

测试：在 android 和 iOS 上验证 DeviceMotion 测试例，效果正常