### PR TITLE
fix typo at jsb_opengl_manual.cpp

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
@@ -4117,7 +4117,7 @@ static bool JSB_glGetParameter(se::State& s)
         case GL_STENCIL_VALUE_MASK:
         case GL_STENCIL_WRITEMASK:
             JSB_GL_CHECK(glGetIntegerv(pname, intbuffer));
-            ret.setUint32((u_int32_t )intbuffer[0]);
+            ret.setUint32((uint32_t)intbuffer[0]);
             break;
 
         case GL_STENCIL_BACK_REF:


### PR DESCRIPTION
错误发生在 https://github.com/cocos-creator/cocos2d-x-lite/pull/1591