### PR TITLE
fix potential crash on websocket for lifecycle sync issues

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_websocket.cpp
@@ -332,7 +332,7 @@ static bool WebSocket_constructor(se::State& s)
             JSB_WebSocketDelegate* delegate = new (std::nothrow) JSB_WebSocketDelegate();
             if (cobj->init(*delegate, url, &protocols, caFilePath))
             {
-                delegate->setJSDelegate(se::Value(obj));
+                delegate->setJSDelegate(se::Value(obj, true));
                 cobj->retain(); // release in finalize function and onClose delegate method
                 delegate->retain(); // release in finalize function and onClose delegate method
             }
@@ -350,7 +350,7 @@ static bool WebSocket_constructor(se::State& s)
             JSB_WebSocketDelegate* delegate = new (std::nothrow) JSB_WebSocketDelegate();
             if (cobj->init(*delegate, url))
             {
-                delegate->setJSDelegate(se::Value(obj));
+                delegate->setJSDelegate(se::Value(obj, true));
                 cobj->retain(); // release in finalize function and onClose delegate method
                 delegate->retain(); // release in finalize function and onClose delegate method
             }


### PR DESCRIPTION
- 当 `JSDelegate` 保存的 js object 是临时对象时，可能被 GC，造成回调时 crash
- 一个特例是 runtime 的 ws 测试例，在 iOS 上的表现，https://github.com/cocos2d-x/cocos-game-client/pull/763