### PR TITLE
[bug] fixed font size not recognized after setting Chinese font

### DIFF
--- a/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
+++ b/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
@@ -377,17 +377,23 @@ void CanvasRenderingContext2D::set_font(const std::string& font)
         _font = font;
 
         std::string boldStr;
-        std::string fontName = "Arial";
+        std::string fontName = "sans-serif";
         std::string fontSizeStr = "30";
-
-        // support get font name from `60px American` or `60px "American abc-abc_abc"`
-        std::regex re("(bold|italic|bold italic|italic bold)?\\s*(\\d+)px\\s+([\\w-]+|\"[\\w -]+\"$)");
+        std::regex re("(bold|italic|bold italic|italic bold)?\\s*(\\d+)px\\s+([^\\r\\n]*)");
         std::match_results<std::string::const_iterator> results;
         if (std::regex_search(_font.cbegin(), _font.cend(), results, re))
         {
             boldStr = results[1].str();
             fontSizeStr = results[2].str();
-            fontName = results[3].str();
+            // support get font name from `60px American` or `60px "American abc-abc_abc"`
+            // support get font name contain space,example `times new roman`
+            // if regex rule that does not conform to the rules,such as Chinese,it defaults to sans-serif
+            std::match_results<std::string::const_iterator> fontResults;
+            std::regex fontRe("([\\w\\s-]+|\"[\\w\\s-]+\"$)");
+            if(std::regex_match(results[3].str(), fontResults, fontRe))
+            {
+                fontName = results[3].str();
+            }
         }
 
         float fontSize = atof(fontSizeStr.c_str());


### PR DESCRIPTION
ctx.font 设置字体为中文时，字体大小不识别。问题在正则表达式为[\\w-]+|\"[\\w -]+\"$  ，是不支持中文识别的。
这里修改分为两个正则表达式判断，第一个的判断字体出修改为非换行符，先取出boldStr和fontSizeStr，第二个在取出来的值基础上匹配规则，不支持的规则默认原来字体。
断点了下android 系统支持的字体（不同系统和不同品牌手机可能会有差别），下面是断点出来的值，可以看到android系统里是没有中文的变量。

![1538989632456](https://user-images.githubusercontent.com/20498898/46651644-4a4e8d00-cbd3-11e8-8fce-869b71e1dc44.jpg)
可以看出，原来默认开头大写的“ Arial”，是不存在的，只有小写开头的“ arial”。另外变量名为存在空格的情况如"times new roman"和“ITC Stone Serif”,故也添加了空格条件
具体查看TypeFace.java源码，可以看到android系统字体是从/system/etc/fonts.xml读出来的，相应的字体库在/system/fonts/。可以看到字体变量一般是不会含有中文。
另外查询到ctx.font默认字体为 sans-serif，故修改了下‘Arial’为‘sans-serif’。链接为：https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font

