### PR TITLE
 free global g_textInputCallback before ScriptEngine clean up

### DIFF
--- a/cocos/ui/edit-box/EditBox-android.cpp
+++ b/cocos/ui/edit-box/EditBox-android.cpp
@@ -41,67 +41,66 @@ NS_CC_BEGIN
 
 void EditBox::show(const cocos2d::EditBox::ShowInfo& showInfo)
 {
-  JniHelper::callStaticVoidMethod(JCLS_EDITBOX,
-                                "showNative",
-                                showInfo.defaultValue,
-                                showInfo.maxLength,
-                                showInfo.isMultiline,
-                                showInfo.confirmHold,
-                                showInfo.confirmType,
-                                showInfo.inputType);
+	JniHelper::callStaticVoidMethod(JCLS_EDITBOX,
+		                            "showNative",
+		                            showInfo.defaultValue,
+		                            showInfo.maxLength,
+		                            showInfo.isMultiline,
+		                            showInfo.confirmHold,
+		                            showInfo.confirmType,
+		                            showInfo.inputType);
 }
 
 void EditBox::hide()
 {
-  JniHelper::callStaticVoidMethod(JCLS_EDITBOX, "hideNative");
+	JniHelper::callStaticVoidMethod(JCLS_EDITBOX, "hideNative");
 }
 
 NS_CC_END
 
 namespace
 {
-  se::Value textInputCallback;
+	se::Value textInputCallback;
 
-  void getTextInputCallback()
-  {
-    se::Value tmpVal;
-    if (! textInputCallback.isUndefined() && textInputCallback.toObject()->getProperty("input", &tmpVal))
-      return;
+	void getTextInputCallback()
+	{
+		if (! textInputCallback.isUndefined())
+			return;
 
-    auto global = se::ScriptEngine::getInstance()->getGlobalObject();
+		auto global = se::ScriptEngine::getInstance()->getGlobalObject();
         se::Value jsbVal;
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &textInputCallback);
         }
-  }
+	}
 
-  void callJSFunc(const std::string& type, const jstring& text)
-  {
-    getTextInputCallback();
+	void callJSFunc(const std::string& type, const jstring& text)
+	{
+		getTextInputCallback();
 
         se::AutoHandleScope scope;
-    se::ValueArray args;
-    args.push_back(se::Value(type));
-    args.push_back(se::Value(cocos2d::JniHelper::jstring2string(text)));
-    textInputCallback.toObject()->call(args, nullptr);
-  }
+		se::ValueArray args;
+		args.push_back(se::Value(type));
+		args.push_back(se::Value(cocos2d::JniHelper::jstring2string(text)));
+		textInputCallback.toObject()->call(args, nullptr);
+	}
 }
 
 extern "C" 
 {
-  JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardInputNative)(JNIEnv* env, jclass, jstring text)
-  {
-    callJSFunc("input", text);
-  }
+	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardInputNative)(JNIEnv* env, jclass, jstring text)
+	{
+		callJSFunc("input", text);
+	}
 
-  JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardCompleteNative)(JNIEnv* env, jclass, jstring text)
-  {
-    callJSFunc("complete", text);
-  }
+	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardCompleteNative)(JNIEnv* env, jclass, jstring text)
+	{
+		callJSFunc("complete", text);
+	}
 
-  JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardConfirmNative)(JNIEnv* env, jclass, jstring text)
-  {
+	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardConfirmNative)(JNIEnv* env, jclass, jstring text)
+	{
         callJSFunc("confirm", text);
-  }
+	}
 }

--- a/cocos/ui/edit-box/EditBox-android.cpp
+++ b/cocos/ui/edit-box/EditBox-android.cpp
@@ -41,33 +41,33 @@ NS_CC_BEGIN
 
 void EditBox::show(const cocos2d::EditBox::ShowInfo& showInfo)
 {
-	JniHelper::callStaticVoidMethod(JCLS_EDITBOX,
-		                            "showNative",
-		                            showInfo.defaultValue,
-		                            showInfo.maxLength,
-		                            showInfo.isMultiline,
-		                            showInfo.confirmHold,
-		                            showInfo.confirmType,
-		                            showInfo.inputType);
+    JniHelper::callStaticVoidMethod(JCLS_EDITBOX,
+                                    "showNative",
+                                    showInfo.defaultValue,
+                                    showInfo.maxLength,
+                                    showInfo.isMultiline,
+                                    showInfo.confirmHold,
+                                    showInfo.confirmType,
+                                    showInfo.inputType);
 }
 
 void EditBox::hide()
 {
-	JniHelper::callStaticVoidMethod(JCLS_EDITBOX, "hideNative");
+    JniHelper::callStaticVoidMethod(JCLS_EDITBOX, "hideNative");
 }
 
 NS_CC_END
 
 namespace
 {
-	se::Value textInputCallback;
+    se::Value textInputCallback;
 
-	void getTextInputCallback()
-	{
-		if (! textInputCallback.isUndefined())
-			return;
+    void getTextInputCallback()
+    {
+        if (! textInputCallback.isUndefined())
+            return;
 
-		auto global = se::ScriptEngine::getInstance()->getGlobalObject();
+        auto global = se::ScriptEngine::getInstance()->getGlobalObject();
         se::Value jsbVal;
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
@@ -77,34 +77,34 @@ namespace
                 textInputCallback.setUndefined();
             });
         }
