### PR TITLE
fix getCurrentLanguageCode erro for windows

### DIFF
--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -325,7 +325,7 @@ std::string Application::getCurrentLanguageCode() const
     LANGID lid = GetUserDefaultUILanguage();
     const LCID locale_id = MAKELCID(lid, SORT_DEFAULT);
     static char code[3] = { 0 };
-    GetLocaleInfoA(locale_id, LOCALE_SISO639LANGNAME, code);
+    GetLocaleInfoA(locale_id, LOCALE_SISO639LANGNAME, code, sizeof(code));
     return code;
 }
 


### PR DESCRIPTION
CCApplication-win32 中的 getCurrentLanguageCode len 参数是必要的