### PR TITLE
free global g_textInputCallback before ScriptEngine clean up

### DIFF
--- a/cocos/ui/edit-box/EditBox-android.cpp
+++ b/cocos/ui/edit-box/EditBox-android.cpp
@@ -72,6 +72,10 @@ namespace
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &textInputCallback);
+            // free globle se::Value before ScriptEngine clean up
+            se::ScriptEngine::getInstance()->addBeforeCleanupHook([](){
+                textInputCallback.setUndefined();
+            });
         }
 	}
 

--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -126,6 +126,10 @@ namespace
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &textInputCallback);
+            // free globle se::Value before ScriptEngine clean up
+            se::ScriptEngine::getInstance()->addBeforeCleanupHook([](){
+                textInputCallback.setUndefined();
+            });
         }
     }
     

--- a/cocos/ui/edit-box/EditBox-mac.mm
+++ b/cocos/ui/edit-box/EditBox-mac.mm
@@ -162,6 +162,10 @@ namespace
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &g_textInputCallback);
+            // free globle se::Value before ScriptEngine clean up
+            se::ScriptEngine::getInstance()->addBeforeCleanupHook([](){
+                g_textInputCallback.setUndefined();
+            });
         }
     }
     

--- a/cocos/ui/edit-box/EditBox-win32.cpp
+++ b/cocos/ui/edit-box/EditBox-win32.cpp
@@ -67,6 +67,10 @@ namespace
         if (global->getProperty("jsb", &jsbVal) && jsbVal.isObject())
         {
             jsbVal.toObject()->getProperty("onTextInput", &g_textInputCallback);
+            // free globle se::Value before ScriptEngine clean up
+            se::ScriptEngine::getInstance()->addBeforeCleanupHook([](){
+                g_textInputCallback.setUndefined();
+            });
         }
     }
 


### PR DESCRIPTION
在 2.0 分支修复，https://github.com/cocos-creator/2d-tasks/issues/647

- EditBox 的全局 `se::Value textInputCallback ` 未正确释放

> 关联 2.1 的修复：https://github.com/cocos-creator/cocos2d-x-lite/pull/1575