### PR TITLE
Use smart pointers to hold references of global Application::_scheduler 

### DIFF
--- a/build/libcocos2d.vcxproj
+++ b/build/libcocos2d.vcxproj
@@ -550,7 +550,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v141_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -560,7 +560,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v141_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/build/libcocos2d.vcxproj
+++ b/build/libcocos2d.vcxproj
@@ -550,7 +550,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v141_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -560,7 +560,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v140_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v141_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/cocos/audio/apple/AudioEngine-inl.h
+++ b/cocos/audio/apple/AudioEngine-inl.h
@@ -86,7 +86,7 @@ private:
     bool _lazyInitLoop;
 
     int _currentAudioID;
-    Scheduler* _scheduler;
+    std::weak_ptr<Scheduler> _scheduler;
 };
 NS_CC_END
 #endif // __AUDIO_ENGINE_INL_H_

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -112,16 +112,16 @@ static ALCcontext *s_ALContext = nullptr;
 AudioEngineImpl::AudioEngineImpl()
 : _lazyInitLoop(true)
 , _currentAudioID(0)
-, _scheduler(nullptr)
 {
 
 }
 
 AudioEngineImpl::~AudioEngineImpl()
 {
-    if (_scheduler != nullptr)
+    auto sche = _scheduler.lock();
+    if (sche)
     {
-        _scheduler->unschedule("AudioEngine", this);
+        sche->unschedule("AudioEngine", this);
     }
 
     if (s_ALContext) {
@@ -251,7 +251,11 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
 
     if (_lazyInitLoop) {
         _lazyInitLoop = false;
-        _scheduler->schedule(CC_CALLBACK_1(AudioEngineImpl::update, this), this, 0.05f, false, "AudioEngine");
+        auto sche = _scheduler.lock();
+        if(sche)
+        {
+            sche->schedule(CC_CALLBACK_1(AudioEngineImpl::update, this), this, 0.05f, false, "AudioEngine");
+        }
     }
 
     return _currentAudioID++;
@@ -265,12 +269,16 @@ void AudioEngineImpl::_play2d(AudioCache *cache, int audioID)
         _threadMutex.lock();
         auto playerIt = _audioPlayers.find(audioID);
         if (playerIt != _audioPlayers.end() && playerIt->second->play2d()) {
-            _scheduler->performFunctionInCocosThread([audioID](){
+            auto sche = _scheduler.lock();
+            if (sche)
+            {
+                sche->performFunctionInCocosThread([audioID]() {
 
-                if (AudioEngine::_audioIDInfoMap.find(audioID) != AudioEngine::_audioIDInfoMap.end()) {
-                    AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PLAYING;
-                }
-            });
+                    if (AudioEngine::_audioIDInfoMap.find(audioID) != AudioEngine::_audioIDInfoMap.end()) {
+                        AudioEngine::_audioIDInfoMap[audioID].state = AudioEngine::AudioState::PLAYING;
+                    }
+                });
+            }
         }
         _threadMutex.unlock();
     }
@@ -513,7 +521,11 @@ void AudioEngineImpl::update(float dt)
 
     if(_audioPlayers.empty()){
         _lazyInitLoop = true;
-        _scheduler->unschedule("AudioEngine", this);
+        auto sche = _scheduler.lock();
+        if(sche)
+        {
+            sche->unschedule("AudioEngine", this);
+        }
     }
 }
 

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -118,8 +118,7 @@ AudioEngineImpl::AudioEngineImpl()
 
 AudioEngineImpl::~AudioEngineImpl()
 {
-    auto sche = _scheduler.lock();
-    if (sche)
+    if (auto sche = _scheduler.lock())
     {
         sche->unschedule("AudioEngine", this);
     }
@@ -251,8 +250,7 @@ int AudioEngineImpl::play2d(const std::string &filePath ,bool loop ,float volume
 
     if (_lazyInitLoop) {
         _lazyInitLoop = false;
-        auto sche = _scheduler.lock();
-        if(sche)
+        if(auto sche = _scheduler.lock())
         {
             sche->schedule(CC_CALLBACK_1(AudioEngineImpl::update, this), this, 0.05f, false, "AudioEngine");
         }
@@ -269,8 +267,7 @@ void AudioEngineImpl::_play2d(AudioCache *cache, int audioID)
         _threadMutex.lock();
         auto playerIt = _audioPlayers.find(audioID);
         if (playerIt != _audioPlayers.end() && playerIt->second->play2d()) {
-            auto sche = _scheduler.lock();
-            if (sche)
+            if (auto sche = _scheduler.lock())
             {
                 sche->performFunctionInCocosThread([audioID]() {
 
@@ -521,8 +518,7 @@ void AudioEngineImpl::update(float dt)
 
     if(_audioPlayers.empty()){
         _lazyInitLoop = true;
-        auto sche = _scheduler.lock();
-        if(sche)
+        if(auto sche = _scheduler.lock())
         {
             sche->unschedule("AudioEngine", this);
         }

--- a/cocos/audio/win32/AudioEngine-win32.h
+++ b/cocos/audio/win32/AudioEngine-win32.h
@@ -84,7 +84,7 @@ private:
     bool _lazyInitLoop;
 
     int _currentAudioID;
-    Scheduler* _scheduler;
+    std::weak_ptr<Scheduler> _scheduler;
 };
 NS_CC_END
 #endif // __AUDIO_ENGINE_INL_H_

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -729,16 +729,24 @@ namespace cocos2d { namespace network {
         sprintf(key, "DownloaderCURL(%p)", this);
         _schedulerKey = key;
 
-        _scheduler->schedule(bind(&DownloaderCURL::_onSchedule, this, placeholders::_1),
+        auto sche = _scheduler.lock();
+        if(sche)
+        {
+            sche->schedule(bind(&DownloaderCURL::_onSchedule, this, placeholders::_1),
                              this,
                              0.1f,
                              true,
                              _schedulerKey);
+        }
     }
 
     DownloaderCURL::~DownloaderCURL()
     {
-        _scheduler->unschedule(_schedulerKey, this);
+        auto sche = _scheduler.lock();
+        if(sche)
+        {
+            sche->unschedule(_schedulerKey, this);
+        }
 
         _impl->stop();
         DLLOG("Destruct DownloaderCURL %p", this);
@@ -753,7 +761,11 @@ namespace cocos2d { namespace network {
 
         _impl->addTask(task, coTask);
         _impl->run();
-        _scheduler->resumeTarget(this);
+        auto sche = _scheduler.lock();
+        if(sche)
+        {
+            sche->resumeTarget(this);
+        }
         return coTask;
     }
 
@@ -793,7 +805,11 @@ namespace cocos2d { namespace network {
         _impl->getFinishedTasks(tasks);
         if (_impl->stoped())
         {
-            _scheduler->pauseTarget(this);
+            auto sche = _scheduler.lock();
+            if (sche)
+            {
+                sche->pauseTarget(this);
+            }
         }
 
         for (auto& wrapper : tasks)

--- a/cocos/network/CCDownloader-curl.cpp
+++ b/cocos/network/CCDownloader-curl.cpp
@@ -729,8 +729,7 @@ namespace cocos2d { namespace network {
         sprintf(key, "DownloaderCURL(%p)", this);
         _schedulerKey = key;
 
-        auto sche = _scheduler.lock();
-        if(sche)
+        if(auto sche = _scheduler.lock())
         {
             sche->schedule(bind(&DownloaderCURL::_onSchedule, this, placeholders::_1),
                              this,
@@ -742,8 +741,7 @@ namespace cocos2d { namespace network {
 
     DownloaderCURL::~DownloaderCURL()
     {
-        auto sche = _scheduler.lock();
-        if(sche)
+        if(auto sche = _scheduler.lock())
         {
             sche->unschedule(_schedulerKey, this);
         }
@@ -761,8 +759,8 @@ namespace cocos2d { namespace network {
 
         _impl->addTask(task, coTask);
         _impl->run();
-        auto sche = _scheduler.lock();
-        if(sche)
+        
+        if(auto sche = _scheduler.lock())
         {
             sche->resumeTarget(this);
         }
@@ -805,8 +803,7 @@ namespace cocos2d { namespace network {
         _impl->getFinishedTasks(tasks);
         if (_impl->stoped())
         {
-            auto sche = _scheduler.lock();
-            if (sche)
+            if (auto sche = _scheduler.lock())
             {
                 sche->pauseTarget(this);
             }

--- a/cocos/network/CCDownloader-curl.h
+++ b/cocos/network/CCDownloader-curl.h
@@ -56,8 +56,8 @@ namespace cocos2d { namespace network
 
         // scheduler for update processing and finished task in main schedule
         void _onSchedule(float);
-        std::string             _schedulerKey;
-        Scheduler*              _scheduler;
+        std::string                 _schedulerKey;
+        std::weak_ptr<Scheduler>    _scheduler;
     };
 
 }}  // namespace cocos2d::network

--- a/cocos/network/HttpClient-android.cpp
+++ b/cocos/network/HttpClient-android.cpp
@@ -838,9 +838,9 @@ void HttpClient::networkThread()
         _responseQueueMutex.unlock();
         
         _schedulerMutex.lock();
-        if (nullptr != _scheduler)
+        if (auto sche = _scheduler.lock())
         {
-            _scheduler->performFunctionInCocosThread(CC_CALLBACK_0(HttpClient::dispatchResponseCallbacks, this));
+            sche->performFunctionInCocosThread(CC_CALLBACK_0(HttpClient::dispatchResponseCallbacks, this));
         }
         _schedulerMutex.unlock();
     }
@@ -866,9 +866,9 @@ void HttpClient::networkThreadAlone(HttpRequest* request, HttpResponse* response
     processResponse(response, responseMessage);
 
     _schedulerMutex.lock();
-    if (_scheduler != nullptr)
+    if (auto sche = _scheduler.lock())
     {
-        _scheduler->performFunctionInCocosThread([this, response, request]{
+        sche->performFunctionInCocosThread([this, response, request]{
             const ccHttpRequestCallback& callback = request->getResponseCallback();
 
             if (callback != nullptr)
@@ -909,10 +909,12 @@ void HttpClient::destroyInstance()
     auto thiz = _httpClient;
     _httpClient = nullptr;
 
-    thiz->_scheduler->unscheduleAllForTarget(thiz);
 
+    if(auto sche = thiz->_scheduler.lock()) {
+        sche->unscheduleAllForTarget(thiz);
+    }
     thiz->_schedulerMutex.lock();
-    thiz->_scheduler = nullptr;
+    thiz->_scheduler.reset();
     thiz->_schedulerMutex.unlock();
 
     {

--- a/cocos/network/HttpClient.cpp
+++ b/cocos/network/HttpClient.cpp
@@ -115,8 +115,7 @@ void HttpClient::networkThread()
         _responseQueueMutex.unlock();
 
         _schedulerMutex.lock();
-        auto sche = _scheduler.lock();
-        if (sche)
+        if (auto sche = _scheduler.lock())
         {
             sche->performFunctionInCocosThread(CC_CALLBACK_0(HttpClient::dispatchResponseCallbacks, this));
         }
@@ -144,8 +143,7 @@ void HttpClient::networkThreadAlone(HttpRequest* request, HttpResponse* response
     processResponse(response, responseMessage);
 
     _schedulerMutex.lock();
-    auto sche = _scheduler.lock();
-    if (sche)
+    if (auto sche = _scheduler.lock())
     {
         sche->performFunctionInCocosThread([this, response, request]{
             const ccHttpRequestCallback& callback = request->getResponseCallback();
@@ -358,8 +356,7 @@ void HttpClient::destroyInstance()
     auto thiz = _httpClient;
     _httpClient = nullptr;
 
-    auto sche = thiz->_scheduler.lock();
-    if(sche)
+    if(auto sche = thiz->_scheduler.lock())
     {
         sche->unscheduleAllForTarget(thiz);
     }

--- a/cocos/network/HttpClient.h
+++ b/cocos/network/HttpClient.h
@@ -185,7 +185,7 @@ private:
     int  _threadCount;
     std::mutex _threadCountMutex;
 
-    Scheduler* _scheduler;
+    std::weak_ptr<Scheduler> _scheduler;
     std::mutex _schedulerMutex;
 
     Vector<HttpRequest*>  _requestQueue;

--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -109,7 +109,7 @@ public:
     virtual void applicationWillEnterForeground();
     
     inline void* getView() const { return _view; }
-    inline Scheduler* getScheduler() const { return _scheduler.get(); }
+    inline std::shared_ptr<Scheduler> getScheduler() const { return _scheduler; }
     inline RenderTexture* getRenderTexture() const { return _renderTexture; }
     
     void runOnMainThread();

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -72,7 +72,7 @@ namespace
     float _systemVersion;
     BOOL _isAppActive;
     cocos2d::Application* _application;
-    cocos2d::Scheduler* _scheduler;
+    std::shared_ptr<cocos2d::Scheduler> _scheduler;
 }
 -(void) startMainLoop;
 -(void) stopMainLoop;


### PR DESCRIPTION
修复"Win32 关闭运行窗口时出现报错"

程序结束时 `Application::_scheduler`先于`Downloader`释放, 导致内存错误.  使用`std::weak_ptr`保证引用的正确性. 
