### PR TITLE
improve cc Data memory control

### DIFF
--- a/cocos/base/CCData.cpp
+++ b/cocos/base/CCData.cpp
@@ -113,7 +113,7 @@ void Data::copy(const unsigned char* bytes, const ssize_t size)
 
 void Data::fastSet(unsigned char* bytes, const ssize_t size)
 {
-    clear();
+    free(_bytes);
     _bytes = bytes;
     _size = size;
 }
@@ -130,7 +130,9 @@ unsigned char* Data::takeBuffer(ssize_t* size)
     auto buffer = getBytes();
     if (size)
         *size = getSize();
-    fastSet(nullptr, 0);
+
+    _bytes = nullptr;
+    _size = 0;
     return buffer;
 }
 

--- a/cocos/base/CCData.h
+++ b/cocos/base/CCData.h
@@ -141,7 +141,7 @@ public:
      * @param size Will fill with the data buffer size in bytes, if you do not care buffer size, pass nullptr.
      * @return the internal data buffer, free it after use.
      */
-    unsigned char* takeBuffer(ssize_t* size);
+    unsigned char* takeBuffer(ssize_t* size = nullptr);
 private:
     void move(Data& other);
 

--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -574,11 +574,12 @@ FileUtils::~FileUtils()
 bool FileUtils::writeStringToFile(const std::string& dataStr, const std::string& fullPath)
 {
     Data data;
-    data.copy((unsigned char*)dataStr.c_str(), dataStr.size());
+    data.fastSet((unsigned char*)dataStr.c_str(), dataStr.size());
 
     bool rv = writeDataToFile(data, fullPath);
 
-    data.fastSet(nullptr, 0);
+    // need to give up buffer ownership for temp using, or double free will occur
+    data.takeBuffer();
     return rv;
 }
 

--- a/cocos/platform/CCFileUtils.h
+++ b/cocos/platform/CCFileUtils.h
@@ -103,7 +103,8 @@ public:
     virtual void resize(size_t size) override {
         size_t oldSize = static_cast<size_t>(_buffer->getSize());
         if (oldSize != size) {
-            auto old = _buffer->getBytes();
+            // need to take buffer ownership for outer memory control
+            auto old = _buffer->takeBuffer();
             void* buffer = realloc(old, size);
             if (buffer)
                 _buffer->fastSet((unsigned char*)buffer, size);


### PR DESCRIPTION
- 按照在 https://github.com/cocos-creator/cocos2d-x-lite/pull/1462 中 @dumganhar 提出的解决方式，完善 Data

- 解决 `ResizableBufferAdapter<Data>` 中使用 `fasetSet` 可能会引起的 double free. [论坛反馈](https://forum.cocos.com/t/cocos-creator-v2-0-5-1030-rc-2/68353/126)


----

> creator 1.x 的 `fasetSet` 是不会释放内存的，后在 https://github.com/cocos-creator/cocos2d-x-lite/commit/eab79d9a697bb8318fea9a26db57501a76c96289 改为了释放，所以其它地方需要做调整