### PR TITLE
fix window.devicePixelRatio always be 1

### DIFF
--- a/cocos/platform/android/jni/JniImp.cpp
+++ b/cocos/platform/android/jni/JniImp.cpp
@@ -110,7 +110,9 @@ namespace
         se::ScriptEngine* se = se::ScriptEngine::getInstance();
         char commandBuf[200] = {0};
         uint8_t devicePixelRatio = Application::getInstance()->getDevicePixelRatio();
-        sprintf(commandBuf, "window.innerWidth = %d; window.innerHeight = %d;",
+        sprintf(commandBuf,
+                "window.devicePixelRatio = %d; window.innerWidth = %d; window.innerHeight = %d;",
+                devicePixelRatio,
                 g_width / devicePixelRatio,
                 g_height / devicePixelRatio);
         se->evalString(commandBuf);


### PR DESCRIPTION
## 问题说明
原有对于 `window.devicePixelRatio` 设置，是在 jsb-builtin.js 中，并且值恒等于 `1`，现在 rutime 需要设置 `CCApplication` 中的 `_devicePixelRatio` 打开离屏渲染，并且需要调用 `window.devicePixelRatio` 也能正常的获取到设置的值。