### PR TITLE
fix spine will crash when load/unload spine res frequently

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_spine_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_spine_manual.cpp
@@ -407,8 +407,8 @@ static bool js_register_spine_initSkeletonData (se::State& s)
     auto mgr = spine::SkeletonDataMgr::getInstance();
     bool hasSkeletonData = mgr->hasSkeletonData(uuid);
     if (hasSkeletonData) {
-      mgr->retainByUUID(uuid)
-      return true;
+        mgr->retainByUUID(uuid);
+        return true;
     }
     
     std::string skeletonDataFile;

--- a/cocos/scripting/js-bindings/manual/jsb_spine_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_spine_manual.cpp
@@ -406,7 +406,10 @@ static bool js_register_spine_initSkeletonData (se::State& s)
     
     auto mgr = spine::SkeletonDataMgr::getInstance();
     bool hasSkeletonData = mgr->hasSkeletonData(uuid);
-    if (hasSkeletonData) return true;
+    if (hasSkeletonData) {
+      mgr->retainByUUID(uuid)
+      return true;
+    }
     
     std::string skeletonDataFile;
     ok = seval_to_std_string(args[1], &skeletonDataFile);


### PR DESCRIPTION
load spine res  ref count = 1
SpineRenderer1 hold ref +1 = 2
play with spine happy
unload spine res ref -1 = 1

load spine res ref count (not change) = 1
SpineRenderer2 hold ref +1 = 2
play with spine happy
unload spine res ref -1 = 1

load spine res ref count (not change) = 1
SpineRenderer3 hold ref +1 = 2
play with spine happy

SE gc
SpineRenderer1 release ref -1 = 1
SpineRenderer2 release ref -1 = 0
play with spine unhappy (crashed)

