### PR TITLE
Xmlhttprequest abort readystate -> 0

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
@@ -240,7 +240,7 @@ void XMLHttpRequest::abort()
 
     _isAborted = true;
 
-    setReadyState(ReadyState::DONE);
+    setReadyState(ReadyState::UNSENT);
 
     if (onabort != nullptr)
     {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/abort
按照标准 `abort()` 后`readyState`值为0
> The `XMLHttpRequest.abort()` method aborts the request if it has already been sent. When a request is aborted, its `readyState` is changed to `XMLHttpRequest.UNSENT` and the request's status code is set to `0`.

