### PR TITLE
init default color for editBox

### DIFF
--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -215,6 +215,7 @@ namespace
         if (! g_textField)
         {
             g_textField = [[UITextField alloc] initWithFrame:rect];
+            g_textField.textColor = [UIColor blackColor];
             [g_textField setBorderStyle:UITextBorderStyleLine];
             g_textField.backgroundColor = [UIColor whiteColor];
             
@@ -240,7 +241,7 @@ namespace
         if (!g_textView)
         {
             g_textView = [[UITextView alloc] initWithFrame:btnRect];
-            
+            g_textView.textColor = [UIColor blackColor];
             g_textViewDelegate = [[TextViewDelegate alloc] init];
             g_textView.delegate = g_textViewDelegate;
             


### PR DESCRIPTION
changeLog:
- 修复 iOS13 深色模式导致白色字体看不到的问题

字体应该设置默认黑色
相关论坛反馈：
https://forum.cocos.com/t/cocos-creator-v2-2-0-09-30-beta-3/82831/421