### PR TITLE
close audio device properly when app force close

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -154,6 +154,8 @@ private:
 
 void AudioEngine::end()
 {
+    stopAll();
+
     if (s_threadPool)
     {
         delete s_threadPool;

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -71,14 +71,15 @@ Application::Application(const std::string& name, int width, int height)
 
 Application::~Application()
 {
-    EventDispatcher::destroy();
-    se::ScriptEngine::destroyInstance();
-    delete _renderTexture;
-    _renderTexture = nullptr;
-
-#if USE_AUDIO // close audio device
+#if USE_AUDIO
     AudioEngine::end();
 #endif
+
+    EventDispatcher::destroy();
+    se::ScriptEngine::destroyInstance();
+
+    delete _renderTexture;
+    _renderTexture = nullptr;
 
     Application::_instance = nullptr;
 }

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -223,8 +223,10 @@ Application::Application(const std::string& name, int width, int height)
 
 Application::~Application()
 {
-    [(CCEAGLView*)_view release];
-    _view = nullptr;
+
+#if USE_AUDIO
+    AudioEngine::end();
+#endif
 
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
@@ -234,12 +236,11 @@ Application::~Application()
     [(MainLoop*)_delegate release];
     _delegate = nullptr;
     
+    [(CCEAGLView*)_view release];
+    _view = nullptr;
+
     delete _renderTexture;
     _renderTexture = nullptr;
-
-#if USE_AUDIO // close audio device
-    AudioEngine::end();
-#endif
 
     Application::_instance = nullptr;
 }

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -83,6 +83,11 @@ Application::Application(const std::string& name, int width, int height)
 
 Application::~Application()
 {
+
+#if USE_AUDIO
+    AudioEngine::end();
+#endif
+
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
     
@@ -91,10 +96,6 @@ Application::~Application()
         
     delete _renderTexture;
     _renderTexture = nullptr;
-    
-#if USE_AUDIO // close audio device
-    AudioEngine::end();
-#endif
 
     Application::_instance = nullptr;
 }

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -117,18 +117,19 @@ Application::Application(const std::string& name, int width, int height)
 
 Application::~Application()
 {
+
+#if USE_AUDIO
+    AudioEngine::end();
+#endif
+
     EventDispatcher::destroy();
     se::ScriptEngine::destroyInstance();
 
     delete CAST_VIEW(_view);
     _view = nullptr;
-    
+
     delete _renderTexture;
     _renderTexture = nullptr;
-
-#if USE_AUDIO // close audio device
-    AudioEngine::end();
-#endif
 
     Application::_instance = nullptr;
 }


### PR DESCRIPTION
- Application 结束时，首先关闭 Audio（ Audio 对其它模块有依赖）
- 修复：iOS 平台，当同时播放多个音频时，进行强制关闭操作（通过双击 Home ，划掉 app），会有 OpenAL 内部 Crash 发生