-	}
+    }
 
-	void callJSFunc(const std::string& type, const jstring& text)
-	{
-		getTextInputCallback();
+    void callJSFunc(const std::string& type, const jstring& text)
+    {
+        getTextInputCallback();
 
         se::AutoHandleScope scope;
-		se::ValueArray args;
-		args.push_back(se::Value(type));
-		args.push_back(se::Value(cocos2d::JniHelper::jstring2string(text)));
-		textInputCallback.toObject()->call(args, nullptr);
-	}
+        se::ValueArray args;
+        args.push_back(se::Value(type));
+        args.push_back(se::Value(cocos2d::JniHelper::jstring2string(text)));
+        textInputCallback.toObject()->call(args, nullptr);
+    }
 }
 
 extern "C" 
 {
-	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardInputNative)(JNIEnv* env, jclass, jstring text)
-	{
-		callJSFunc("input", text);
-	}
+    JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardInputNative)(JNIEnv* env, jclass, jstring text)
+    {
+        callJSFunc("input", text);
+    }
 
-	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardCompleteNative)(JNIEnv* env, jclass, jstring text)
-	{
-		callJSFunc("complete", text);
-	}
+    JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardCompleteNative)(JNIEnv* env, jclass, jstring text)
+    {
+        callJSFunc("complete", text);
+    }
 
-	JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardConfirmNative)(JNIEnv* env, jclass, jstring text)
-	{
+    JNIEXPORT void JNICALL JNI_EDITBOX(onKeyboardConfirmNative)(JNIEnv* env, jclass, jstring text)
+    {
         callJSFunc("confirm", text);
-	}
+    }
 }

--- a/cocos/ui/edit-box/EditBox-android.cpp
+++ b/cocos/ui/edit-box/EditBox-android.cpp
@@ -72,6 +72,10 @@ namespace
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &textInputCallback);
+            // free globle se::Value before ScriptEngine clean up
+            se::ScriptEngine::getInstance()->addBeforeCleanupHook([](){
+                textInputCallback.setUndefined();
+            });
         }
 	}
 

--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -126,6 +126,10 @@ namespace
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &textInputCallback);
+            // free globle se::Value before ScriptEngine clean up
+            se::ScriptEngine::getInstance()->addBeforeCleanupHook([](){
+                textInputCallback.setUndefined();
+            });
         }
     }
     

--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -118,8 +118,7 @@ namespace
     
     void getTextInputCallback()
     {
-        se::Value tmpVal;
-        if (! textInputCallback.isUndefined() && textInputCallback.toObject()->getProperty("input", &tmpVal))
+        if (! textInputCallback.isUndefined())
             return;
         
         auto global = se::ScriptEngine::getInstance()->getGlobalObject();

--- a/cocos/ui/edit-box/EditBox-mac.mm
+++ b/cocos/ui/edit-box/EditBox-mac.mm
@@ -154,10 +154,9 @@ namespace
 {
     void getTextInputCallback()
     {
-        se::Value tmpVal;
-        if (! g_textInputCallback.isUndefined() && g_textInputCallback.toObject()->getProperty("input", &tmpVal))
+        if (! g_textInputCallback.isUndefined())
             return;
-
+        
         auto global = se::ScriptEngine::getInstance()->getGlobalObject();
         se::Value jsbVal;
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())

--- a/cocos/ui/edit-box/EditBox-mac.mm
+++ b/cocos/ui/edit-box/EditBox-mac.mm
@@ -162,6 +162,10 @@ namespace
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &g_textInputCallback);
+            // free globle se::Value before ScriptEngine clean up
+            se::ScriptEngine::getInstance()->addBeforeCleanupHook([](){
+                g_textInputCallback.setUndefined();
+            });
         }
     }
     

--- a/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/cocos/ui/edit-box/EditBox-win32.cpp
@@ -67,6 +67,10 @@ namespace
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &g_textInputCallback);
+            // free globle se::Value before ScriptEngine clean up
+            se::ScriptEngine::getInstance()->addBeforeCleanupHook([](){
+                g_textInputCallback.setUndefined();
+            });
         }
     }
 

--- a/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/cocos/ui/edit-box/EditBox-win32.cpp
@@ -59,8 +59,7 @@ namespace
 
     void getTextInputCallback()
     {
-        se::Value tmpVal;
-        if (! g_textInputCallback.isUndefined() && g_textInputCallback.toObject()->getProperty("input", &tmpVal))
+        if (!g_textInputCallback.isUndefined())
             return;
 
         auto global = se::ScriptEngine::getInstance()->getGlobalObject();


### PR DESCRIPTION
修复: https://github.com/cocos-creator/2d-tasks/issues/726

- 合理释放 EditBox 中的全局 `se::Value g_textInputCallback`

> 同时对于 https://github.com/cocos-creator/2d-tasks/issues/647 是一个更好的修复