### PR TITLE
fix misusage of SelectObject and DeleteObject

### DIFF
--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -534,9 +534,6 @@ private:
 
     Point _convertDrawPoint(Point point, std::string text) {
         Size textSize = measureText(text);
-        // Convert from bottom left to top left.
-        point.y -= _fontSize;
-
         if (_textAlign == CanvasTextAlign::CENTER)
         {
             point.x -= textSize.width / 2.0f;
@@ -554,6 +551,9 @@ private:
         {
              point.y += _fontSize / 2.0f;
         }
+
+        GetTextMetrics(_DC, &_tm);
+        point.y -= _tm.tmAscent;
 
         return point;
     }

--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -549,9 +549,11 @@ private:
         }
         else if (_textBaseLine == CanvasTextBaseline::MIDDLE)
         {
-             point.y += _fontSize / 2.0f;
+            point.y += _fontSize / 2.0f;
         }
 
+        // Since the web platform cannot get the baseline of the font, an additive offset is performed for all platforms.
+        // That's why we should add baseline back again on other platforms
         GetTextMetrics(_DC, &_tm);
         point.y -= _tm.tmAscent;
 

--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -62,12 +62,10 @@ public:
 
     ~CanvasRenderingContext2DImpl()
     {
-        _prepareBitmap(0, 0);
-        if (_DC)
-        {
-            DeleteDC(_DC);
-        }
+        _deleteBitmap();
         _removeCustomFont();
+        if (_DC)
+            DeleteDC(_DC);
     }
 
     void recreateBuffer(float w, float h)
@@ -76,7 +74,7 @@ public:
         _bufferHeight = h;
         if (_bufferWidth < 1.0f || _bufferHeight < 1.0f)
         {
-            _prepareBitmap(0, 0);
+            _deleteBitmap();
             return;
         }
 
@@ -199,16 +197,12 @@ public:
 
     void updateFont(const std::string& fontName, float fontSize, bool bold = false)
     {
-        bool bRet = false;
         do
         {
             _fontName = fontName;
             _fontSize = fontSize;
             std::string fontPath;
-            HFONT       hDefFont = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
-            LOGFONTA    tNewFont = { 0 };
-            LOGFONTA    tOldFont = { 0 };
-            GetObjectA(hDefFont, sizeof(tNewFont), &tNewFont);
+            LOGFONTA    tFont = { 0 };
             if (!_fontName.empty())
             {
                 // firstly, try to create font from ttf file
@@ -240,33 +234,20 @@ public:
                         }
                     }
                 }
-                tNewFont.lfCharSet = DEFAULT_CHARSET;
-                strcpy_s(tNewFont.lfFaceName, LF_FACESIZE, _fontName.c_str());
+                tFont.lfCharSet = DEFAULT_CHARSET;
+                strcpy_s(tFont.lfFaceName, LF_FACESIZE, _fontName.c_str());
             }
 
             if (_fontSize)
-            {
-                tNewFont.lfHeight = -_fontSize;
-            }
+                tFont.lfHeight = -_fontSize;
 
             if (bold)
-            {
-                tNewFont.lfWeight = FW_BOLD;
-            }
+                tFont.lfWeight = FW_BOLD;
             else
-            {
-                tNewFont.lfWeight = FW_NORMAL;
-            }
+                tFont.lfWeight = FW_NORMAL;
 
-            GetObjectA(_font, sizeof(tOldFont), &tOldFont);
-
-            if (tOldFont.lfHeight == tNewFont.lfHeight
-                && tOldFont.lfWeight == tNewFont.lfWeight
-                && 0 == strcmp(tOldFont.lfFaceName, tNewFont.lfFaceName))
-            {
-                bRet = true;
-                break;
-            }
+            // disable Cleartype
+            tFont.lfQuality = ANTIALIASED_QUALITY;
 
             // delete old font
             _removeCustomFont();
@@ -286,17 +267,13 @@ public:
                 }
             }
 
-            _font = nullptr;
-
-            // disable Cleartype
-            tNewFont.lfQuality = ANTIALIASED_QUALITY;
-
             // create new font
