### PR TITLE
XMLHttpRequest fix readyState during onabort callback

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
@@ -257,7 +257,7 @@ void XMLHttpRequest::abort()
         onloadend();
     }
 
-    setReadyState(ReadyState::UNSENT);
+    _readyState = ReadyState::UNSENT;
 }
 
 void XMLHttpRequest::setReadyState(ReadyState readyState)

--- a/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_xmlhttprequest.cpp
@@ -244,7 +244,7 @@ void XMLHttpRequest::abort()
 
     _isAborted = true;
 
-    setReadyState(ReadyState::UNSENT);
+    setReadyState(ReadyState::DONE);
 
     if (onabort != nullptr)
     {
@@ -256,6 +256,8 @@ void XMLHttpRequest::abort()
     {
         onloadend();
     }
+
+    setReadyState(ReadyState::UNSENT);
 }
 
 void XMLHttpRequest::setReadyState(ReadyState readyState)


### PR DESCRIPTION
在回调`onabort` 期间`readyState`为`4`, 结束后后为`0`

相关 https://github.com/cocos-creator/cocos2d-x-lite/pull/1564