### PR TITLE
Fix IOS debug mode Spine crash bug

### DIFF
--- a/cocos/editor-support/spine/Json.cpp
+++ b/cocos/editor-support/spine/Json.cpp
@@ -407,7 +407,7 @@ const char *Json::parseArray(Json *item, const char *value) {
 		return value + 1; /* empty array. */
 	}
 
-	item->_child = child = new(__FILE__, __LINE__) Json(NULL);
+	item->_child = child = new Json(NULL);
 	if (!item->_child) {
 		return NULL; /* memory fail */
 	}
@@ -421,7 +421,7 @@ const char *Json::parseArray(Json *item, const char *value) {
 	item->_size = 1;
 
 	while (*value == ',') {
-		Json *new_item = new(__FILE__, __LINE__) Json(NULL);
+		Json *new_item = new Json(NULL);
 		if (!new_item) {
 			return NULL; /* memory fail */
 		}
@@ -463,7 +463,7 @@ const char *Json::parseObject(Json *item, const char *value) {
 		return value + 1; /* empty array. */
 	}
 
-	item->_child = child = new(__FILE__, __LINE__) Json(NULL);
+	item->_child = child = new Json(NULL);
 	if (!item->_child) {
 		return NULL;
 	}
@@ -486,7 +486,7 @@ const char *Json::parseObject(Json *item, const char *value) {
 	item->_size = 1;
 
 	while (*value == ',') {
-		Json *new_item = new(__FILE__, __LINE__) Json(NULL);
+		Json *new_item = new Json(NULL);
 		if (!new_item) {
 			return NULL; /* memory fail */
 		}

--- a/cocos/editor-support/spine/Json.h
+++ b/cocos/editor-support/spine/Json.h
@@ -39,7 +39,7 @@
 #endif
 
 namespace spine {
-class SP_API Json : public SpineObject {
+class SP_API Json {
 	friend class SkeletonJson;
 
 public:

--- a/cocos/editor-support/spine/SkeletonJson.cpp
+++ b/cocos/editor-support/spine/SkeletonJson.cpp
@@ -122,7 +122,7 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 	_error = "";
 	_linkedMeshes.clear();
 
-	root = new(__FILE__, __LINE__) Json(json);
+	root = new Json(json);
 
 	if (!root) {
 		setError(NULL, "Invalid skeleton JSON: ", Json::getError());


### PR DESCRIPTION
修复在ios平台上，选择debug模式时，某些spine文件初始时会崩溃的问题
在spine库中 原本开源的json c库 被修改为c++文件，且继承了Spine的基类，会导致在创建一个对象时，添加各种调试信息，如文件路径名，行号，这些信息会添加到Json的每一个分支结构中，当分支非常多时，调试信息会暴涨，导致在ios中crash。