### PR TITLE
improve getCurrentLanguage to android

### DIFF
--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -128,8 +128,7 @@ void Application::setPreferredFramesPerSecond(int fps)
 
 std::string Application::getCurrentLanguageCode() const
 {
-    std::string language = getCurrentLanguageCodeJNI();
-    return language;
+    return getCurrentLanguageCodeJNI();
 }
 
 bool Application::isDisplayStats() {

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -128,7 +128,7 @@ void Application::setPreferredFramesPerSecond(int fps)
 
 std::string Application::getCurrentLanguageCode() const
 {
-    std::string language = getCurrentLanguageJNI();
+    std::string language = getCurrentLanguageCodeJNI();
     return language;
 }
 

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -305,7 +305,11 @@ public class Cocos2dxHelper {
     public static String getCurrentLanguage() {
         return Locale.getDefault().getLanguage();
     }
-    
+
+    public static String getCurrentLanguageCode() {
+        return Locale.getDefault().toString();
+    }
+
     public static String getDeviceModel(){
         return Build.MODEL;
     }

--- a/cocos/platform/android/jni/JniImp.cpp
+++ b/cocos/platform/android/jni/JniImp.cpp
@@ -599,6 +599,11 @@ std::string getCurrentLanguageJNI()
     return JniHelper::callStaticStringMethod(JCLS_HELPER, "getCurrentLanguage");
 }
 
+std::string getCurrentLanguageCodeJNI()
+{
+    return JniHelper::callStaticStringMethod(JCLS_HELPER, "getCurrentLanguageCode");
+}
+
 std::string getSystemVersionJNI()
 {
     return JniHelper::callStaticStringMethod(JCLS_HELPER, "getSystemVersion");

--- a/cocos/platform/android/jni/JniImp.h
+++ b/cocos/platform/android/jni/JniImp.h
@@ -42,6 +42,7 @@ extern int getDeviceSampleRateJNI();
 extern int getDeviceAudioBufferSizeInFramesJNI();
 
 extern std::string getCurrentLanguageJNI();
+extern std::string getCurrentLanguageCodeJNI();
 extern std::string getSystemVersionJNI();
 extern bool openURLJNI(const std::string& url);
 extern void copyTextToClipboardJNI(const std::string& text);


### PR DESCRIPTION
用户反馈: https://forum.cocos.com/t/cc-sys-languagecode/81212/2

修复 cc.sys.languageCode 在安卓平台无法获取完整语言地区码