### PR TITLE
Fix dragonbones's alpha has not cascade bug

### DIFF
--- a/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -295,8 +295,7 @@ void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity
         Armature* childArmature = slot->getChildArmature();
         if (childArmature != nullptr)
         {
-            parentOpacity *= slot->color.a / 255.0f;
-            traverseArmature(childArmature, parentOpacity);
+            traverseArmature(childArmature, parentOpacity * slot->color.a / 255.0f);
             continue;
         }
         

--- a/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -203,7 +203,7 @@ CCArmatureDisplay* CCArmatureDisplay::getRootDisplay()
     return (CCArmatureDisplay*)slot->_armature->getDisplay();
 }
 
-void CCArmatureDisplay::traverseArmature(Armature* armature)
+void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity)
 {
     auto& slots = armature->getSlots();
     auto mgr = MiddlewareManager::getInstance();
@@ -294,7 +294,8 @@ void CCArmatureDisplay::traverseArmature(Armature* armature)
         Armature* childArmature = slot->getChildArmature();
         if (childArmature != nullptr)
         {
-            traverseArmature(childArmature);
+            parentOpacity *= slot->color.a;
+            traverseArmature(childArmature, parentOpacity);
             continue;
         }
         

--- a/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -314,7 +314,7 @@ void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity
         
         // Calculation vertex color.
         a = _nodeColor.a * slot->color.a * parentOpacity;
-        float multiplier = _premultipliedAlpha ? a / 255.0f: 1.0f;
+        float multiplier = _premultipliedAlpha ? a / 255.0f : 1.0f;
         r = _nodeColor.r * slot->color.r * multiplier;
         g = _nodeColor.g * slot->color.g * multiplier;
         b = _nodeColor.b * slot->color.b * multiplier;

--- a/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -313,7 +313,7 @@ void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity
         }
         
         // Calculation vertex color.
-        a = _nodeColor.a  * slot->color.a * parentOpacity;
+        a = _nodeColor.a * slot->color.a * parentOpacity;
         float multiplier = _premultipliedAlpha ? a / 255.0f: 1.0f;
         r = _nodeColor.r * slot->color.r * multiplier;
         g = _nodeColor.g * slot->color.g * multiplier;

--- a/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -214,6 +214,7 @@ void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity
     auto renderInfo = renderMgr->getBuffer();
     if (!renderInfo) return;
     
+    float r, g, b, a;
     CCSlot* slot = nullptr;
     middleware::Texture2D* texture = nullptr;
     int isFull = 0;
@@ -294,7 +295,7 @@ void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity
         Armature* childArmature = slot->getChildArmature();
         if (childArmature != nullptr)
         {
-            parentOpacity *= slot->color.a;
+            parentOpacity *= slot->color.a / 255.0f;
             traverseArmature(childArmature, parentOpacity);
             continue;
         }
@@ -313,11 +314,11 @@ void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity
         }
         
         // Calculation vertex color.
-        _finalColor.a = _nodeColor.a * slot->color.a * 255;
-        float multiplier = _premultipliedAlpha ? slot->color.a : 255;
-        _finalColor.r = _nodeColor.r * slot->color.r * multiplier;
-        _finalColor.g = _nodeColor.g * slot->color.g * multiplier;
-        _finalColor.b = _nodeColor.b * slot->color.b * multiplier;
+        a = _nodeColor.a  * slot->color.a * parentOpacity;
+        float multiplier = _premultipliedAlpha ? slot->color.a * parentOpacity / 255.0f: 1.0f;
+        r = _nodeColor.r * slot->color.r * multiplier;
+        g = _nodeColor.g * slot->color.g * multiplier;
+        b = _nodeColor.b * slot->color.b * multiplier;
         
         // Transform component matrix to global matrix
         middleware::Triangles& triangles = slot->triangles;
