### PR TITLE
set default text color for editText

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -88,6 +88,7 @@ public class Cocos2dxEditBox {
             super(context);
             //remove focus border
             this.setBackground(null);
+            this.setTextColor(Color.BLACK);
             mScreenHeight = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).
                     getDefaultDisplay().getHeight();
             mPaint = new Paint();


### PR DESCRIPTION
changeLog:
- 修复安卓原生平台在部分机型上， editText 输入框字体默认为白色的问题

<img width="270" alt="test" src="https://user-images.githubusercontent.com/17872773/61838977-5be0f700-aebe-11e9-903c-a11d524f2c21.png">
