### PR TITLE
fix maxLength of composed character on EditBox

### DIFF
--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -345,8 +345,10 @@ namespace
         return;
 
     // check length limit after text changed, a little rude
-    if (textField.text.length > g_maxLength)
-        textField.text = [textField.text substringToIndex:g_maxLength];
+    if (textField.text.length > g_maxLength) {
+        NSRange rangeIndex = [textField.text rangeOfComposedCharacterSequenceAtIndex:g_maxLength];
+        textField.text = [textField.text substringToIndex:rangeIndex.location];
+    }
 
     callJSFunc("input", [textField.text UTF8String]);
     setText(textField.text);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1700
相关论坛反馈：
https://forum.cocos.com/t/editbox-bug/81979

changeLog: 
- 修复 EditBox 输入 emoj 时，字符串截取失败的问题

因为 emoj 占用不止一个字节，可能会被截取掉一半，所以在截取之前，应该先拿到可截取的 index

<img width="921" alt="1" src="https://user-images.githubusercontent.com/17872773/63400280-caee3480-c405-11e9-99e3-3b31b4ac01d6.png">

修复后：
<img width="848" alt="2" src="https://user-images.githubusercontent.com/17872773/63400381-291b1780-c406-11e9-8bd7-2bb1de736eae.png">


