### PR TITLE
[jsb] XMLHttpRequest & WebSocket API standardize

### DIFF
--- a/cocos/network/WebSocket-apple.mm
+++ b/cocos/network/WebSocket-apple.mm
@@ -336,6 +336,24 @@ void WebSocket::closeAsync()
     [_impl closeAsync];
 }
 
+void WebSocket::closeAsync(int code, const std::string &reason)
+{
+    //lws_close_reason() replacement required
+    closeAsync();
+}
+
+std::string WebSocket::getExtensions() const
+{
+    //TODO websocket extensions
+    return "";
+}
+
+size_t WebSocket::getBufferedAmount() const
+{
+    //TODO pending send bytes
+    return 0;
+}
+
 WebSocket::State WebSocket::getReadyState() const
 {
     return [_impl getReadyState];

--- a/cocos/network/WebSocket-libwebsockets.cpp
+++ b/cocos/network/WebSocket-libwebsockets.cpp
@@ -853,7 +853,8 @@ void WebSocketImpl::close()
 
 void WebSocketImpl::closeAsync(int code, const std::string &reason)
 {
-    lws_close_reason(_wsInstance, (lws_close_status)code, (unsigned char*)reason.c_str(), reason.length);
+    std::string tmp = reason;
+    lws_close_reason(_wsInstance, (lws_close_status)code, (unsigned char*)tmp.c_str(), tmp.length());
     closeAsync();
 }
 

--- a/cocos/network/WebSocket-libwebsockets.cpp
+++ b/cocos/network/WebSocket-libwebsockets.cpp
@@ -853,8 +853,7 @@ void WebSocketImpl::close()
 
 void WebSocketImpl::closeAsync(int code, const std::string &reason)
 {
-    std::string tmp = reason;
-    lws_close_reason(_wsInstance, (lws_close_status)code, (unsigned char*)tmp.c_str(), tmp.length());
+    lws_close_reason(_wsInstance, (lws_close_status)code, (unsigned char*)const_cast<char*>(reason.c_str()), reason.length());
     closeAsync();
 }
 

--- a/cocos/network/WebSocket-libwebsockets.cpp
+++ b/cocos/network/WebSocket-libwebsockets.cpp
@@ -192,6 +192,7 @@ public:
     void send(const unsigned char* binaryMsg, unsigned int len);
     void close();
     void closeAsync();
+    void closeAsync(int code, const std::string &reason);
     cocos2d::network::WebSocket::State getReadyState() const;
     const std::string& getUrl() const;
     const std::string& getProtocol() const;
@@ -848,6 +849,12 @@ void WebSocketImpl::close()
     // Wait 5 milliseconds for onConnectionClosed to exit!
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     _delegate->onClose(_ws);
+}
+
+void WebSocketImpl::closeAsync(int code, const std::string &reason)
+{
+    lws_close_reason(_wsInstance, (lws_close_status)code, (unsigned char*)reason.c_str(), reason.length);
+    closeAsync();
 }
 
 void WebSocketImpl::closeAsync()
@@ -1509,6 +1516,11 @@ void WebSocket::closeAsync()
 {
     _impl->closeAsync();
 }
+void WebSocket::closeAsync(int code, const std::string &reason)
+{
+    _impl->closeAsync(code, reason);
+}
+
 
 WebSocket::State WebSocket::getReadyState() const
 {

--- a/cocos/network/WebSocket-libwebsockets.cpp
+++ b/cocos/network/WebSocket-libwebsockets.cpp
@@ -1528,6 +1528,11 @@ WebSocket::State WebSocket::getReadyState() const
     return _impl->getReadyState();
 }
 
