### PR TITLE
Fix error when exit game use websocket

### DIFF
--- a/cocos/network/WebSocket-libwebsockets.cpp
+++ b/cocos/network/WebSocket-libwebsockets.cpp
@@ -501,7 +501,10 @@ void WsThreadHelper::wsThreadEntryFunc()
 
 void WsThreadHelper::sendMessageToCocosThread(const std::function<void()>& cb)
 {
-    cocos2d::Application::getInstance()->getScheduler()->performFunctionInCocosThread(cb);
+    if (cocos2d::Application::getInstance() != nullptr &&
+        cocos2d::Application::getInstance()->getScheduler() != nullptr) {
+        cocos2d::Application::getInstance()->getScheduler()->performFunctionInCocosThread(cb);
+    }
 }
 
 void WsThreadHelper::sendMessageToWebSocketThread(WsMessage *msg)


### PR DESCRIPTION
## 问题描述
在 runtime 中，进入 creator 官方测试例 `05——scripting/11_network/network` 测试例后，退出测试例，程序会弹出崩溃的提示框。

## 原因
在 WebSocket_finalize 函数中，调用了 cobj->closeAsync(); 函数，在当 websocket 真正析构时，会调用以下代码

```JAVA
    cocos2d::Application::getInstance()->getScheduler()->performFunctionInCocosThread(cb);
```

在 runtime 中发现，_scheduler 会为空指针，最终导致报错。所以在代码中添加了判空的逻辑。

> 说明，该问题只能在部分手机中重现，现在发现的能够重现的手机型号有：
> samsung glaxy s7
> nexus