### PR TITLE
make all transparent pixel color the same as font but alpha

### DIFF
--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -521,11 +521,10 @@ private:
                     COLORREF textColor = (b << 16 | g << 8 | r) & 0x00ffffff;
 
                     // "dirtyValue > 0" means pixel was covered when drawing text
-                    // Set all transparent pixel to (255, 255, 255, 0)
                     if (dirtyValue > 0)
                         val = ((BYTE)(255 * alpha) << 24) | textColor;
                     else
-                        val = textColor;
+                        val = textColor; // Set all transparent pixels to the same color as font.
 
                     ++pPixel;
                     ++pImage;

--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -515,16 +515,18 @@ private:
                     COLORREF& clr = *pPixel;
                     COLORREF& val = *pImage;
                     uint8_t dirtyValue = GetRValue(clr);
+                    r = _fillStyle.r * 255;
+                    g = _fillStyle.g * 255;
+                    b = _fillStyle.b * 255;
+                    COLORREF textColor = (b << 16 | g << 8 | r) & 0x00ffffff;
+
                     // "dirtyValue > 0" means pixel was covered when drawing text
+                    // Set all transparent pixel to (255, 255, 255, 0)
                     if (dirtyValue > 0)
-                    {
-                        // r = _fillStyle.r * 255 * (dirtyValue / 255);
-                        r = _fillStyle.r * dirtyValue;
-                        g = _fillStyle.g * dirtyValue;
-                        b = _fillStyle.b * dirtyValue;
-                        COLORREF textColor = (b << 16 | g << 8 | r) & 0x00ffffff;
-                        val = ((BYTE)(dirtyValue * alpha) << 24) | textColor;
-                    }
+                        val = ((BYTE)(255 * alpha) << 24) | textColor;
+                    else
+                        val = textColor;
+
                     ++pPixel;
                     ++pImage;
                 }


### PR DESCRIPTION
windows 绘制文本时，透明像素的值是(0, 0, 0, 0)。那么在纹理边缘采样时，就会返回(125, 125, 125, 0.5) (因为使用的是 linear）。通过把非透明像素值改为 (255, 255, 255, 0) 后，边缘采样返回的值就是 （255, 255, 255,0.5)。