### PR TITLE
add getCurrentLanguageCode 

### DIFF
--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -129,7 +129,7 @@ void Application::setPreferredFramesPerSecond(int fps)
 std::string Application::getCurrentLanguageCode() const
 {
     std::string language = getCurrentLanguageJNI();
-    return language.substr(0, 2);
+    return language;
 }
 
 bool Application::isDisplayStats() {

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -273,17 +273,10 @@ void Application::setPreferredFramesPerSecond(int fps)
 
 std::string Application::getCurrentLanguageCode() const
 {
-    char code[3]={0};
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSArray *languages = [defaults objectForKey:@"AppleLanguages"];
     NSString *currentLanguage = [languages objectAtIndex:0];
-
-    // get the current language code.(such as English is "en", Chinese is "zh" and so on)
-    NSDictionary* temp = [NSLocale componentsFromLocaleIdentifier:currentLanguage];
-    NSString * languageCode = [temp objectForKey:NSLocaleLanguageCode];
-    [languageCode getCString:code maxLength:3 encoding:NSASCIIStringEncoding];
-    code[2]='\0';
-    return std::string(code);
+    return [currentLanguage UTF8String];
 }
 
 bool Application::isDisplayStats() {

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -197,17 +197,10 @@ Application::Platform Application::getPlatform() const
 
 std::string Application::getCurrentLanguageCode() const
 {
-    static char code[3]={0};
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSArray *languages = [defaults objectForKey:@"AppleLanguages"];
     NSString *currentLanguage = [languages objectAtIndex:0];
-    
-    // get the current language code.(such as English is "en", Chinese is "zh" and so on)
-    NSDictionary* temp = [NSLocale componentsFromLocaleIdentifier:currentLanguage];
-    NSString * languageCode = [temp objectForKey:NSLocaleLanguageCode];
-    [languageCode getCString:code maxLength:3 encoding:NSASCIIStringEncoding];
-    code[2]='\0';
-    return code;
+    return [currentLanguage UTF8String];
 }
 
 bool Application::isDisplayStats() {

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -325,8 +325,7 @@ std::string Application::getCurrentLanguageCode() const
     LANGID lid = GetUserDefaultUILanguage();
     const LCID locale_id = MAKELCID(lid, SORT_DEFAULT);
     static char code[3] = { 0 };
-    GetLocaleInfoA(locale_id, LOCALE_SISO639LANGNAME, code, sizeof(code));
-    code[2] = '\0';
+    GetLocaleInfoA(locale_id, LOCALE_SISO639LANGNAME, code);
     return code;
 }
 

--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -607,6 +607,14 @@ static bool JSBCore_getCurrentLanguage(se::State& s)
 }
 SE_BIND_FUNC(JSBCore_getCurrentLanguage)
 
+static bool JSBCore_getCurrentLanguageCode(se::State& s)
+{
+    std::string language = Application::getInstance()->getCurrentLanguageCode();
+    s.rval().setString(language);
+    return true;
+}
+SE_BIND_FUNC(JSBCore_getCurrentLanguageCode)
+
 static bool JSB_getOSVersion(se::State& s)
 {
     std::string systemVersion = Application::getInstance()->getSystemVersion();
@@ -1143,6 +1151,7 @@ bool jsb_register_global_variables(se::Object* global)
     global->defineFunction("__getOS", _SE(JSBCore_os));
     global->defineFunction("__getOSVersion", _SE(JSB_getOSVersion));
     global->defineFunction("__getCurrentLanguage", _SE(JSBCore_getCurrentLanguage));
+    global->defineFunction("__getCurrentLanguageCode", _SE(JSBCore_getCurrentLanguageCode));
     global->defineFunction("__getVersion", _SE(JSBCore_version));
     global->defineFunction("__restartVM", _SE(JSB_core_restartVM));
     global->defineFunction("__cleanScript", _SE(JSB_cleanScript));


### PR DESCRIPTION
@drelaptop 

关联：https://github.com/cocos-creator/engine/pull/3671

完善在 native 使用 getCurrentLanguageCode 返回各个平台的系统完整的语言