### PR TITLE
Fix frame buffer crash bug

### DIFF
--- a/cocos/renderer/gfx/FrameBuffer.cpp
+++ b/cocos/renderer/gfx/FrameBuffer.cpp
@@ -87,12 +87,11 @@ void FrameBuffer::setColorBuffer(RenderTarget* rt, int index)
 
 void FrameBuffer::setColorBuffers(const std::vector<RenderTarget*>& renderTargets)
 {
+    for (auto& colorBufffer : renderTargets)
+        RENDERER_SAFE_RETAIN(colorBufffer);
     for (auto& colorBufffer : _colorBuffers)
         RENDERER_SAFE_RELEASE(colorBufffer);
-
     _colorBuffers = renderTargets;
-    for (auto& colorBufffer : _colorBuffers)
-        RENDERER_SAFE_RETAIN(colorBufffer);
 }
 
 void FrameBuffer::setDepthBuffer(RenderTarget* rt)

--- a/cocos/renderer/gfx/FrameBuffer.cpp
+++ b/cocos/renderer/gfx/FrameBuffer.cpp
@@ -46,19 +46,22 @@ void FrameBuffer::destroy()
 {
     for (auto colorBufffer : _colorBuffers)
         RENDERER_SAFE_RELEASE(colorBufffer);
+    _colorBuffers.clear();
     
     RENDERER_SAFE_RELEASE(_depthBuffer);
+    _depthBuffer = nullptr;
+    
     RENDERER_SAFE_RELEASE(_stencilBuffer);
+    _stencilBuffer = nullptr;
+    
     RENDERER_SAFE_RELEASE(_depthStencilBuffer);
+    _depthStencilBuffer = nullptr;
     
-    if (_glID == 0)
+    if (_glID != 0)
     {
-        RENDERER_LOGE("The frame-buffer is invalid!");
-        return;
+        glDeleteFramebuffers(1, &_glID);
+        _glID = 0;
     }
-    
-    glDeleteFramebuffers(1, &_glID);
-    _glID = 0;
 }
 
 bool FrameBuffer::init(DeviceGraphics* device, uint16_t width, uint16_t height)

--- a/cocos/renderer/gfx/GraphicsHandle.h
+++ b/cocos/renderer/gfx/GraphicsHandle.h
@@ -51,7 +51,7 @@ public:
     inline GLuint getHandle() const { return _glID; }
 
 protected:
-    GLuint _glID;
+    GLuint _glID = 0;
 };
 
 // end of gfx group


### PR DESCRIPTION
脚本层主动调用framebuffer 的 destroy方法，当framebuffer GC的时候，又会调一次destroy，会造成crash。