### PR TITLE
change font search method to avoid font search error

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_platfrom_apple.mm
+++ b/cocos/scripting/js-bindings/manual/jsb_platfrom_apple.mm
@@ -74,19 +74,29 @@ static std::string getFontFamilyByCompareAvailableFontFamilyNames(const std::vec
     size_t afterLen = after.size();
     if (afterLen > beforeLen)
     {
-        for (size_t i = 0; i < beforeLen; ++i)
+        for(size_t i = 0;i < afterLen; ++i)
         {
-            if (before[i] != after[i])
+            bool hasFont = false;
+            for(size_t j = 0;j < beforeLen; ++j)
+            {
+                if (after[i] == before[j])
+                {
+                    hasFont = true;
+                    break;
+                }
+            }
+
+            if (!hasFont)
             {
                 ret = after[i];
                 break;
             }
+
+            if (ret.empty())
+                ret = after.back();
+
         }
-
-        if (ret.empty())
-            ret = after.back();
     }
-
     return ret;
 }
 


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/1065
修复ios12 无法加载正确的ttf文件的bug
