### PR TITLE
improve error log when require failed by JSB

### DIFF
--- a/cocos/platform/CCFileUtils.cpp
+++ b/cocos/platform/CCFileUtils.cpp
@@ -1431,7 +1431,9 @@ long FileUtils::getFileSize(const std::string &filepath)
 //////////////////////////////////////////////////////////////////////////
 // Notification support when getFileData from invalid file path.
 //////////////////////////////////////////////////////////////////////////
-static bool s_popupNotify = true;
+
+/* Default to false, enable it by setPopupNotify if needed */
+static bool s_popupNotify = false;
 
 void FileUtils::setPopupNotify(bool notify)
 {

--- a/cocos/scripting/js-bindings/jswrapper/chakracore/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/chakracore/ScriptEngine.cpp
@@ -470,6 +470,7 @@ namespace se {
 
         if (errCode != JsNoError)
         {
+            SE_LOGE("ScriptEngine::evalString script %s, failed!\n", fileName);
             clearException();
             return false;
         }

--- a/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.mm
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.mm
@@ -607,6 +607,11 @@ namespace se {
                 internal::jsToSeValue(_cx, result, ret);
         }
 
+        if (!ok)
+        {
+            SE_LOGE("ScriptEngine::evalString script %s, failed!\n", fileName);
+        }
+
         _clearException(exception);
 
         return ok;

--- a/cocos/scripting/js-bindings/jswrapper/sm/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/sm/ScriptEngine.cpp
@@ -1095,6 +1095,11 @@ namespace se {
         {
             internal::jsToSeValue(_cx, rval, ret);
         }
+
+        if (!ok)
+        {
+            SE_LOGE("ScriptEngine::evalString script %s, failed!\n", fileName);
+        }
         return ok;
     }
 

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -667,7 +667,10 @@ namespace se {
             }
         }
 
-//        assert(success);
+        if (!success)
+        {
+            SE_LOGE("ScriptEngine::evalString script %s, failed!\n", fileName);
+        }
         return success;
     }
 

--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -198,7 +198,13 @@ void jsb_init_file_operation_delegate()
                 }
             }
 
-            return FileUtils::getInstance()->getStringFromFile(path);
+            if (FileUtils::getInstance()->isFileExist(path)) {
+                return FileUtils::getInstance()->getStringFromFile(path);
+            }
+            else {
+                SE_LOGE("ScriptEngine::onGetStringFromFile %s not found, possible missing file.\n", path.c_str());
+            }
+            return "";
         };
 
         delegate.onGetFullPath = [](const std::string& path) -> std::string{


### PR DESCRIPTION
#### 原生 require 失败时，无法根据日志判断是 require 哪个文件失败，不利于定位问题

- 如果 require (不存在的文件) `jsb-adapter/Foo.js` 失败，旧的输出是：
```
[ERROR] Failed to invoke require, location: /Users/laptop/gitCode/fireball/cocos2d-x/cocos/scripting/js-bindings/manual/jsb_global.cpp:292
```
改动后的是
```
ScriptEngine::onGetStringFromFile jsb-adapter/Foo.js not found, possible missing file.
ScriptEngine::runScript script jsb-adapter/Foo.js, buffer is empty!
[ERROR] Failed to invoke require, location: /Users/laptop/gitCode/fireball/cocos2d-x/cocos/scripting/js-bindings/manual/jsb_global.cpp:292
```
  - 如果 require 脚本，文件存在，但执行出错，日志会像是：

```
ScriptEngine::evalString script jsb-adapter/jsb-engine.js, failed!
[ERROR] Failed to invoke require, location: /Users/laptop/gitCode/fireball/cocos2d-x/cocos/scripting/js-bindings/manual/jsb_global.cpp:292
ERROR: Uncaught ReferenceError: cc is not defined, location: jsb-adapter/jsb-engine.js:0:0
STACK:
[0]13@jsb-adapter/jsb-engine.js:2391
[1]o@jsb-adapter/jsb-engine.js:1
[2]anonymous@jsb-adapter/jsb-engine.js:1
[3]1../jsb-assets-manager.js@jsb-adapter/jsb-engine.js:29
[4]o@jsb-adapter/jsb-engine.js:1
[5]r@jsb-adapter/jsb-engine.js:1
[6]anonymous@jsb-adapter/jsb-engine.js:1
[7]anonymous@main.js:190
ScriptEngine::evalString script main.js, failed!
```