@@ -329,10 +330,10 @@ void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity
             middleware::V2F_T2F_C4B* worldVertex = worldTriangles + v;
             worldVertex->vertex.x = vertex->vertex.x * worldMatrix.m[0] + vertex->vertex.y * worldMatrix.m[4] + worldMatrix.m[12];
             worldVertex->vertex.y = vertex->vertex.x * worldMatrix.m[1] + vertex->vertex.y * worldMatrix.m[5] + worldMatrix.m[13];
-            worldVertex->color.r = (GLubyte)_finalColor.r;
-            worldVertex->color.g = (GLubyte)_finalColor.g;
-            worldVertex->color.b = (GLubyte)_finalColor.b;
-            worldVertex->color.a = (GLubyte)_finalColor.a;
+            worldVertex->color.r = (GLubyte)r;
+            worldVertex->color.g = (GLubyte)g;
+            worldVertex->color.b = (GLubyte)b;
+            worldVertex->color.a = (GLubyte)a;
         }
         
         // Fill MiddlewareManager vertex buffer

--- a/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
+++ b/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.cpp
@@ -314,7 +314,7 @@ void CCArmatureDisplay::traverseArmature(Armature* armature, float parentOpacity
         
         // Calculation vertex color.
         a = _nodeColor.a  * slot->color.a * parentOpacity;
-        float multiplier = _premultipliedAlpha ? slot->color.a * parentOpacity / 255.0f: 1.0f;
+        float multiplier = _premultipliedAlpha ? a / 255.0f: 1.0f;
         r = _nodeColor.r * slot->color.r * multiplier;
         g = _nodeColor.g * slot->color.g * multiplier;
         b = _nodeColor.b * slot->color.b * multiplier;

--- a/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.h
+++ b/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.h
@@ -135,7 +135,10 @@ public:
     
     void setColor(cocos2d::Color4B& color)
     {
-        _nodeColor = color;
+        _nodeColor.r = color.r / 255.0f;
+        _nodeColor.g = color.g / 255.0f;
+        _nodeColor.b = color.b / 255.0f;
+        _nodeColor.a = color.a / 255.0f;
     }
     
     void setDebugBonesEnabled(bool enabled)
@@ -170,7 +173,7 @@ private:
     std::map<std::string,bool> _listenerIDMap;
     cocos2d::middleware::IOTypedArray* _renderInfoOffset = nullptr;
     cocos2d::middleware::IOTypedArray* _debugBuffer = nullptr;
-    cocos2d::Color4B _nodeColor = cocos2d::Color4B::WHITE;
+    cocos2d::Color4F _nodeColor = cocos2d::Color4F::WHITE;
     
     int _preBlendMode = -1;
     int _preTextureIndex = -1;
@@ -186,7 +189,6 @@ private:
     std::size_t _materialLenOffset = -1;
     
     bool _premultipliedAlpha = false;
-    cocos2d::Color4B _finalColor = cocos2d::Color4B::WHITE;
     dbEventCallback _dbEventCallback = nullptr;
 };
 

--- a/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.h
+++ b/cocos/editor-support/dragonbones-creator-support/CCArmatureDisplay.h
@@ -50,7 +50,7 @@ public:
     static CCArmatureDisplay* create();
     
 private:
-    void traverseArmature(Armature* armature);
+    void traverseArmature(Armature* armature, float parentOpacity = 1.0f);
     
 protected:
     bool _debugDraw = false;

--- a/cocos/editor-support/spine-creator-support/SpineRenderer.cpp
+++ b/cocos/editor-support/spine-creator-support/SpineRenderer.cpp
@@ -580,14 +580,14 @@ void SpineRenderer::update (float deltaTime)
                 continue;
         }
         
-        float alpha = _skeleton->color.a * slot->color.a * color.a * 255;
+        color.a = _skeleton->color.a * slot->color.a * color.a * _nodeColor.a * 255;
         // skip rendering if the color of this attachment is 0
-        if (alpha == 0)
+        if (color.a == 0)
         {
             spSkeletonClipping_clipEnd(_clipper, slot);
             continue;
         }
