### PR TITLE
alBufferData instead of alBufferDataStatic for small audio file on Apple

### DIFF
--- a/cocos/audio/apple/AudioCache.mm
+++ b/cocos/audio/apple/AudioCache.mm
@@ -51,22 +51,6 @@ unsigned int __idIndex = 0;
 #define INVALID_AL_BUFFER_ID 0xFFFFFFFF
 #define PCMDATA_CACHEMAXSIZE 1048576
 
-typedef ALvoid	AL_APIENTRY	(*alBufferDataStaticProcPtr) (const ALint bid, ALenum format, ALvoid* data, ALsizei size, ALsizei freq);
-static ALvoid  alBufferDataStaticProc(const ALint bid, ALenum format, ALvoid* data, ALsizei size, ALsizei freq)
-{
-    static alBufferDataStaticProcPtr proc = nullptr;
-
-    if (proc == nullptr) {
-        proc = (alBufferDataStaticProcPtr) alcGetProcAddress(nullptr, (const ALCchar*) "alBufferDataStatic");
-    }
-
-    if (proc){
-        proc(bid, format, data, size, freq);
-    }
-
-    return;
-}
-
 @interface NSTimerWrapper : NSObject
 {
     std::function<void()> _timeoutCallback;
@@ -103,11 +87,6 @@ static ALvoid  alBufferDataStaticProc(const ALint bid, ALenum format, ALvoid* da
 }
 
 @end
-
-static void setTimeout(double seconds, const std::function<void()>& cb)
-{
-    [[[NSTimerWrapper alloc] initWithTimeInterval:seconds callback:cb] autorelease];
-}
 
 using namespace cocos2d;
 
@@ -149,35 +128,19 @@ AudioCache::~AudioCache()
     }
     //wait for the 'readDataTask' task to exit
     _readDataTaskMutex.lock();
-    _readDataTaskMutex.unlock();
 
-    if (_pcmData)
+    if (_state == State::READY)
     {
-        if (_state == State::READY)
+        if (_alBufferId != INVALID_AL_BUFFER_ID && alIsBuffer(_alBufferId))
         {
-            if (_alBufferId != INVALID_AL_BUFFER_ID && alIsBuffer(_alBufferId))
-            {
-                ALOGV("~AudioCache(id=%u), delete buffer: %u", _id, _alBufferId);
-                alDeleteBuffers(1, &_alBufferId);
-                _alBufferId = INVALID_AL_BUFFER_ID;
-            }
+            ALOGV("~AudioCache(id=%u), delete buffer: %u", _id, _alBufferId);
+            alDeleteBuffers(1, &_alBufferId);
+            _alBufferId = INVALID_AL_BUFFER_ID;
         }
-        else
-        {
-            ALOGW("AudioCache (%p), id=%u, buffer isn't ready, state=%d", this, _id, _state);
-        }
-
-        // fixed #17494: CrashIfClientProvidedBogusAudioBufferList
-        // We're using 'alBufferDataStaticProc' for speeding up
-        // the performance of playing audio without preload, but we need to manage the memory by ourself carefully.
-        // It's probably that '_pcmData' is freed before OpenAL finishes the audio render task,
-        // then 'CrashIfClientProvidedBogusAudioBufferList' may be triggered.
-        // 'cpp-tests/NewAudioEngineTest/AudioSwitchStateTest' can reproduce this issue without the following fix.
-        // The workaround is delaying 200ms to free pcm data.
-        char* data = _pcmData;
-        setTimeout(0.2, [data](){
-            free(data);
-        });
+    }
+    else
+    {
+        ALOGW("AudioCache (%p), id=%u, buffer isn't ready, state=%d", this, _id, _state);
     }
 
     if (_queBufferFrames > 0)
@@ -188,6 +151,7 @@ AudioCache::~AudioCache()
         }
     }
     ALOGVV("~AudioCache() %p, id=%u, end", this, _id);
+    _readDataTaskMutex.unlock();
 }
 
 void AudioCache::readDataTask(unsigned int selfId)
