### PR TITLE
fixed particle autoRemoveOnFinish bug

### DIFF
--- a/cocos/editor-support/particle/ParticleSimulator.cpp
+++ b/cocos/editor-support/particle/ParticleSimulator.cpp
@@ -98,6 +98,7 @@ ParticleSimulator::~ParticleSimulator()
 
 void ParticleSimulator::stop()
 {
+    _readyPlay = false;
     _active = false;
     _elapsed = duration;
     _emitCounter = 0;
@@ -108,6 +109,7 @@ void ParticleSimulator::reset()
     _active = true;
     _elapsed = 0;
     _emitCounter = 0;
+    _readyPlay = true;
     _finished = false;
     for (auto particle : _particles)
     {
@@ -449,7 +451,7 @@ void ParticleSimulator::render(float dt)
     assembler->updateIABuffer(0, mb->getGLVB(), mb->getGLIB());
     assembler->updateIARange(0, indexStart, indexCount);
     
-    if (_particles.size() == 0 && !_active)
+    if (_particles.size() == 0 && !_active && !_readyPlay)
     {
         _finished = true;
         if (_finishedCallback)

--- a/cocos/editor-support/particle/ParticleSimulator.h
+++ b/cocos/editor-support/particle/ParticleSimulator.h
@@ -228,6 +228,7 @@ public:
 private:
     std::vector<Particle*>          _particles;
     bool                            _active = false;
+    bool                            _readyPlay = true;
     bool                            _finished = false;
     float                           _elapsed = 0;
     float                           _emitCounter = 0;


### PR DESCRIPTION
cocos-creator/2d-tasks#1919

未修复之前，当 particle 组件的节点为勾选 autoRemoveOnFinish 时，如果它没有选择 playOnLoad 的话，就会在 _finishedSimulation 函数中被销毁。
加了一个 readyPlay 字段，记录粒子是否处理准备播放阶段。