### PR TITLE
Fix clear dragon bones asset cause exception

### DIFF
--- a/cocos/editor-support/dragonbones-creator-support/CCFactory.cpp
+++ b/cocos/editor-support/dragonbones-creator-support/CCFactory.cpp
@@ -191,8 +191,6 @@ CCArmatureDisplay* CCFactory::buildArmatureDisplay(const std::string& armatureNa
     const auto armature = buildArmature(armatureName, dragonBonesName, skinName, textureAtlasName);
     if (armature != nullptr)
     {
-        _dragonBones->getClock()->add(armature);
-
         return static_cast<CCArmatureDisplay*>(armature->getDisplay());
     }
 


### PR DESCRIPTION
原生层加入了当dragonbones asset 释放的时候，自动释放DragonbonesData对象的机制，而某些测试例子中，把DragonBones节点当成了池子，却没有去释放这个池子，造成ArmatureData被释放，但Armature没有释放，于是clock保留了Armature对象，导致触发Exception，这里确保只有节点被加入到节点树时，才将Armature加入到clock中，避免释放资源时，触发Exception。