### PR TITLE
support parse font size with float value

### DIFF
--- a/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
+++ b/cocos/platform/android/CCCanvasRenderingContext2D-android.cpp
@@ -379,7 +379,7 @@ void CanvasRenderingContext2D::set_font(const std::string& font)
         std::string boldStr;
         std::string fontName = "sans-serif";
         std::string fontSizeStr = "30";
-        std::regex re("(bold|italic|bold italic|italic bold)?\\s*(\\d+)px\\s+([^\\r\\n]*)");
+        std::regex re("(bold|italic|bold italic|italic bold)?\\s*((\\d+)([\\.]\\d+)?)px\\s+([^\\r\\n]*)");
         std::match_results<std::string::const_iterator> results;
         if (std::regex_search(_font.cbegin(), _font.cend(), results, re))
         {
@@ -390,9 +390,9 @@ void CanvasRenderingContext2D::set_font(const std::string& font)
             // if regex rule that does not conform to the rules,such as Chinese,it defaults to sans-serif
             std::match_results<std::string::const_iterator> fontResults;
             std::regex fontRe("([\\w\\s-]+|\"[\\w\\s-]+\"$)");
-            if(std::regex_match(results[3].str(), fontResults, fontRe))
+            if(std::regex_match(results[5].str(), fontResults, fontRe))
             {
-                fontName = results[3].str();
+                fontName = results[5].str();
             }
         }
 

--- a/cocos/platform/apple/CCCanvasRenderingContext2D-apple.mm
+++ b/cocos/platform/apple/CCCanvasRenderingContext2D-apple.mm
@@ -712,13 +712,13 @@ void CanvasRenderingContext2D::set_font(const std::string& font)
         std::string fontSizeStr = "30";
 
         // support get font name from `60px American` or `60px "American abc-abc_abc"`
-        std::regex re("(bold)?\\s*(\\d+)px\\s+([\\w-]+|\"[\\w -]+\"$)");
+        std::regex re("(bold)?\\s*((\\d+)([\\.]\\d+)?)px\\s+([\\w-]+|\"[\\w -]+\"$)");
         std::match_results<std::string::const_iterator> results;
         if (std::regex_search(_font.cbegin(), _font.cend(), results, re))
         {
             boldStr = results[1].str();
             fontSizeStr = results[2].str();
-            fontName = results[3].str();
+            fontName = results[5].str();
         }
 
         CGFloat fontSize = atof(fontSizeStr.c_str());

--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -785,13 +785,13 @@ void CanvasRenderingContext2D::set_font(const std::string& font)
         std::string fontSizeStr = "30";
 
         // support get font name from `60px American` or `60px "American abc-abc_abc"`
-        std::regex re("(bold)?\\s*(\\d+)px\\s+([\\w-]+|\"[\\w -]+\"$)");
+        std::regex re("(bold)?\\s*((\\d+)([\\.]\\d+)?)px\\s+([\\w-]+|\"[\\w -]+\"$)");
         std::match_results<std::string::const_iterator> results;
         if (std::regex_search(_font.cbegin(), _font.cend(), results, re))
         {
             boldStr = results[1].str();
             fontSizeStr = results[2].str();
-            fontName = results[3].str();
+            fontName = results[5].str();
         }
 
         float fontSize = atof(fontSizeStr.c_str());


### PR DESCRIPTION
Fix https://github.com/cocos-creator/example-cases/issues/608

匹配字体大小正则表达式中的

`(\\d+)px` 改为 `((\\d+)([\\.]\\d+)?)px` 支持匹配浮点数