### PR TITLE
fixed the compressed texture error

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -774,34 +774,33 @@ namespace
         imgInfo->hasAlpha = img->hasAlpha();
         imgInfo->hasPremultipliedAlpha = img->hasPremultipliedAlpha();
         imgInfo->compressed = img->isCompressed();
-        imgInfo->length = img->getWidth() * img->getHeight() * 4;
 
         // Convert to RGBA888 because standard web api will return only RGBA888.
         // If not, then it may have issue in glTexSubImage. For example, engine
         // will create a big texture, and update its content with small pictures.
         // The big texture is RGBA888, then the small picture should be the same
         // format, or it will cause 0x502 error on OpenGL ES 2.
-        uint8_t* dst = nullptr;
-        uint32_t length = imgInfo->length;
-        uint8_t* src = imgInfo->data;
-        switch(imgInfo->glFormat) {
-            case GL_RGBA: break;
-            case GL_LUMINANCE_ALPHA:
-                dst = convertIA2RGBA(length, src);
-                break;
-            case GL_ALPHA:
-            case GL_LUMINANCE:
-                dst = convertI2RGBA(length, src);
-                break;
-            case GL_RGB:
-                dst = convertRGB2RGBA(length, src);
-                break;
-            default:
-                SE_LOGE("unknown image format");
-                break;
-        }
+        if (!imgInfo->compressed && imgInfo.glFormat != GL_RGBA) {
+            imgInfo->length = img->getWidth() * img->getHeight() * 4;
+            uint8_t* dst = nullptr;
+            uint32_t length = imgInfo->length;
+            uint8_t* src = imgInfo->data;
+            switch(imgInfo->glFormat) {
+                case GL_LUMINANCE_ALPHA:
+                    dst = convertIA2RGBA(length, src);
+                    break;
+                case GL_ALPHA:
+                case GL_LUMINANCE:
+                    dst = convertI2RGBA(length, src);
+                    break;
+                case GL_RGB:
+                    dst = convertRGB2RGBA(length, src);
+                    break;
+                default:
+                    SE_LOGE("unknown image format");
+                    break;
+            }
 
-        if (imgInfo->glFormat != GL_RGBA) {
             imgInfo->data = dst;
             imgInfo->hasAlpha = true;
             imgInfo->bpp = 32;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/example-cases/pull/671
copy image data size doesn't match the compress data size
修复 2.1 compress texture 渲染报错问题。
因为之前提交代码不够严谨，导致 imgInfo->length 每次都会重新计算成 宽高 * signed_bytes