### PR TITLE
Fix bug on ios getNetworkType

### DIFF
--- a/cocos/platform/ios/CCDevice-ios.mm
+++ b/cocos/platform/ios/CCDevice-ios.mm
@@ -290,6 +290,7 @@ Device::NetworkType Device::getNetworkType()
             break;
         case Reachability::NetworkStatus::REACHABLE_VIA_WWAN:
             ret = NetworkType::WWAN;
+            break;
         default:
             ret = NetworkType::NONE;
             break;


### PR DESCRIPTION
Fix bug on ios, getNetworkType return None while network status is ReachableViaWWAN