### PR TITLE
Add USE_V8_DEBUGGER to control chrome debugger

### DIFF
--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -84,6 +84,9 @@ ui/edit-box/EditBox-android.cpp
 
 # only compile v8 debugger in DEBUG mode
 ifeq ($(NDK_DEBUG),1)
+USE_V8_DEBUGGER := 1
+endif
+ifeq ($(USE_V8_DEBUGGER),1)
 LOCAL_SRC_FILES += \
 scripting/js-bindings/jswrapper/v8/debugger/SHA1.cpp \
 scripting/js-bindings/jswrapper/v8/debugger/util.cc \

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -58,18 +58,6 @@ THE SOFTWARE.
 #define USE_NET_WORK 1
 #endif
 
-#ifndef USE_V8_DEBUGGER
-    #ifdef COCOS2D_DEBUG
-        #if COCOS2D_DEBUG > 0
-            #define USE_V8_DEBUGGER 1
-        #else
-            #define USE_V8_DEBUGGER 0
-        #endif
-    #else
-        #define USE_V8_DEBUGGER 0
-    #endif
-#endif
-
 /** @def CC_ENABLE_STACKABLE_ACTIONS
  * If enabled, actions that alter the position property (eg: MoveBy, JumpBy, BezierBy, etc..) will be stacked.
  * If you run 2 or more 'position' actions at the same time on a node, then end position will be the sum of all the positions.

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -58,6 +58,14 @@ THE SOFTWARE.
 #define USE_NET_WORK 1
 #endif
 
+#ifndef USE_V8_DEBUGGER
+#if define(COCOS2D_DEBUG) && COCOS2D_DEBUG > 0
+#define USE_V8_DEBUGGER 1
+#else
+#define USE_V8_DEBUGGER 0
+#endif
+#endif
+
 /** @def CC_ENABLE_STACKABLE_ACTIONS
  * If enabled, actions that alter the position property (eg: MoveBy, JumpBy, BezierBy, etc..) will be stacked.
  * If you run 2 or more 'position' actions at the same time on a node, then end position will be the sum of all the positions.

--- a/cocos/base/ccConfig.h
+++ b/cocos/base/ccConfig.h
@@ -59,11 +59,15 @@ THE SOFTWARE.
 #endif
 
 #ifndef USE_V8_DEBUGGER
-#if define(COCOS2D_DEBUG) && COCOS2D_DEBUG > 0
-#define USE_V8_DEBUGGER 1
-#else
-#define USE_V8_DEBUGGER 0
-#endif
+    #ifdef COCOS2D_DEBUG
+        #if COCOS2D_DEBUG > 0
+            #define USE_V8_DEBUGGER 1
+        #else
+            #define USE_V8_DEBUGGER 0
+        #endif
+    #else
+        #define USE_V8_DEBUGGER 0
+    #endif
 #endif
 
 /** @def CC_ENABLE_STACKABLE_ACTIONS

--- a/cocos/scripting/js-bindings/jswrapper/config.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/config.hpp
@@ -45,6 +45,14 @@
     #error "Unknown Script Engine"
 #endif
 
+#ifndef USE_V8_DEBUGGER
+#if defined(COCOS2D_DEBUG) && COCOS2D_DEBUG > 0
+#define USE_V8_DEBUGGER 1
+#else
+#define USE_V8_DEBUGGER 0
+#endif
+#endif
+
 #if !defined(ANDROID_INSTANT) && defined(USE_V8_DEBUGGER) && USE_V8_DEBUGGER > 0
 #define SE_ENABLE_INSPECTOR 1
 #define SE_DEBUG 2

--- a/cocos/scripting/js-bindings/jswrapper/config.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/config.hpp
@@ -45,7 +45,7 @@
     #error "Unknown Script Engine"
 #endif
 
-#if !defined(ANDROID_INSTANT) && defined(COCOS2D_DEBUG) && COCOS2D_DEBUG > 0
+#if !defined(ANDROID_INSTANT) && defined(USE_V8_DEBUGGER) && USE_V8_DEBUGGER > 0
 #define SE_ENABLE_INSPECTOR 1
 #define SE_DEBUG 2
 #define HAVE_INSPECTOR 1


### PR DESCRIPTION
## 需求
希望在 release 模式下也能够正常的使用 chrome 调试 JS 代码。

## 使用
修改代码后，默认在 release 模式下时无法使用 chrome 调试代码的，需要修改 Application.mk 文件，添加下列代码

```
USE_V8_DEBUGGER := 1
APP_CPPFLAGS += -DUSE_V8_DEBUGGER=${USE_V8_DEBUGGER}
APP_CFLAGS += -DUSE_V8_DEBUGGER=${USE_V8_DEBUGGER}
```
