### PR TITLE
Improved audio engine interface to get any audio duration from its filepath

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -431,6 +431,18 @@ float AudioEngine::getDuration(int audioID)
     return TIME_UNKNOWN;
 }
 
+float AudioEngine::getDurationFromFile(const std::string& filePath)
+{
+    lazyInit();
+
+    if (_audioEngineImpl)
+    {
+        return _audioEngineImpl->getDurationFromFile(filePath);
+    }
+
+    return TIME_UNKNOWN;
+}
+
 bool AudioEngine::setCurrentTime(int audioID, float time)
 {
     auto it = _audioIDInfoMap.find(audioID);

--- a/cocos/audio/android/AudioEngine-inl.cpp
+++ b/cocos/audio/android/AudioEngine-inl.cpp
@@ -400,6 +400,16 @@ float AudioEngineImpl::getDuration(int audioID)
     return 0.0f;
 }
 
+float AudioEngineImpl::getDurationFromFile(const std::string &filePath)
+{
+    if (_audioPlayerProvider != nullptr)
+    {
+        auto fullPath = FileUtils::getInstance()->fullPathForFilename(filePath);
+        return _audioPlayerProvider->getDurationFromFile(fullPath);
+    }
+    return 0;
+}
+
 float AudioEngineImpl::getCurrentTime(int audioID)
 {
     auto iter = _audioPlayers.find(audioID);

--- a/cocos/audio/android/AudioEngine-inl.h
+++ b/cocos/audio/android/AudioEngine-inl.h
@@ -64,6 +64,7 @@ public:
     void stop(int audioID);
     void stopAll();
     float getDuration(int audioID);
+    float getDurationFromFile(const std::string &fileFullPath);
     float getCurrentTime(int audioID);
     bool setCurrentTime(int audioID, float time);
     void setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback);

--- a/cocos/audio/android/AudioPlayerProvider.cpp
+++ b/cocos/audio/android/AudioPlayerProvider.cpp
@@ -431,6 +431,16 @@ bool AudioPlayerProvider::isSmallFile(const AudioFileInfo &info)
     return info.length < __audioFileIndicator[0].smallSizeIndicator;
 }
 
+float AudioPlayerProvider::getDurationFromFile(const std::string &filePath)
+{
+    std::lock_guard<std::mutex> lk(_pcmCacheMutex);
+    auto iter = _pcmCache.find(filePath);
+    if (iter != _pcmCache.end()){
+        return iter->second.duration;
+    }
+    return 0;
+}
+
 void AudioPlayerProvider::clearPcmCache(const std::string &audioFilePath)
 {
     std::lock_guard<std::mutex> lk(_pcmCacheMutex);

--- a/cocos/audio/android/AudioPlayerProvider.h
+++ b/cocos/audio/android/AudioPlayerProvider.h
@@ -58,6 +58,7 @@ public:
     typedef std::function<void(bool/* succeed */, PcmData /* data */)> PreloadCallback;
     void preloadEffect(const std::string &audioFilePath, const PreloadCallback& cb);
 
+    float getDurationFromFile(const std::string &filePath);
     void clearPcmCache(const std::string &audioFilePath);
 
     void clearAllPcmCaches();

--- a/cocos/audio/apple/AudioEngine-inl.h
+++ b/cocos/audio/apple/AudioEngine-inl.h
@@ -55,6 +55,7 @@ public:
     void stop(int audioID);
     void stopAll();
     float getDuration(int audioID);
+    float getDurationFromFile(const std::string &fileFullPath);
     float getCurrentTime(int audioID);
     bool setCurrentTime(int audioID, float time);
     void setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback);

--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -574,6 +574,17 @@ float AudioEngineImpl::getDuration(int audioID)
     }
 }
 
