### PR TITLE
fix crash when restart application

### DIFF
--- a/cocos/renderer/gfx/VertexBuffer.cpp
+++ b/cocos/renderer/gfx/VertexBuffer.cpp
@@ -45,8 +45,7 @@ VertexBuffer::~VertexBuffer()
 bool VertexBuffer::init(DeviceGraphics* device, VertexFormat* format, Usage usage, const void* data, size_t dataByteLength, uint32_t numVertices)
 {
     _device = device;
-    _format = format;
-    CC_SAFE_RETAIN(_format);
+    setFormat(format);
     _usage = usage;
     _numVertices = numVertices;
 

--- a/cocos/renderer/gfx/VertexBuffer.h
+++ b/cocos/renderer/gfx/VertexBuffer.h
@@ -132,8 +132,8 @@ public:
     void destroy();
 
 private:
-    DeviceGraphics* _device;
-    VertexFormat* _format;
+    DeviceGraphics* _device = nullptr;
+    VertexFormat* _format = nullptr;
     Usage _usage;
     uint32_t _numVertices;
     uint32_t _bytes;

--- a/cocos/renderer/scene/assembler/Assembler.cpp
+++ b/cocos/renderer/scene/assembler/Assembler.cpp
@@ -77,6 +77,7 @@ Assembler::Assembler()
 Assembler::~Assembler()
 {
     CC_SAFE_RELEASE_NULL(_datas);
+    CC_SAFE_RELEASE(_vfmt);
 }
 
 void Assembler::updateMeshIndex(std::size_t iaIndex, int meshIndex)
@@ -205,6 +206,8 @@ void Assembler::fillBuffers(NodeProxy* node, MeshBuffer* buffer, std::size_t ind
 void Assembler::setVertexFormat(VertexFormat* vfmt)
 {
     if (_vfmt == vfmt) return;
+    CC_SAFE_RETAIN(vfmt);
+    CC_SAFE_RELEASE(_vfmt);
     _vfmt = vfmt;
     if (_vfmt)
     {

--- a/cocos/scripting/js-bindings/manual/jsb_gfx_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_gfx_manual.cpp
@@ -847,7 +847,7 @@ static bool js_cocos2d_renderer_VertexFormat_finalize(se::State& s)
 {
     cocos2d::renderer::VertexFormat* cobj = (cocos2d::renderer::VertexFormat*)s.nativeThisObject();
     SE_PRECONDITION2(cobj, false, "js_gfx_VertexFormat_getElement : Invalid Native Object");
-    delete cobj;
+    cobj->release();
     return true;
 }
 SE_BIND_FINALIZE_FUNC(js_cocos2d_renderer_VertexFormat_finalize)


### PR DESCRIPTION
崩溃的主要原因是 JS 的析构函数使用了 delete 操作，而别的地方使用 retain/release 操作导致的问题。

另外我改了其它的几处地方：
- VertexBuffer::init 如果被调用多次的话会有内存泄露
- Assembler 也对 VertexFormat 进行 retain/release 操作，虽然从前后逻辑来看是不需要。但是加上会比较保险，使用习惯也一致。以后要是改变逻辑也不用担心。