### PR TITLE
add script engine initialize check when evalString from native

### DIFF
--- a/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
@@ -47,6 +47,11 @@ extern "C" {
 JNIEXPORT jint JNICALL JNI_JSJAVABRIDGE(evalString)
         (JNIEnv *env, jclass cls, jstring value)
 {
+    if (!se::ScriptEngine::getInstance()->isValid()) {
+        CCLOG("ScriptEngine has not been initialized");
+        return 0;
+    }
+
     se::AutoHandleScope hs;
     bool strFlag = false;
     std::string strValue = cocos2d::StringUtils::getStringUTFCharsJNI(env, value, &strFlag);


### PR DESCRIPTION
先提前判断下当前的 ScriptEngine 是否可用，避免在初始化的时候直接调用 evalString 直接崩溃的 bug
https://github.com/cocos-creator/2d-tasks/issues/1424