### PR TITLE
V2.2.0  fix native sprite position incorrect when parent opacity is zero

### DIFF
--- a/cocos/renderer/scene/assembler/AssemblerSprite.cpp
+++ b/cocos/renderer/scene/assembler/AssemblerSprite.cpp
@@ -93,7 +93,7 @@ void AssemblerSprite::fillBuffers(NodeProxy* node, MeshBuffer* buffer, std::size
     uint32_t vertexId = bufferOffset.vertex;
     uint32_t vertexOffset = vertexId - vertexStart;
     
-    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED) || node->isDirty(RenderFlow::NODE_OPACITY_CHANGED))
+    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED | RenderFlow::NODE_OPACITY_CHANGED))
     {
         generateWorldVertices();
         calculateWorldVertices(node->getWorldMatrix());

--- a/cocos/renderer/scene/assembler/AssemblerSprite.cpp
+++ b/cocos/renderer/scene/assembler/AssemblerSprite.cpp
@@ -93,7 +93,7 @@ void AssemblerSprite::fillBuffers(NodeProxy* node, MeshBuffer* buffer, std::size
     uint32_t vertexId = bufferOffset.vertex;
     uint32_t vertexOffset = vertexId - vertexStart;
     
-    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED))
+    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED) || node->isDirty(RenderFlow::NODE_OPACITY_CHANGED))
     {
         generateWorldVertices();
         calculateWorldVertices(node->getWorldMatrix());

--- a/cocos/renderer/scene/assembler/SimpleSprite2D.cpp
+++ b/cocos/renderer/scene/assembler/SimpleSprite2D.cpp
@@ -51,7 +51,7 @@ void SimpleSprite2D::fillBuffers(NodeProxy* node, MeshBuffer* buffer, std::size_
     uint32_t indexId = bufferOffset.index;
     uint32_t vertexId = bufferOffset.vertex;
     
-    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED))
+    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED) || node->isDirty(RenderFlow::NODE_OPACITY_CHANGED))
     {
         float vl = _localData[0],
         vr = _localData[2],

--- a/cocos/renderer/scene/assembler/SimpleSprite2D.cpp
+++ b/cocos/renderer/scene/assembler/SimpleSprite2D.cpp
@@ -51,7 +51,7 @@ void SimpleSprite2D::fillBuffers(NodeProxy* node, MeshBuffer* buffer, std::size_
     uint32_t indexId = bufferOffset.index;
     uint32_t vertexId = bufferOffset.vertex;
     
-    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED) || node->isDirty(RenderFlow::NODE_OPACITY_CHANGED))
+    if (*_dirty & VERTICES_DIRTY || node->isDirty(RenderFlow::WORLD_TRANSFORM_CHANGED | RenderFlow::NODE_OPACITY_CHANGED))
     {
         float vl = _localData[0],
         vr = _localData[2],


### PR DESCRIPTION
forum：https://forum.cocos.com/t/cocos-creator-v2-2-0-09-23-beta-1/82831/239?u=jjyinkailejj
修复原生平台，当父节点透明度为0，修改子节点的位置，然后恢复父节点透明为1，子节点位置不正确的问题。