### PR TITLE
assertNotSelfChild should check start from this, not this->getParent()

### DIFF
--- a/cocos/renderer/scene/NodeProxy.cpp
+++ b/cocos/renderer/scene/NodeProxy.cpp
@@ -121,7 +121,7 @@ void NodeProxy::addChild(NodeProxy* child)
     auto assertNotSelfChild
         ( [ this, child ]() -> bool
           {
-              for ( NodeProxy* parent( getParent() ); parent != nullptr;
+              for ( NodeProxy* parent( this ); parent != nullptr;
                     parent = parent->getParent() )
                   if ( parent == child )
                       return false;


### PR DESCRIPTION
未修改之前, 我遇到一次爆栈, 原因就是 自己是自己的子节点, 然后无限循环了

此处问题比较大, 有时需要渲染的节点一多就卡死了; 还遇到过满屏元素乱飞的问题
暂时没看完 NodeMemPool 的所有逻辑代码, 暂时不知道为什么会出现 this == child的情况