### PR TITLE
fix js_saveImageData memory leak

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -895,6 +895,7 @@ static bool js_saveImageData(se::State& s)
         bool ret = img->saveToFile(filePath, false);
         s.rval().setBoolean(ret);
 
+        img->release();
         return ret;
     }
     SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 2);


### PR DESCRIPTION
https://github.com/cocos-creator/cocos2d-x-lite/pull/1554

img 应该释放，防止内存泄漏