### PR TITLE
Fix if spine has not loaded normaly, then will trigger crash

### DIFF
--- a/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
+++ b/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
@@ -161,7 +161,6 @@ SpineAnimation::SpineAnimation (const std::string& skeletonDataFile, const std::
 
 SpineAnimation::~SpineAnimation ()
 {
-    clearTracks();
     _startListener = nullptr;
     _interruptListener = nullptr;
     _endListener = nullptr;
@@ -171,6 +170,7 @@ SpineAnimation::~SpineAnimation ()
 
     if (_state)
     {
+        clearTracks();
         if (_ownsAnimationStateData) spAnimationStateData_dispose(_state->data);
         spAnimationState_dispose(_state);
     }
@@ -256,9 +256,7 @@ spTrackEntry* SpineAnimation::getCurrent (int trackIndex)
 
 void SpineAnimation::clearTracks ()
 {
-    if (_state) {
-        spAnimationState_clearTracks(_state);
-    }
+    spAnimationState_clearTracks(_state);
 }
 
 void SpineAnimation::clearTrack (int trackIndex)

--- a/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
+++ b/cocos/editor-support/spine-creator-support/SpineAnimation.cpp
@@ -256,7 +256,9 @@ spTrackEntry* SpineAnimation::getCurrent (int trackIndex)
 
 void SpineAnimation::clearTracks ()
 {
-    spAnimationState_clearTracks(_state);
+    if (_state) {
+        spAnimationState_clearTracks(_state);
+    }
 }
 
 void SpineAnimation::clearTrack (int trackIndex)


### PR DESCRIPTION
Fix if spine has not loaded normaly，then will trigger destructor，so state may empty.