### PR TITLE
 fix editbox out of works after cc.game.restart

### DIFF
--- a/cocos/ui/edit-box/EditBox-android.cpp
+++ b/cocos/ui/edit-box/EditBox-android.cpp
@@ -41,67 +41,67 @@ NS_CC_BEGIN
 
 void EditBox::show(const cocos2d::EditBox::ShowInfo& showInfo)
 {
-	JniHelper::callStaticVoidMethod(JCLS_EDITBOX,
-		                            "showNative",
-		                            showInfo.defaultValue,
-		                            showInfo.maxLength,
-		                            showInfo.isMultiline,
-		                            showInfo.confirmHold,
-		                            showInfo.confirmType,
-		                            showInfo.inputType);
+  JniHelper::callStaticVoidMethod(JCLS_EDITBOX,
+                                "showNative",
+                                showInfo.defaultValue,
+                                showInfo.maxLength,
+                                showInfo.isMultiline,
+                                showInfo.confirmHold,
+                                showInfo.confirmType,
+                                showInfo.inputType);
 }
 
 void EditBox::hide()
 {
-	JniHelper::callStaticVoidMethod(JCLS_EDITBOX, "hideNative");
+  JniHelper::callStaticVoidMethod(JCLS_EDITBOX, "hideNative");
 }
 
 NS_CC_END
 
 namespace
 {
-	se::Value textInputCallback;
+  se::Value textInputCallback;
 
-	void getTextInputCallback()
-	{
-		se::Value tmpVal;
+  void getTextInputCallback()
+  {
+    se::Value tmpVal;
     if (! textInputCallback.isUndefined() && textInputCallback.toObject()->getProperty("input", &tmpVal))
-			return;
+      return;
 
-		auto global = se::ScriptEngine::getInstance()->getGlobalObject();
+    auto global = se::ScriptEngine::getInstance()->getGlobalObject();
         se::Value jsbVal;
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &textInputCallback);
         }
-	}
+  }
 
-	void callJSFunc(const std::string& type, const jstring& text)
-	{
-		getTextInputCallback();
+  void callJSFunc(const std::string& type, const jstring& text)
+  {
+    getTextInputCallback();
 
         se::AutoHandleScope scope;
-		se::ValueArray args;
-		args.push_back(se::Value(type));
-		args.push_back(se::Value(cocos2d::JniHelper::jstring2string(text)));
-		textInputCallback.toObject()->call(args, nullptr);
-	}
+    se::ValueArray args;
+    args.push_back(se::Value(type));
+    args.push_back(se::Value(cocos2d::JniHelper::jstring2string(text)));
+    textInputCallback.toObject()->call(args, nullptr);
+  }
 }
 
 extern "C" 
 {
-	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardInputNative)(JNIEnv* env, jclass, jstring text)
-	{
-		callJSFunc("input", text);
-	}
+  JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardInputNative)(JNIEnv* env, jclass, jstring text)
+  {
+    callJSFunc("input", text);
+  }
 
-	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardCompleteNative)(JNIEnv* env, jclass, jstring text)
-	{
-		callJSFunc("complete", text);
-	}
+  JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardCompleteNative)(JNIEnv* env, jclass, jstring text)
+  {
+    callJSFunc("complete", text);
+  }
 
-	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardConfirmNative)(JNIEnv* env, jclass, jstring text)
-	{
+  JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardConfirmNative)(JNIEnv* env, jclass, jstring text)
+  {
         callJSFunc("confirm", text);
-	}
+  }
 }

--- a/cocos/ui/edit-box/EditBox-android.cpp
+++ b/cocos/ui/edit-box/EditBox-android.cpp
@@ -64,7 +64,8 @@ namespace
 
 	void getTextInputCallback()
 	{
-		if (! textInputCallback.isUndefined())
+		se::Value tmpVal;
+    if (! textInputCallback.isUndefined() && textInputCallback.toObject()->getProperty("input", &tmpVal))
 			return;
 
 		auto global = se::ScriptEngine::getInstance()->getGlobalObject();

--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -118,7 +118,8 @@ namespace
     
     void getTextInputCallback()
     {
-        if (! textInputCallback.isUndefined())
+        se::Value tmpVal;
+        if (! textInputCallback.isUndefined() && textInputCallback.toObject()->getProperty("input", &tmpVal))
             return;
         
         auto global = se::ScriptEngine::getInstance()->getGlobalObject();

--- a/cocos/ui/edit-box/EditBox-mac.mm
+++ b/cocos/ui/edit-box/EditBox-mac.mm
@@ -154,9 +154,10 @@ namespace
 {
     void getTextInputCallback()
     {
-        if (! g_textInputCallback.isUndefined())
+        se::Value tmpVal;
+        if (! g_textInputCallback.isUndefined() && g_textInputCallback.toObject()->getProperty("input", &tmpVal))
             return;
-        
+
         auto global = se::ScriptEngine::getInstance()->getGlobalObject();
         se::Value jsbVal;
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())

--- a/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/cocos/ui/edit-box/EditBox-win32.cpp
@@ -61,7 +61,7 @@ namespace
     {
         se::Value tmpVal;
         if (! g_textInputCallback.isUndefined() && g_textInputCallback.toObject()->getProperty("input", &tmpVal))
-			return;
+            return;
 
         auto global = se::ScriptEngine::getInstance()->getGlobalObject();
         se::Value jsbVal;

--- a/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/cocos/ui/edit-box/EditBox-win32.cpp
@@ -59,8 +59,9 @@ namespace
 
     void getTextInputCallback()
     {
-        if (!g_textInputCallback.isUndefined())
-            return;
+        se::Value tmpVal;
+        if (! g_textInputCallback.isUndefined() && g_textInputCallback.toObject()->getProperty("input", &tmpVal))
+			return;
 
         auto global = se::ScriptEngine::getInstance()->getGlobalObject();
         se::Value jsbVal;


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/647

- `g_textInputCallback` 是全局的，在重启后，内部的方法失效了，同时也没自动重置为 `Undefined`。（类似重启后，变为了野指针。）

- 增加一个额外检测，去获取内部方法，如果获取成功，才认为 `g_textInputCallback` 变量正常，不需要重新获取。

在 iOS & Android & mac 上验证，重启后 EditBox 工作正常