### PR TITLE
[WIP] not push root view when EditBox pop on Android

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -67,6 +67,7 @@ public class Cocos2dxEditBox {
     private boolean mConfirmHold = true;
     private Cocos2dxActivity mActivity = null;
     private RelativeLayout mButtonLayout = null;
+    private RelativeLayout mEditBoxLayout = null;
     private RelativeLayout.LayoutParams mButtonParams;
     private int mEditTextID = 1;
     private int mButtonLayoutID = 2;
@@ -234,6 +235,15 @@ public class Cocos2dxEditBox {
                     // if more than a quarter of the screen, its probably a keyboard
                     if (heightDiff > mScreenHeight/4) {
                         if (!keyboardVisible) {
+                            Cocos2dxEditBox.sThis.mActivity.runOnUiThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
+                                            RelativeLayout.LayoutParams.WRAP_CONTENT);
+                                    layoutParams.topMargin = r.bottom - r.top - mEditBoxLayout.getHeight();
+                                    mEditBoxLayout.setLayoutParams(layoutParams);
+                                }
+                            });
                             keyboardVisible = true;
                         }
                     } else {
@@ -266,14 +276,11 @@ public class Cocos2dxEditBox {
      Private functions.
      **************************************************************************************/
     private void addItems(Cocos2dxActivity context, RelativeLayout layout) {
-        RelativeLayout myLayout = new RelativeLayout(context);
-        this.addEditText(context, myLayout);
-        this.addButton(context, myLayout);
+        mEditBoxLayout = new RelativeLayout(context);
+        this.addEditText(context, mEditBoxLayout);
+        this.addButton(context, mEditBoxLayout);
 
-        RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT);
-        layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
-        layout.addView(myLayout, layoutParams);
+        layout.addView(mEditBoxLayout);
 
         //FXI ME: Is it needed?
         // When touch area outside EditText and soft keyboard, then hide.

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -235,15 +235,11 @@ public class Cocos2dxEditBox {
                     // if more than a quarter of the screen, its probably a keyboard
                     if (heightDiff > mScreenHeight/4) {
                         if (!keyboardVisible) {
-                            Cocos2dxEditBox.sThis.mActivity.runOnUiThread(new Runnable() {
-                                @Override
-                                public void run() {
-                                    RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
-                                            RelativeLayout.LayoutParams.WRAP_CONTENT);
-                                    layoutParams.topMargin = r.bottom - r.top - mEditBoxLayout.getHeight();
-                                    mEditBoxLayout.setLayoutParams(layoutParams);
-                                }
-                            });
+                            RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(
+                                    RelativeLayout.LayoutParams.MATCH_PARENT,
+                                    RelativeLayout.LayoutParams.WRAP_CONTENT);
+                            layoutParams.topMargin = r.bottom - r.top - mEditBoxLayout.getHeight();
+                            mEditBoxLayout.setLayoutParams(layoutParams);
                             keyboardVisible = true;
                         }
                     } else {


### PR DESCRIPTION
for https://github.com/cocos-creator/2d-tasks/issues/804 , 目前虽然可以达到这个效果，但是很生硬，__不要合并__

- EditBox 的出现不像 iOS 一样，可以随键盘推出

> 键盘的弹出是有动画的，但是 EditBox 的位置确定是瞬间的

- 进入游戏，第一次打开 EditBox 会先出现再顶部，再瞬间移动到确定的位置

> 在键盘要弹出前，暂时无法拿到键盘高度