+std::string WebSocket::getExtensions() const
+{
+    return _impl->getExtensions();
+}
+
 size_t WebSocket::getBufferedAmount() const
 {
     return _impl->getBufferedAmount();

--- a/cocos/network/WebSocket.h
+++ b/cocos/network/WebSocket.h
@@ -33,6 +33,7 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #ifndef OBJC_CLASS
 #ifdef __OBJC__
@@ -52,6 +53,9 @@ OBJC_CLASS(WebSocketImpl);
 NS_CC_BEGIN
 
 namespace network {
+
+
+class WebSocketFrame;
 
 /**
  * WebSocket is wrapper of the libwebsockets-protocol, let the develop could call the websocket easily.
@@ -93,6 +97,7 @@ public:
         ssize_t len, issued;
         bool isBinary;
         void* ext;
+        ssize_t getRemain() { return std::max((ssize_t)0, len - issued); }
     };
 
     /**
@@ -216,6 +221,11 @@ public:
      *  @brief Gets the URL of websocket connection.
      */
     const std::string& getUrl() const;
+
+    /**
+    * @brief Returns the number of bytes of data that have been queued using calls to send() but not yet transmitted to the network.
+    */
+    size_t getBufferedAmount() const;
 
     /**
      *  @brief Gets the protocol selected by websocket server.

--- a/cocos/network/WebSocket.h
+++ b/cocos/network/WebSocket.h
@@ -228,6 +228,11 @@ public:
     size_t getBufferedAmount() const;
 
     /**
+    * @brief Returns the extensions selected by the server.
+    */
+    std::string getExtensions() const;
+
+    /**
      *  @brief Gets the protocol selected by websocket server.
      */
     const std::string& getProtocol() const;

--- a/cocos/network/WebSocket.h
+++ b/cocos/network/WebSocket.h
@@ -212,6 +212,16 @@ public:
     void closeAsync();
 
     /**
+    *  @brief Closes the connection to server asynchronously.
+    *  @note It's an asynchronous method, it just notifies websocket thread to exit and returns directly,
+    *        If using 'closeAsync' to close websocket connection,
+    *        be careful of not using destructed variables in the callback of 'onClose'.
+    *  @param code close reason
+    *  @param reason reason text description
+    */
+    void closeAsync(int code, const std::string &reason);
+
+    /**
      *  @brief Gets current state of connection.
      *  @return State the state value could be State::CONNECTING, State::OPEN, State::CLOSING or State::CLOSED
      */

--- a/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
@@ -489,6 +489,23 @@ static bool WebSocket_getBufferedAmount(se::State& s)
 }
 SE_BIND_PROP_GET(WebSocket_getBufferedAmount)
 
+static bool WebSocket_getExtensions(se::State& s)
+{
+    const auto& args = s.args();
+    int argc = (int)args.size();
+
+    if (argc == 0)
+    {
+        WebSocket* cobj = (WebSocket*)s.nativeThisObject();
+        s.rval().setString(cobj->getExtensions());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting 0", argc);
+    return false;
+}
+SE_BIND_PROP_GET(WebSocket_getExtensions)
+
+
 bool register_all_websocket(se::Object* obj)
 {
     se::Class* cls = se::Class::create("WebSocket", obj, nullptr, _SE(WebSocket_constructor));
@@ -498,6 +515,7 @@ bool register_all_websocket(se::Object* obj)
     cls->defineFunction("close", _SE(WebSocket_close));
     cls->defineProperty("readyState", _SE(WebSocket_getReadyState), nullptr);
     cls->defineProperty("bufferedAmount", _SE(WebSocket_getBufferedAmount), nullptr);
+    cls->defineProperty("extensions", _SE(WebSocket_getExtensions), nullptr);
 
     cls->install();
 

--- a/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
@@ -477,7 +477,7 @@ static bool WebSocket_close(se::State& s)
         std::string reasonString;
         seval_to_int32(args[0], &reasonCode);
         seval_to_std_string(args[1], &reasonString);
-        cobj->closeAsync(1005, reasonString);
+        cobj->closeAsync(reasonCode, reasonString);
     }
     else 
     {

--- a/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
@@ -442,8 +442,47 @@ SE_BIND_FUNC(WebSocket_send)
 
 static bool WebSocket_close(se::State& s)
 {
+    const auto& args = s.args();
+    int argc = (int)args.size();
+
     WebSocket* cobj = (WebSocket*)s.nativeThisObject();
-    cobj->closeAsync();
+    if(argc == 0)
+    {
+        cobj->closeAsync();
+    }
+    else if (argc == 1)
+    {
+        if (args[0].isNumber())
+        {
+            int reason;
+            seval_to_int32(args[0], &reason);
+            cobj->closeAsync(reason, "no_reason");
+        }
+        else if (args[0].isString())
+        {
+            std::string reason;
+            seval_to_std_string(args[0], &reason);
+            cobj->closeAsync(1005, reason);
+        }
+        else
+        {
+            assert(false);
+        }
+    }
+    else if (argc == 2)
+    {
+        assert(args[0].isNumber());
+        assert(args[1].isString());
+        int reasonCode;
+        std::string reasonString;
+        seval_to_int32(args[0], &reasonCode);
+        seval_to_std_string(args[1], &reasonString);
+        cobj->closeAsync(1005, reasonString);
+    }
+    else 
+    {
+        assert(false);
+    }
     // Attach current WebSocket instance to global object to prevent WebSocket instance
     // being garbage collected after "ws.close(); ws = null;"
     // There is a state that current WebSocket JS instance is being garbaged but its finalize

--- a/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
@@ -473,6 +473,22 @@ static bool WebSocket_getReadyState(se::State& s)
 }
 SE_BIND_PROP_GET(WebSocket_getReadyState)
 
+static bool WebSocket_getBufferedAmount(se::State& s)
+{
+    const auto& args = s.args();
+    int argc = (int)args.size();
+
+    if (argc == 0)
+    {
+        WebSocket* cobj = (WebSocket*)s.nativeThisObject();
+        s.rval().setUint32((uint32_t)cobj->getBufferedAmount());
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting 0", argc);
+    return false;
+}
+SE_BIND_PROP_GET(WebSocket_getBufferedAmount)
+
 bool register_all_websocket(se::Object* obj)
 {
     se::Class* cls = se::Class::create("WebSocket", obj, nullptr, _SE(WebSocket_constructor));
@@ -481,6 +497,7 @@ bool register_all_websocket(se::Object* obj)
     cls->defineFunction("send", _SE(WebSocket_send));
     cls->defineFunction("close", _SE(WebSocket_close));
     cls->defineProperty("readyState", _SE(WebSocket_getReadyState), nullptr);
+    cls->defineProperty("bufferedAmount", _SE(WebSocket_getBufferedAmount), nullptr);
 
     cls->install();
 

--- a/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
@@ -1020,6 +1020,10 @@ static bool XMLHttpRequest_setResponseType(se::State& s)
         {
             xhr->setResponseType(XMLHttpRequest::ResponseType::JSON);
         }
+        else if (type == "document")
+        {
+            xhr->setResponseType(XMLHttpRequest::ResponseType::DOCUMENT);
+        }
         else
         {
             SE_PRECONDITION2(false, false, "The response type isn't supported!");

--- a/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
@@ -877,17 +877,9 @@ SE_BIND_PROP_GET(XMLHttpRequest_getResponseText)
 
 static bool XMLHttpRequest_getResponseXML(se::State& s)
 {
-    // do not generate document object here, return a string instead.
-    // jsb-adapter will convert this into a document
-    XMLHttpRequest* xhr = (XMLHttpRequest*)s.nativeThisObject();
-    if (xhr->getResponseType() == XMLHttpRequest::ResponseType::DOCUMENT)
-    {
-        s.rval().setString(xhr->getResponseText());
-    }
-    else
-    {
-        s.rval().setNull();
-    }
+    // DOM API is not fully supported in cocos2d-x-lite.
+    // `.responseXML` requires a document object that is not possible to fulfill. 
+    s.rval().setNull();
     return true;
 }
 SE_BIND_PROP_GET(XMLHttpRequest_getResponseXML)
@@ -1061,7 +1053,7 @@ bool register_all_xmlhttprequest(se::Object* global)
     cls->defineProperty("status", _SE(XMLHttpRequest_getStatus), nullptr);
     cls->defineProperty("statusText", _SE(XMLHttpRequest_getStatusText), nullptr);
     cls->defineProperty("responseText", _SE(XMLHttpRequest_getResponseText), nullptr);
-    cls->defineProperty("__responseXML", _SE(XMLHttpRequest_getResponseXML), nullptr);
+    cls->defineProperty("responseXML", _SE(XMLHttpRequest_getResponseXML), nullptr);
     cls->defineProperty("response", _SE(XMLHttpRequest_getResponse), nullptr);
     cls->defineProperty("timeout", _SE(XMLHttpRequest_getTimeout), _SE(XMLHttpRequest_setTimeout));
     cls->defineProperty("responseType", _SE(XMLHttpRequest_getResponseType), _SE(XMLHttpRequest_setResponseType));

--- a/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
@@ -324,10 +324,10 @@ void XMLHttpRequest::getHeader(const std::string& header)
 
                 // Get Response Status
                 pch = strtok (nullptr, " ");
-                mystream << pch;
+                //mystream << pch;    //ignore HTTP statusCode 
 
                 pch = strtok (nullptr, " ");
-                mystream << " " << pch;
+                mystream << pch;
 
                 _statusText = mystream.str();
                 


### PR DESCRIPTION
WebSocket
1. 增加`void close(code, reason)`
2. 增加`bufferedAmount`属性
3. 增加`extensions`属性

XMLHttpRequest
1. `statusText` 修复`200 OK` -> `OK`
2. ~~`responseXML`~~

**由于缺乏完整的`DOM/document`实现,`XMLHttpRequest#responseXML`无法支持.**
