### PR TITLE
修正音乐文件不在OBB时无法加载的bug

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -97,7 +97,7 @@ static int fdGetter(const std::string& url, off_t* start, off_t* length)
     {
         fd = getObbAssetFileDescriptorJNI(url.c_str(), start, length);
     } 
-    else
+    if (fd <= 0)
     {
         auto asset = AAssetManager_open(cocos2d::FileUtilsAndroid::getAssetManager(), url.c_str(), AASSET_MODE_UNKNOWN);
         // open asset as file descriptor


### PR DESCRIPTION
在使用OBB扩展包时，如果音乐文件没有在OBB中，会读取不到
优化一下判断逻辑，当OBB包中没有时，再检查一下apk assets中是否存在