### PR TITLE
update gradle to 4.4, plugin 3.1.4

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/CanvasRenderingContext2DImpl.java
@@ -191,7 +191,7 @@ public class CanvasRenderingContext2DImpl {
         if(obliqueFont) {
             paint.setTextSkewX(_sApproximatingOblique);
         }
-        if(smallCapsFontVariant && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if(smallCapsFontVariant && Build.VERSION.SDK_INT >= 21) {
             paint.setFontFeatureSettings("smcp");
         }
         return paint;

--- a/templates/js-template-android-instant/frameworks/runtime-src/proj.android-studio/build.gradle
+++ b/templates/js-template-android-instant/frameworks/runtime-src/proj.android-studio/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
 
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/templates/js-template-android-instant/frameworks/runtime-src/proj.android-studio/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/js-template-android-instant/frameworks/runtime-src/proj.android-studio/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/build.gradle
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
 
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/build.gradle
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
 
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
- 原 gradle 插件是 android studio 3.0 的，和 ndk-r18 搭配在一起有已知问题:
https://android.googlesource.com/platform/ndk/+/ndk-release-r18/CHANGELOG.md

- ndk18 与 gradle plugin 3.0 的 issue 是：
> This version of the NDK is incompatible with the Android Gradle plugin version 3.0 or older. If you see an error like No toolchains found in the NDK toolchains folder for ABI with prefix: mips64el-linux-android, update your project file to use plugin version 3.1 or newer. You will also need to upgrade to Android Studio 3.1 or newer.

- 官方建议更新至 3.1+ ，现更新为 3.1.4 对应（Android Studio 3.1.4），如果使用 Android Studio 3.2 不要根据提示更新 Gradle 至 android plugin 3.2（gradle 4.6），因为 gradle 4.6 有已知 issues 会导致资源打包结果为空。

- gradle 4.6 已知 issues 是：

https://developer.android.com/studio/known-issues
> Modifying variant outputs at build time may not work
Using the Variant API to manipulate variant outputs is broken with the new plugin. It still works for simple tasks, such as changing the APK name during build time, as shown below: