### PR TITLE
refine pause playing audio when enter background

### DIFF
--- a/cocos/audio/android/AudioEngine-inl.h
+++ b/cocos/audio/android/AudioEngine-inl.h
@@ -75,10 +75,6 @@ public:
 
     void setAudioFocusForAllPlayers(bool isFocus);
 private:
-
-    void onEnterBackground(const CustomEvent&);
-    void onEnterForeground(const CustomEvent&);
-
     // engine interfaces
     SLObjectItf _engineObject;
     SLEngineItf _engineEngine;
@@ -94,8 +90,6 @@ private:
     std::unordered_map<int, IAudioPlayer*> _urlAudioPlayersNeedResume;
 
     AudioPlayerProvider* _audioPlayerProvider;
-    uint32_t _onPauseListenerID;
-    uint32_t _onResumeListenerID;
 
     int _audioIDIndex;
     

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -29,6 +29,9 @@
 #include "base/ccMacros.h"
 #include "audio/include/Export.h"
 
+#include "scripting/js-bindings/event/EventDispatcher.h"
+#include "scripting/js-bindings/event/CustomEventTypes.h"
+
 #include <functional>
 #include <list>
 #include <string>
@@ -371,6 +374,14 @@ protected:
     static AudioEngineThreadPool* s_threadPool;
     
     static bool _isEnabled;
+    
+private:
+    static uint32_t _onPauseListenerID;
+    static uint32_t _onResumeListenerID;
+    static std::vector<int> _breakAudioID;
+    
+    static void onEnterBackground(const CustomEvent&);
+    static void onEnterForeground(const CustomEvent&);
     
     friend class AudioEngineImpl;
 };

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -27,7 +27,6 @@
 
 #include "cocos2d.h"
 
-#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/manual/jsb_module_register.hpp"
 #include "cocos/scripting/js-bindings/manual/jsb_global.h"
 #include "cocos/scripting/js-bindings/jswrapper/SeApi.h"
@@ -80,12 +79,10 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
-    AudioEngine::pauseAll();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
-    AudioEngine::resumeAll();
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -27,7 +27,6 @@
 
 #include "cocos2d.h"
 
-#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/manual/jsb_module_register.hpp"
 #include "cocos/scripting/js-bindings/manual/jsb_global.h"
 #include "cocos/scripting/js-bindings/jswrapper/SeApi.h"
@@ -79,12 +78,10 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
-    AudioEngine::pauseAll();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
-    AudioEngine::resumeAll();
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -26,8 +26,6 @@
 #include "AppDelegate.h"
 
 #include "cocos2d.h"
-
-#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/event/EventDispatcher.h"
 
 #include "ide-support/CodeIDESupport.h"
@@ -66,12 +64,10 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
-    AudioEngine::pauseAll();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
-    AudioEngine::resumeAll();
     EventDispatcher::dispatchEnterForegroundEvent();
 }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1886 https://github.com/cocos-creator/2d-tasks/issues/1806

changeLog:
- 修复暂停的音频，进入后台再回到前台后，自动恢复播放的问题

进入后台时，应该暂停正在播放的 Audio，回到前台，才恢复播放
最开始这部分逻辑只在安卓上的 AudioEngineImpl 做了，可能是历史遗留问题。。。
把这部分实现挪到最顶层的 AudioEngine 里实现跨平台