### PR TITLE
correct max audio instance on Android

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.h
+++ b/cocos/audio/android/AudioEngine-inl.h
@@ -36,7 +36,7 @@
 #include "base/CCRef.h"
 #include "base/ccUtils.h"
 
-#define MAX_AUDIOINSTANCES 24
+#define MAX_AUDIOINSTANCES 13
 
 #define ERRORLOG(msg) log("fun:%s,line:%d,msg:%s",__func__,__LINE__,#msg)
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1881

changeLog:
- 更正安卓上最大的音频实例数量为 13

由于安卓上使用的音频库是 OpenSL，不同于 其他原生平台的 OpenAL，实际测试里，支持的最大音轨数量是 13
<img width="1389" alt="1" src="https://user-images.githubusercontent.com/17872773/66552476-0393ca00-eb7c-11e9-92b1-d768f58f48f4.png">