-            _font = CreateFontIndirectA(&tNewFont);
+            _font = CreateFontIndirectA(&tFont);
             if (!_font)
             {
                 // create failed, use default font
-                _font = hDefFont;
+                SE_LOGE("Failed to create custom font(font name: %s, font size: %f), use default font.\n",
+                    _fontName.c_str(), fontSize);
                 break;
             }
             else
@@ -304,11 +281,7 @@ public:
                 SelectObject(_DC, _font);
                 SendMessage(_wnd, WM_FONTCHANGE, 0, 0);
             }
-
-            bRet = true;
-
         } while (0);
-
     }
 
     void setTextAlign(CanvasTextAlign align)
@@ -403,8 +376,7 @@ private:
         HFONT hDefFont = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
         if (hDefFont != _font)
         {
-            DeleteObject(_font);
-            _font = hDefFont;
+            DeleteObject(SelectObject(_DC, hDefFont));
         }
         // release temp font resource
         if (_curFontPath.size() > 0)
@@ -453,18 +425,11 @@ private:
 
             // SE_LOGE("_drawText text,%s size: (%d, %d) offset after convert: (%d, %d) \n", text.c_str(), newSize.cx, newSize.cy, offsetX, offsetY);
 
-            // draw text
-            HGDIOBJ hOldFont = SelectObject(_DC, _font);
-            HGDIOBJ hOldBmp = SelectObject(_DC, _bmp);
-
             SetBkMode(_DC, TRANSPARENT);
             SetTextColor(_DC, RGB(255, 255, 255)); // white color
 
             // draw text
             nRet = DrawTextW(_DC, pwszBuffer, bufferLen, &rcText, dwFmt);
-
-            DeleteObject(hOldBmp);
-            DeleteObject(hOldFont);
         } while (0);
         CC_SAFE_DELETE_ARRAY(pwszBuffer);
 
@@ -481,39 +446,35 @@ private:
             RECT rc = { 0, 0, 0, 0 };
             DWORD dwCalcFmt = DT_CALCRECT;
 
-            // use current font to measure text extent
-            HGDIOBJ hOld = SelectObject(_DC, _font);
-
             // measure text size
             DrawTextW(_DC, pszText, nLen, &rc, dwCalcFmt);
 
             tRet.cx = rc.right;
             tRet.cy = rc.bottom;
-
-            DeleteObject(hOld);
-
         } while (0);
 
         return tRet;
     }
 
-    bool _prepareBitmap(int nWidth, int nHeight)
+    void _prepareBitmap(int nWidth, int nHeight)
     {
         // release bitmap
+        _deleteBitmap();
+
+        if (nWidth > 0 && nHeight > 0)
+        {
+            _bmp = CreateBitmap(nWidth, nHeight, 1, 32, nullptr);
+            SelectObject(_DC, _bmp);
+        }
+    }
+
+    void _deleteBitmap()
+    {
         if (_bmp)
         {
             DeleteObject(_bmp);
             _bmp = nullptr;
         }
-        if (nWidth > 0 && nHeight > 0)
-        {
-            _bmp = CreateBitmap(nWidth, nHeight, 1, 32, nullptr);
-            if (!_bmp)
-            {
-                return false;
-            }
-        }
-        return true;
     }
 
     void _fillTextureData()
@@ -573,6 +534,9 @@ private:
 
     Point _convertDrawPoint(Point point, std::string text) {
         Size textSize = measureText(text);
+        // Convert from bottom left to top left.
+        point.y -= _fontSize;
+
         if (_textAlign == CanvasTextAlign::CENTER)
         {
             point.x -= textSize.width / 2.0f;
@@ -588,13 +552,8 @@ private:
         }
         else if (_textBaseLine == CanvasTextBaseline::MIDDLE)
         {
-            point.y += _fontSize / 2.0f;
+             point.y += _fontSize / 2.0f;
         }
-
-        // Since the web platform cannot get the baseline of the font, an additive offset is performed for all platforms.
-        // That's why we should add baseline back again on other platforms
-        GetTextMetrics(_DC, &_tm);
-        point.y -= _tm.tmAscent;
 
         return point;
     }


### PR DESCRIPTION
修复 windows 文本大小变化的问题。之前的代码误用了 `SelectObject()` 和 `DeleteObject()`，同时稍微重构了一下代码，删除不必要的代码。