### PR TITLE
Fix model batcher crash issue

### DIFF
--- a/cocos/renderer/scene/ModelBatcher.cpp
+++ b/cocos/renderer/scene/ModelBatcher.cpp
@@ -53,7 +53,8 @@ ModelBatcher::ModelBatcher(RenderFlow* flow)
 
 ModelBatcher::~ModelBatcher()
 {
-    reset();
+    setCurrentEffect(nullptr);
+    setNode(nullptr);
     
     for (int i = 0; i < _modelPool.size(); i++)
     {


### PR DESCRIPTION
调用reset方法，会访问RenderFlow，由于RenderFlow在脚本层创建，有可能被gc，导致关闭应用的时候，引起crash的问题。