### PR TITLE
use absolute path for appActivity

### DIFF
--- a/templates/js-template-android-instant/frameworks/runtime-src/proj.android-studio/game/AndroidManifest.xml
+++ b/templates/js-template-android-instant/frameworks/runtime-src/proj.android-studio/game/AndroidManifest.xml
@@ -17,7 +17,7 @@
             android:value="cocos2djs" />
 
         <activity
-            android:name=".AppActivity"
+            android:name="org.cocos2dx.javascript.AppActivity"
             android:screenOrientation="sensorLandscape"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"


### PR DESCRIPTION
主要是因为instant 的 task 用 gradle 配置 applicationId 无效，只能换回改 androidManifest.xml 的文件的 
 package 字段去修改包名，所以要把 appActivity 的包名设置为绝对路径，不然改了包名就找不到啦。。。。

@drelaptop @minggo please review 。