### PR TITLE
fix error that can not stop video if it is played by clicking playback controls

### DIFF
--- a/cocos/ui/videoplayer/VideoPlayer-ios.mm
+++ b/cocos/ui/videoplayer/VideoPlayer-ios.mm
@@ -137,7 +137,7 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 
 -(BOOL) isPlaying
 {
-    return (_state == PlayerbackState::PlayerbackStatePlaying);
+    return (self.playerController.player && self.playerController.player.rate != 0);
 }
 
 -(void) setURL:(int)videoSource :(std::string &)videoUrl
@@ -193,7 +193,7 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 
 -(void) play
 {
-    if (self.playerController.player && _state != PlayerbackStatePlaying) {
+    if (self.playerController.player && ![self isPlaying] ) {
         [self.playerController.player play];
         _state = PlayerbackStatePlaying;
         _videoPlayer->onPlayEvent((int)VideoPlayer::EventType::PLAYING);
@@ -202,7 +202,7 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 
 -(void) pause
 {
-    if (self.playerController.player && _state == PlayerbackStatePlaying) {
+    if ( [self isPlaying] ) {
         [self.playerController.player pause];
         _state = PlayerbackStatePaused;
         _videoPlayer->onPlayEvent((int)VideoPlayer::EventType::PAUSED);
@@ -217,8 +217,8 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 
 -(void) stop
 {
-    // AVPlayer doesn't have stop, so just pause it, and seek time to 0.
-    if (self.playerController.player && _state != PlayerbackStopped && _state != PlayerbackStateUnknown) {
+    // AVPlayer doesn't have `stop` method, so just pause it, and seek time to 0.
+    if (self.playerController.player && _state != PlayerbackStopped) {
         [self seekTo:0];
         [self.playerController.player pause];
         _state = PlayerbackStopped;


### PR DESCRIPTION
通过 videoplayer 自带的状态栏播放视频时，程序无法得到通知，这样就会导致内部的状态出现错误导致无法停止播放。现在改成查询 `VideoPlayer.rate` 属性来判断视频是否正在播放。