### PR TITLE
support input signed decimal in EditBox

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -193,7 +193,7 @@ public class Cocos2dxEditBox {
             else if (inputType.contentEquals("email"))
                 this.setInputType(InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
             else if (inputType.contentEquals("number"))
-                this.setInputType(InputType.TYPE_CLASS_NUMBER);
+                this.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL | InputType.TYPE_NUMBER_FLAG_SIGNED);
             else if (inputType.contentEquals("phone"))
                 this.setInputType(InputType.TYPE_CLASS_PHONE);
             else if (inputType.contentEquals("password"))


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1204

修复 安卓平台，`number inputType` 下，EditBox 不支持输入 小数点，也不支持输入符号的问题