-        float multiplier = _premultipliedAlpha ? alpha : 255;
+        float multiplier = _premultipliedAlpha ? color.a : 255;
         
         float red = _nodeColor.r * _skeleton->color.r * color.r * multiplier;
         float green = _nodeColor.g * _skeleton->color.g * color.g * multiplier;
@@ -596,7 +596,6 @@ void SpineRenderer::update (float deltaTime)
         color.r = red * slot->color.r;
         color.g = green * slot->color.g;
         color.b = blue * slot->color.b;
-        color.a = alpha * _nodeColor.a;
         
         if (slot->darkColor)
         {

--- a/cocos/editor-support/spine-creator-support/SpineRenderer.cpp
+++ b/cocos/editor-support/spine-creator-support/SpineRenderer.cpp
@@ -284,12 +284,6 @@ void SpineRenderer::update (float deltaTime)
     auto renderInfo = renderMgr->getBuffer();
     if (!renderInfo) return;
     
-    Color4F nodeColor;
-    nodeColor.r = _nodeColor.r / (float)255;
-    nodeColor.g = _nodeColor.g / (float)255;
-    nodeColor.b = _nodeColor.b / (float)255;
-    nodeColor.a = _nodeColor.a / (float)255;
-    
     _renderInfoOffset->reset();
     //  store renderInfo offset
     _renderInfoOffset->writeUint32((uint32_t)renderInfo->getCurPos() / sizeof(uint32_t));
@@ -595,14 +589,14 @@ void SpineRenderer::update (float deltaTime)
         }
         float multiplier = _premultipliedAlpha ? alpha : 255;
         
-        float red = nodeColor.r * _skeleton->color.r * color.r * multiplier;
-        float green = nodeColor.g * _skeleton->color.g * color.g * multiplier;
-        float blue = nodeColor.b * _skeleton->color.b * color.b * multiplier;
+        float red = _nodeColor.r * _skeleton->color.r * color.r * multiplier;
+        float green = _nodeColor.g * _skeleton->color.g * color.g * multiplier;
+        float blue = _nodeColor.b * _skeleton->color.b * color.b * multiplier;
         
         color.r = red * slot->color.r;
         color.g = green * slot->color.g;
         color.b = blue * slot->color.b;
-        color.a = alpha * nodeColor.a;
+        color.a = alpha * _nodeColor.a;
         
         if (slot->darkColor)
         {
@@ -899,7 +893,10 @@ void SpineRenderer::paused(bool value)
 
 void SpineRenderer::setColor (cocos2d::Color4B& color)
 {
-    _nodeColor = color;
+    _nodeColor.r = color.r / 255.0f;
+    _nodeColor.g = color.g / 255.0f;
+    _nodeColor.b = color.b / 255.0f;
+    _nodeColor.a = color.a / 255.0f;
 }
 
 void SpineRenderer::setDebugBonesEnabled (bool enabled)

--- a/cocos/editor-support/spine-creator-support/SpineRenderer.h
+++ b/cocos/editor-support/spine-creator-support/SpineRenderer.h
@@ -165,7 +165,7 @@ namespace spine {
         
         bool                _debugSlots = false;
         bool                _debugBones = false;
-        cocos2d::Color4B    _nodeColor = cocos2d::Color4B::WHITE;
+        cocos2d::Color4F    _nodeColor = cocos2d::Color4F::WHITE;
         bool                _premultipliedAlpha = false;
         spSkeletonClipping* _clipper = nullptr;
         bool                _useTint = false;


### PR DESCRIPTION
关联pr:https://github.com/cocos-creator/engine/pull/4068
issue:https://github.com/cocos-creator/2d-tasks/issues/1054
修复dragonbones父骨骼透明度没有与子骨骼透明度级联的问题
修复使用GLuByte存储slotcolor与nodecolor相乘的结果，会导致溢出的问题，改由float存储，最后再转为GLuByte。