@@ -260,23 +224,15 @@ void AudioCache::readDataTask(unsigned int selfId)
 
             _pcmData = (char*)malloc(dataSize);
             memset(_pcmData, 0x00, dataSize);
+            ALOGV("  id=%u _pcmData alloc: %p", selfId, _pcmData);
 
             if (adjustFrames > 0)
             {
                 memcpy(_pcmData + (dataSize - adjustFrameBuf.size()), adjustFrameBuf.data(), adjustFrameBuf.size());
             }
 
-            alGenBuffers(1, &_alBufferId);
-            auto alError = alGetError();
-            if (alError != AL_NO_ERROR) {
-                ALOGE("%s: attaching audio to buffer fail: %x", __PRETTY_FUNCTION__, alError);
-                break;
-            }
-
             if (*_isDestroyed)
                 break;
-
-            alBufferDataStaticProc(_alBufferId, _format, _pcmData, (ALsizei)dataSize, (ALsizei)sampleRate);
 
             framesRead = decoder.readFixedFrames(std::min(framesToReadOnce, remainingFrames), _pcmData + _framesRead * bytesPerFrame);
             _framesRead += framesRead;
@@ -284,10 +240,6 @@ void AudioCache::readDataTask(unsigned int selfId)
 
             if (*_isDestroyed)
                 break;
-
-            _state = State::READY;
-
-            invokingPlayCallbacks();
 
             uint32_t frames = 0;
             while (!*_isDestroyed && _framesRead < originalTotalFrames)
@@ -308,9 +260,22 @@ void AudioCache::readDataTask(unsigned int selfId)
             {
                 memset(_pcmData + _framesRead * bytesPerFrame, 0x00, (totalFrames - _framesRead) * bytesPerFrame);
             }
-            ALOGV("pcm buffer was loaded successfully, total frames: %u, total read frames: %u, adjust frames: %u, remainingFrames: %u", totalFrames, _framesRead, adjustFrames, remainingFrames);
 
+            ALOGV("pcm buffer was loaded successfully, total frames: %u, total read frames: %u, adjust frames: %u, remainingFrames: %u", totalFrames, _framesRead, adjustFrames, remainingFrames);
             _framesRead += adjustFrames;
+
+            alGenBuffers(1, &_alBufferId);
+            auto alError = alGetError();
+            if (alError != AL_NO_ERROR) {
+                ALOGE("%s: attaching audio to buffer fail: %x", __PRETTY_FUNCTION__, alError);
+                break;
+            }
+            ALOGV("  id=%u generated alGenBuffers: %u  for _pcmData: %p", selfId, _alBufferId, _pcmData);
+            ALOGV("  id=%u _pcmData alBufferData: %p", selfId, _pcmData);
+            alBufferData(_alBufferId, _format, _pcmData, (ALsizei)dataSize, (ALsizei)sampleRate);
+            _state = State::READY;
+            invokingPlayCallbacks();
+
         }
         else
         {
@@ -332,6 +297,10 @@ void AudioCache::readDataTask(unsigned int selfId)
 
     } while (false);
 
+    if (_pcmData != nullptr){
+        CC_SAFE_FREE(_pcmData);
+    }
+
     decoder.close();
 
     //IDEA: Why to invoke play callback first? Should it be after 'load' callback?
@@ -344,7 +313,7 @@ void AudioCache::readDataTask(unsigned int selfId)
         _state = State::FAILED;
         if (_alBufferId != INVALID_AL_BUFFER_ID && alIsBuffer(_alBufferId))
         {
-            ALOGV("readDataTask failed, delete buffer: %u", _alBufferId);
+            ALOGV("  id=%u readDataTask failed, delete buffer: %u", selfId, _alBufferId);
             alDeleteBuffers(1, &_alBufferId);
             _alBufferId = INVALID_AL_BUFFER_ID;
         }


### PR DESCRIPTION
同步 -x 代码，调整小音频在 apple 上用 alBufferData 而不是 alBufferDataStatic
https://github.com/cocos2d/cocos2d-x/pull/19227

相关讨论
https://forum.cocos.com/t/ios-glteximage2d-exc-bad-access/74364/15?u=jare