### PR TITLE
fix editBox background color in iOS13

### DIFF
--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -216,6 +216,7 @@ namespace
         {
             g_textField = [[UITextField alloc] initWithFrame:rect];
             g_textField.textColor = [UIColor blackColor];
+            g_textField.backgroundColor = [UIColor whiteColor];
             [g_textField setBorderStyle:UITextBorderStyleLine];
             g_textField.backgroundColor = [UIColor whiteColor];
             
@@ -242,6 +243,7 @@ namespace
         {
             g_textView = [[UITextView alloc] initWithFrame:btnRect];
             g_textView.textColor = [UIColor blackColor];
+            g_textView.backgroundColor = [UIColor whiteColor];
             g_textViewDelegate = [[TextViewDelegate alloc] init];
             g_textView.delegate = g_textViewDelegate;
             

--- a/cocos/ui/edit-box/EditBox-mac.mm
+++ b/cocos/ui/edit-box/EditBox-mac.mm
@@ -186,6 +186,8 @@ namespace
         if (! g_textView)
         {
             g_textView = [[NSTextView alloc] initWithFrame:rect];
+            g_textView.textColor = [NSColor blackColor];
+            g_textView.backgroundColor = [NSColor whiteColor];
             g_textView.editable = TRUE;
             g_textView.hidden = FALSE;
             g_textView.delegate = [[TextViewDelegate alloc] init];
@@ -230,6 +232,8 @@ namespace
             if (! g_secureTextField)
             {
                 g_secureTextField = [[NSSecureTextField alloc] init];
+                g_secureTextField.textColor = [NSColor blackColor];
+                g_secureTextField.backgroundColor = [NSColor whiteColor];
                 g_secureTextField.delegate = [[TextFieldDelegate alloc] init];
                 g_secureTextField.formatter = [[TextFieldFormatter alloc] init];
             }
@@ -240,6 +244,8 @@ namespace
             if (! g_textField)
             {
                 g_textField = [[NSTextField alloc] init];
+                g_textField.textColor = [NSColor blackColor];
+                g_textField.backgroundColor = [NSColor whiteColor];
                 g_textField.delegate = [[TextFieldDelegate alloc] init];
                 g_textField.formatter = [[TextFieldFormatter alloc] init];
             }


### PR DESCRIPTION
changeLog:
- 统一 iOS13 和 MacOS Catalina 深色模式下 EditBox 的字体颜色为白色，背景颜色为黑色

textView 和 textField 的背景颜色不统一
<img width="648" alt="1" src="https://user-images.githubusercontent.com/17872773/66904534-d55c3180-f036-11e9-9a03-f8837346eb7a.png">
<img width="508" alt="2" src="https://user-images.githubusercontent.com/17872773/66904543-d8efb880-f036-11e9-8b28-2576dcedc3b1.png">
![3](https://user-images.githubusercontent.com/17872773/66904558-dbeaa900-f036-11e9-93fc-05212f529e4a.jpeg)
![4](https://user-images.githubusercontent.com/17872773/66904565-dee59980-f036-11e9-89d8-258a414f2812.jpeg)
