### PR TITLE
V2.2.0 fix sprite position incorrect when opacity is zero

### DIFF
--- a/build/libcocos2d.vcxproj
+++ b/build/libcocos2d.vcxproj
@@ -37,6 +37,7 @@
     <ClCompile Include="..\cocos\base\CCValue.cpp" />
     <ClCompile Include="..\cocos\base\csscolorparser.cpp" />
     <ClCompile Include="..\cocos\base\etc1.cpp" />
+    <ClCompile Include="..\cocos\base\etc2.cpp" />
     <ClCompile Include="..\cocos\base\pvr.cpp" />
     <ClCompile Include="..\cocos\base\TGAlib.cpp" />
     <ClCompile Include="..\cocos\base\ZipUtils.cpp" />
@@ -325,6 +326,7 @@
     <ClInclude Include="..\cocos\base\CCVector.h" />
     <ClInclude Include="..\cocos\base\csscolorparser.hpp" />
     <ClInclude Include="..\cocos\base\etc1.h" />
+    <ClInclude Include="..\cocos\base\etc2.h" />
     <ClInclude Include="..\cocos\base\pvr.h" />
     <ClInclude Include="..\cocos\base\TGAlib.h" />
     <ClInclude Include="..\cocos\base\uthash.h" />

--- a/build/libcocos2d.vcxproj.filters
+++ b/build/libcocos2d.vcxproj.filters
@@ -806,7 +806,7 @@
     <ClCompile Include="..\cocos\renderer\scene\assembler\TiledMapAssembler.cpp">
       <Filter>renderer\scene\assembler</Filter>
     </ClCompile>
-        <ClCompile Include="..\cocos\renderer\scene\assembler\MeshAssembler.cpp">
+    <ClCompile Include="..\cocos\renderer\scene\assembler\MeshAssembler.cpp">
       <Filter>renderer\scene\assembler</Filter>
     </ClCompile>
     <ClCompile Include="..\cocos\renderer\renderer\CustomProperties.cpp">
@@ -835,6 +835,9 @@
     </ClCompile>
     <ClCompile Include="..\cocos\editor-support\dragonbones-creator-support\CCArmatureCacheDisplay.cpp">
       <Filter>editor-support\dragonbones-creator-support</Filter>
+    </ClCompile>
+    <ClCompile Include="..\cocos\base\etc2.cpp">
+      <Filter>base</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1876,6 +1879,9 @@
     </ClInclude>
     <ClInclude Include="..\cocos\editor-support\dragonbones-creator-support\CCArmatureCacheDisplay.h">
       <Filter>editor-support\dragonbones-creator-support</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cocos\base\etc2.h">
+      <Filter>base</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/base/etc2.cpp
+++ b/cocos/base/etc2.cpp
@@ -25,7 +25,7 @@
  ****************************************************************************/
 
 #include "base/etc2.h"
-
+#include <stdint.h>
 #include <string.h>
 
 static const char kMagic[] = { 'P', 'K', 'M', ' ', '2', '0' };

--- a/cocos/renderer/scene/assembler/AssemblerSprite.cpp
+++ b/cocos/renderer/scene/assembler/AssemblerSprite.cpp
@@ -93,7 +93,7 @@ void AssemblerSprite::fillBuffers(NodeProxy* node, MeshBuffer* buffer, std::size
     uint32_t vertexId = bufferOffset.vertex;
     uint32_t vertexOffset = vertexId - vertexStart;
     
-    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED))
+    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED) || node->isDirty(RenderFlow::NODE_OPACITY_CHANGED))
     {
         generateWorldVertices();
         calculateWorldVertices(node->getWorldMatrix());

--- a/cocos/renderer/scene/assembler/SimpleSprite2D.cpp
+++ b/cocos/renderer/scene/assembler/SimpleSprite2D.cpp
@@ -51,7 +51,7 @@ void SimpleSprite2D::fillBuffers(NodeProxy* node, MeshBuffer* buffer, std::size_
     uint32_t indexId = bufferOffset.index;
     uint32_t vertexId = bufferOffset.vertex;
     
-    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED))
+    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED) || node->isDirty(RenderFlow::NODE_OPACITY_CHANGED))
     {
         float vl = _localData[0],
         vr = _localData[2],


### PR DESCRIPTION
forum：https://forum.cocos.com/t/cocos-creator-v2-2-0-09-23-beta-1/82831/239?u=jjyinkailejj
修复原生平台，当父节点透明度为0，修改子节点的位置，然后恢复父节点透明为1，子节点位置不正确的问题。