+float AudioEngineImpl::getDurationFromFile(const std::string &filePath)
+{
+    auto it = _audioCaches.find(filePath);
+    if (it == _audioCaches.end()) {
+        this->preload(filePath, nullptr);
+        return AudioEngine::TIME_UNKNOWN;
+    }
+
+    return it->second._duration;
+}
+
 float AudioEngineImpl::getCurrentTime(int audioID)
 {
     float ret = 0.0f;

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -219,6 +219,14 @@ public:
     static float getDuration(int audioID);
 
     /** 
+    * Gets the duration of an audio file.
+    *
+    * @param filePath The path of an audio file.
+    * @return The duration of an audio file.
+    */
+    static float getDurationFromFile(const std::string& filePath);
+
+    /** 
      * Returns the state of an audio instance.
      *
      * @param audioID An audioID returned by the play2d function.

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -392,6 +392,17 @@ float AudioEngineImpl::getDuration(int audioID)
     }
 }
 
+float AudioEngineImpl::getDurationFromFile(const std::string &filePath)
+{
+    auto it = _audioCaches.find(filePath);
+    if (it == _audioCaches.end()) {
+        this->preload(filePath, nullptr);
+        return AudioEngine::TIME_UNKNOWN;
+    }
+
+    return it->second._duration;
+}
+
 float AudioEngineImpl::getCurrentTime(int audioID)
 {
     float ret = 0.0f;

--- a/cocos/audio/win32/AudioEngine-win32.h
+++ b/cocos/audio/win32/AudioEngine-win32.h
@@ -56,6 +56,7 @@ public:
     void stop(int audioID);
     void stopAll();
     float getDuration(int audioID);
+    float getDurationFromFile(const std::string &fileFullPath);
     float getCurrentTime(int audioID);
     bool setCurrentTime(int audioID, float time);
     void setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback);

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_audioengine_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_audioengine_auto.cpp
@@ -610,6 +610,25 @@ static bool js_audioengine_AudioEngine_getDuration(se::State& s)
 }
 SE_BIND_FUNC(js_audioengine_AudioEngine_getDuration)
 
+static bool js_audioengine_AudioEngine_getDurationFromFile(se::State& s)
+{
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+        if (argc == 1) {
+        std::string arg0;
+        ok &= seval_to_std_string(args[0], &arg0);
+        SE_PRECONDITION2(ok, false, "js_audioengine_AudioEngine_getDurationFromFile : Error processing arguments");
+        float result = cocos2d::AudioEngine::getDurationFromFile(arg0);
+        ok &= float_to_seval(result, &s.rval());
+        SE_PRECONDITION2(ok, false, "js_audioengine_AudioEngine_getDurationFromFile : Error processing arguments");
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
+    return false;
+}
+SE_BIND_FUNC(js_audioengine_AudioEngine_getDurationFromFile)
+
 static bool js_audioengine_AudioEngine_setLoop(se::State& s)
 {
     const auto& args = s.args();
@@ -772,6 +791,7 @@ bool js_register_audioengine_AudioEngine(se::Object* obj)
     cls->defineStaticFunction("resume", _SE(js_audioengine_AudioEngine_resume));
     cls->defineStaticFunction("stop", _SE(js_audioengine_AudioEngine_stop));
     cls->defineStaticFunction("getDuration", _SE(js_audioengine_AudioEngine_getDuration));
+    cls->defineStaticFunction("getDurationFromFile", _SE(js_audioengine_AudioEngine_getDurationFromFile));
     cls->defineStaticFunction("setLoop", _SE(js_audioengine_AudioEngine_setLoop));
     cls->defineStaticFunction("getDefaultProfile", _SE(js_audioengine_AudioEngine_getDefaultProfile));
     cls->defineStaticFunction("setFinishCallback", _SE(js_audioengine_AudioEngine_setFinishCallback));

--- a/cocos/scripting/js-bindings/auto/jsb_cocos2dx_audioengine_auto.hpp
+++ b/cocos/scripting/js-bindings/auto/jsb_cocos2dx_audioengine_auto.hpp
@@ -39,6 +39,7 @@ SE_DECLARE_FUNC(js_audioengine_AudioEngine_getState);
 SE_DECLARE_FUNC(js_audioengine_AudioEngine_resume);
 SE_DECLARE_FUNC(js_audioengine_AudioEngine_stop);
 SE_DECLARE_FUNC(js_audioengine_AudioEngine_getDuration);
+SE_DECLARE_FUNC(js_audioengine_AudioEngine_getDurationFromFile);
 SE_DECLARE_FUNC(js_audioengine_AudioEngine_setLoop);
 SE_DECLARE_FUNC(js_audioengine_AudioEngine_getDefaultProfile);
 SE_DECLARE_FUNC(js_audioengine_AudioEngine_setFinishCallback);


### PR DESCRIPTION
Improved the audio engine interface to get any audio duration using its filepath
Right now, with the current implementation, the audio needs to be played one time to get the audio id which is needed to get the audio duration with the current getDuration API.
With this improvement, the duration can be obtained using the resource filepath without the need to play it one time.
I've described the problem in detail here:
https://discuss.cocos2d-x.org/t/audioengine-interface-improvement/34034