### PR TITLE
fix window size

### DIFF
--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -137,6 +137,8 @@ public:
      @return Current language iso 639-1 code.
      */
     std::string getCurrentLanguageCode() const;
+    
+    cocos2d::Vec2 getResolution();
 
     /**
      @brief Get current display stats.

--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -138,14 +138,8 @@ public:
      */
     std::string getCurrentLanguageCode() const;
     
-    cocos2d::Vec2 getViewSize();
-
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
-    void updateViewSize();
-#elif (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
+    const cocos2d::Vec2& getViewSize();
     void updateViewSize(int width, int height);
-#endif
-
 
     /**
      @brief Get current display stats.
@@ -214,10 +208,7 @@ private:
     bool _isStarted = false;
     bool _isDownsampleEnabled = false;
 
-
-#if (CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID)
     cocos2d::Vec2 _viewSize;
-#endif
 };
 
 // end of platform group

--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -140,6 +140,13 @@ public:
     
     cocos2d::Vec2 getViewSize();
 
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+    void updateViewSize();
+#elif (CC_TARGET_PLATFORM == CC_PLATFORM_MAC || CC_TARGET_PLATFORM == CC_PLATFORM_WIN32)
+    void updateViewSize(int width, int height);
+#endif
+
+
     /**
      @brief Get current display stats.
      @return bool, is displaying stats or not.
@@ -206,6 +213,11 @@ private:
     bool _multiTouch = false;
     bool _isStarted = false;
     bool _isDownsampleEnabled = false;
+
+
+#if (CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID)
+    cocos2d::Vec2 _viewSize;
+#endif
 };
 
 // end of platform group

--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -138,7 +138,7 @@ public:
      */
     std::string getCurrentLanguageCode() const;
     
-    cocos2d::Vec2 getResolution();
+    cocos2d::Vec2 getViewSize();
 
     /**
      @brief Get current display stats.

--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -138,7 +138,7 @@ public:
      */
     std::string getCurrentLanguageCode() const;
     
-    const cocos2d::Vec2& getViewSize();
+    const cocos2d::Vec2& getViewSize() const;
     void updateViewSize(int width, int height);
 
     /**

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "platform/CCApplication.h"
 #include <EGL/egl.h>
 #include <cstring>
+#include <jni.h>
 #include "platform/android/jni/JniImp.h"
 #include "platform/android/CCGL-android.h"
 #include "base/CCScheduler.h"
@@ -51,6 +52,22 @@ PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOESEXT = 0;
 PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
 
 NS_CC_BEGIN
+
+// _resolution can't be private member of Application
+// because _resolution updated before initiating Application
+cocos2d::Vec2 _resolution;
+
+void updateResolution(int width, int height)
+{
+    _resolution.x = width;
+    _resolution.y = height;
+}
+
+extern "C" {
+    void Java_org_cocos2dx_lib_Cocos2dxGLSurfaceView_nativeOnSizeChanged(JNIEnv * env, jobject obj, jint width, jint height) {
+        updateResolution(width, height);
+    }
+}
 
 Application* Application::_instance = nullptr;
 std::shared_ptr<Scheduler> Application::_scheduler = nullptr;
@@ -264,6 +281,11 @@ void Application::copyTextToClipboard(const std::string &text)
 std::string Application::getSystemVersion()
 {
     return getSystemVersionJNI();
+}
+
+cocos2d::Vec2 Application::getResolution()
+{
+    return _resolution;
 }
 
 NS_CC_END

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -53,11 +53,7 @@ PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
 
 NS_CC_BEGIN
 
-// _viewSize can't be private member of Application
-// because _viewSize updated before initiating Application
-cocos2d::Vec2 _viewSize;
-
-void updateViewSize(int width, int height)
+void Application::updateViewSize(int width, int height)
 {
     _viewSize.x = width;
     _viewSize.y = height;
@@ -65,7 +61,11 @@ void updateViewSize(int width, int height)
 
 extern "C" {
     void Java_org_cocos2dx_lib_Cocos2dxGLSurfaceView_nativeOnSizeChanged(JNIEnv * env, jobject obj, jint width, jint height) {
-        updateViewSize(width, height);
+        auto inst = Application::getInstance();
+        // nativeOnSizeChanged is firstly called before Application initiating.
+        if (inst != nullptr) {
+            inst->updateViewSize(width, height);
+        }
     }
 }
 
@@ -84,6 +84,7 @@ Application::Application(const std::string& name, int width, int height)
     PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = (PFNGLDELETEVERTEXARRAYSOESPROC)eglGetProcAddress("glDeleteVertexArraysOES");
 
     _renderTexture = new RenderTexture(width, height);
+    updateViewSize(width, height);
 }
 
 Application::~Application()
@@ -283,7 +284,7 @@ std::string Application::getSystemVersion()
     return getSystemVersionJNI();
 }
 
-cocos2d::Vec2 Application::getViewSize()
+const cocos2d::Vec2& Application::getViewSize()
 {
     return _viewSize;
 }

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -284,7 +284,7 @@ std::string Application::getSystemVersion()
     return getSystemVersionJNI();
 }
 
-const cocos2d::Vec2& Application::getViewSize()
+const cocos2d::Vec2& Application::getViewSize() const
 {
     return _viewSize;
 }

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -53,19 +53,19 @@ PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOESEXT = 0;
 
 NS_CC_BEGIN
 
-// _resolution can't be private member of Application
-// because _resolution updated before initiating Application
-cocos2d::Vec2 _resolution;
+// _viewSize can't be private member of Application
+// because _viewSize updated before initiating Application
+cocos2d::Vec2 _viewSize;
 
-void updateResolution(int width, int height)
+void updateViewSize(int width, int height)
 {
-    _resolution.x = width;
-    _resolution.y = height;
+    _viewSize.x = width;
+    _viewSize.y = height;
 }
 
 extern "C" {
     void Java_org_cocos2dx_lib_Cocos2dxGLSurfaceView_nativeOnSizeChanged(JNIEnv * env, jobject obj, jint width, jint height) {
-        updateResolution(width, height);
+        updateViewSize(width, height);
     }
 }
 
@@ -283,9 +283,9 @@ std::string Application::getSystemVersion()
     return getSystemVersionJNI();
 }
 
-cocos2d::Vec2 Application::getResolution()
+cocos2d::Vec2 Application::getViewSize()
 {
-    return _resolution;
+    return _viewSize;
 }
 
 NS_CC_END

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxGLSurfaceView.java
@@ -54,6 +54,8 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
     private Cocos2dxRenderer mCocos2dxRenderer;
     private boolean mStopHandleTouchAndKeyEvents = false;
 
+    public static native void nativeOnSizeChanged(int width, int height);
+
     // ===========================================================
     // Constructors
     // ===========================================================
@@ -250,6 +252,7 @@ public class Cocos2dxGLSurfaceView extends GLSurfaceView {
     protected void onSizeChanged(final int pNewSurfaceWidth, final int pNewSurfaceHeight, final int pOldSurfaceWidth, final int pOldSurfaceHeight) {
         if(!this.isInEditMode()) {
             this.mCocos2dxRenderer.setScreenWidthAndHeight(pNewSurfaceWidth, pNewSurfaceHeight);
+            nativeOnSizeChanged(pNewSurfaceWidth, pNewSurfaceHeight);
         }
     }
 

--- a/cocos/platform/desktop/CCGLView-desktop.cpp
+++ b/cocos/platform/desktop/CCGLView-desktop.cpp
@@ -215,6 +215,11 @@ float GLView::getScale() const
     return _scale;
 }
 
+void GLView::getWindowSize(int &width, int &height)
+{
+    glfwGetWindowSize(_mainWindow, &width, &height);
+}
+
 GLint GLView::getMainFBO() const
 {
     return _mainFBO;

--- a/cocos/platform/desktop/CCGLView-desktop.cpp
+++ b/cocos/platform/desktop/CCGLView-desktop.cpp
@@ -184,6 +184,7 @@ GLView::GLView(Application* application, const std::string& name, int x, int y, 
     computeScale();
     
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_mainFBO);
+    Application::getInstance()->updateViewSize(width, height);
 }
 
 GLView::~GLView()
@@ -213,11 +214,6 @@ void GLView::swapBuffers()
 float GLView::getScale() const
 {
     return _scale;
-}
-
-void GLView::getWindowSize(int &width, int &height)
-{
-    glfwGetWindowSize(_mainWindow, &width, &height);
 }
 
 GLint GLView::getMainFBO() const
@@ -448,6 +444,7 @@ void GLView::onGLFWWindowIconifyCallback(GLFWwindow* /*window*/, int iconified)
 
 void GLView::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int height)
 {
+    Application::getInstance()->updateViewSize(width, height);
     EventDispatcher::dispatchResizeEvent(width, height);
 }
 

--- a/cocos/platform/desktop/CCGLView-desktop.h
+++ b/cocos/platform/desktop/CCGLView-desktop.h
@@ -65,6 +65,7 @@ public:
     void pollEvents();
     void swapBuffers();
     float getScale() const;
+    void getWindowSize(int &width, int &height);
     GLint getMainFBO() const;
     void setIsEditboxEditing(bool value);
 

--- a/cocos/platform/desktop/CCGLView-desktop.h
+++ b/cocos/platform/desktop/CCGLView-desktop.h
@@ -65,7 +65,6 @@ public:
     void pollEvents();
     void swapBuffers();
     float getScale() const;
-    void getWindowSize(int &width, int &height);
     GLint getMainFBO() const;
     void setIsEditboxEditing(bool value);
 

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -39,19 +39,9 @@
 
 namespace
 {
-    cocos2d::Vec2 getResolution()
-    {
-        CGRect bounds = [UIScreen mainScreen].bounds;
-        float scale = [[UIScreen mainScreen] scale];
-        float width = bounds.size.width * scale;
-        float height = bounds.size.height * scale;
-        
-        return cocos2d::Vec2(width, height);
-    }
-    
     bool setCanvasCallback(se::Object* global)
     {
-        cocos2d::Vec2 resolution = getResolution();
+        cocos2d::Vec2 resolution = cocos2d::Application::getInstance()->getResolution();
         se::ScriptEngine* se = se::ScriptEngine::getInstance();
         uint8_t devicePixelRatio = cocos2d::Application::getInstance()->getDevicePixelRatio();
         char commandBuf[200] = {0};
@@ -243,6 +233,16 @@ Application::~Application()
     _renderTexture = nullptr;
 
     Application::_instance = nullptr;
+}
+
+cocos2d::Vec2 Application::getResolution()
+{
+    CGRect bounds = [UIScreen mainScreen].bounds;
+    float scale = [[UIScreen mainScreen] scale];
+    float width = bounds.size.width * scale;
+    float height = bounds.size.height * scale ;
+    
+    return cocos2d::Vec2(width, height);
 }
 
 void Application::start()

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -209,6 +209,8 @@ Application::Application(const std::string& name, int width, int height)
     EventDispatcher::init();
     
     _delegate = [[MainLoop alloc] initWithApplication:this];
+    
+    updateViewSize();
 }
 
 Application::~Application()
@@ -237,12 +239,17 @@ Application::~Application()
 
 cocos2d::Vec2 Application::getViewSize()
 {
+    return _viewSize;
+}
+
+void Application::updateViewSize()
+{
     CGRect bounds = [UIScreen mainScreen].bounds;
     float scale = [[UIScreen mainScreen] scale];
     float width = bounds.size.width * scale;
-    float height = bounds.size.height * scale ;
-    
-    return cocos2d::Vec2(width, height);
+    float height = bounds.size.height * scale;
+    _viewSize.x = width;
+    _viewSize.y = height;
 }
 
 void Application::start()

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -210,7 +210,7 @@ Application::Application(const std::string& name, int width, int height)
     
     _delegate = [[MainLoop alloc] initWithApplication:this];
     
-    updateViewSize();
+    updateViewSize(width, height);
 }
 
 Application::~Application()
@@ -237,17 +237,13 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-cocos2d::Vec2 Application::getViewSize()
+const cocos2d::Vec2& Application::getViewSize()
 {
     return _viewSize;
 }
 
-void Application::updateViewSize()
+void Application::updateViewSize(int width, int height)
 {
-    CGRect bounds = [UIScreen mainScreen].bounds;
-    float scale = [[UIScreen mainScreen] scale];
-    float width = bounds.size.width * scale;
-    float height = bounds.size.height * scale;
     _viewSize.x = width;
     _viewSize.y = height;
 }

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -41,15 +41,15 @@ namespace
 {
     bool setCanvasCallback(se::Object* global)
     {
-        cocos2d::Vec2 resolution = cocos2d::Application::getInstance()->getResolution();
+        cocos2d::Vec2 viewSize = cocos2d::Application::getInstance()->getViewSize();
         se::ScriptEngine* se = se::ScriptEngine::getInstance();
         uint8_t devicePixelRatio = cocos2d::Application::getInstance()->getDevicePixelRatio();
         char commandBuf[200] = {0};
         sprintf(commandBuf, "window.innerWidth = %d; window.innerHeight = %d;",
-                (int)(resolution.x / devicePixelRatio),
-                (int)(resolution.y / devicePixelRatio));
+                (int)(viewSize.x / devicePixelRatio),
+                (int)(viewSize.y / devicePixelRatio));
         se->evalString(commandBuf);
-        cocos2d::ccViewport(0, 0, resolution.x / devicePixelRatio, resolution.y / devicePixelRatio);
+        cocos2d::ccViewport(0, 0, viewSize.x / devicePixelRatio, viewSize.y / devicePixelRatio);
         glDepthMask(GL_TRUE);
         return true;
     }
@@ -235,7 +235,7 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-cocos2d::Vec2 Application::getResolution()
+cocos2d::Vec2 Application::getViewSize()
 {
     CGRect bounds = [UIScreen mainScreen].bounds;
     float scale = [[UIScreen mainScreen] scale];

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -41,7 +41,7 @@ namespace
 {
     bool setCanvasCallback(se::Object* global)
     {
-        cocos2d::Vec2 viewSize = cocos2d::Application::getInstance()->getViewSize();
+        auto &viewSize = cocos2d::Application::getInstance()->getViewSize();
         se::ScriptEngine* se = se::ScriptEngine::getInstance();
         uint8_t devicePixelRatio = cocos2d::Application::getInstance()->getDevicePixelRatio();
         char commandBuf[200] = {0};
@@ -237,7 +237,7 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-const cocos2d::Vec2& Application::getViewSize()
+const cocos2d::Vec2& Application::getViewSize() const
 {
     return _viewSize;
 }

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -100,13 +100,13 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-cocos2d::Vec2 Application::getResolution() {
-    auto res = Vec2();
+cocos2d::Vec2 Application::getViewSize() {
+    auto viewSize = Vec2();
     int width, height;
     CAST_VIEW(_view)->getWindowSize(width, height);
-    res.x = width;
-    res.y = height;
-    return res;
+    viewSize.x = width;
+    viewSize.y = height;
+    return viewSize;
 }
 
 void Application::start()

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -101,12 +101,12 @@ Application::~Application()
 }
 
 cocos2d::Vec2 Application::getViewSize() {
-    auto viewSize = Vec2();
-    int width, height;
-    CAST_VIEW(_view)->getWindowSize(width, height);
-    viewSize.x = width;
-    viewSize.y = height;
-    return viewSize;
+    return _viewSize;
+}
+
+void Application::updateViewSize(int width, int height) {
+    _viewSize.x = width;
+    _viewSize.y = height;
 }
 
 void Application::start()

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -100,6 +100,15 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
+cocos2d::Vec2 Application::getResolution() {
+    auto res = Vec2();
+    int width, height;
+    CAST_VIEW(_view)->getWindowSize(width, height);
+    res.x = width;
+    res.y = height;
+    return res;
+}
+
 void Application::start()
 {
     if (!_view)

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -100,7 +100,7 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-cocos2d::Vec2 Application::getViewSize() {
+const cocos2d::Vec2& Application::getViewSize() {
     return _viewSize;
 }
 

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -100,11 +100,13 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-const cocos2d::Vec2& Application::getViewSize() {
+const cocos2d::Vec2& Application::getViewSize() const
+{
     return _viewSize;
 }
 
-void Application::updateViewSize(int width, int height) {
+void Application::updateViewSize(int width, int height)
+{
     _viewSize.x = width;
     _viewSize.y = height;
 }

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -134,11 +134,13 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-const cocos2d::Vec2& Application::getViewSize() {
+const cocos2d::Vec2& Application::getViewSize() const
+{
     return _viewSize;
 }
 
-void Application::updateViewSize(int width, int height) {
+void Application::updateViewSize(int width, int height)
+{
     _viewSize.x = width;
     _viewSize.y = height;
 }

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -134,13 +134,13 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-cocos2d::Vec2 Application::getResolution() {
-    auto res = Vec2();
+cocos2d::Vec2 Application::getViewSize() {
+    auto viewSize = Vec2();
     int width, height;
     CAST_VIEW(_view)->getWindowSize(width, height);
-    res.x = width;
-    res.y = height;
-    return res;
+    viewSize.x = width;
+    viewSize.y = height;
+    return viewSize;
 }
 
 void Application::start()

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -134,6 +134,15 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
+cocos2d::Vec2 Application::getResolution() {
+    auto res = Vec2();
+    int width, height;
+    CAST_VIEW(_view)->getWindowSize(width, height);
+    res.x = width;
+    res.y = height;
+    return res;
+}
+
 void Application::start()
 {
     if (!_view)

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -135,12 +135,12 @@ Application::~Application()
 }
 
 cocos2d::Vec2 Application::getViewSize() {
-    auto viewSize = Vec2();
-    int width, height;
-    CAST_VIEW(_view)->getWindowSize(width, height);
-    viewSize.x = width;
-    viewSize.y = height;
-    return viewSize;
+    return _viewSize;
+}
+
+void Application::updateViewSize(int width, int height) {
+    _viewSize.x = width;
+    _viewSize.y = height;
 }
 
 void Application::start()

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -134,7 +134,7 @@ Application::~Application()
     Application::_instance = nullptr;
 }
 
-cocos2d::Vec2 Application::getViewSize() {
+const cocos2d::Vec2& Application::getViewSize() {
     return _viewSize;
 }
 

--- a/cocos/renderer/renderer/ForwardRenderer.cpp
+++ b/cocos/renderer/renderer/ForwardRenderer.cpp
@@ -92,11 +92,11 @@ void ForwardRenderer::render(Scene* scene)
     updateLights(scene);
     scene->sortCameras();
     auto& cameras = scene->getCameras();
-    Vec2 res = Application::getInstance()->getResolution();
+    Vec2 viewSize = Application::getInstance()->getViewSize();
     for (auto& camera : cameras)
     {
         View* view = requestView();
-        camera->extractView(*view, res.x, res.y);
+        camera->extractView(*view, viewSize.x, viewSize.y);
     }
 
     for (size_t i = 0, len = _views->getLength(); i < len; ++i) {
@@ -110,9 +110,9 @@ void ForwardRenderer::render(Scene* scene)
 void ForwardRenderer::renderCamera(Camera* camera, Scene* scene)
 {
     reset();
-    Vec2 res = Application::getInstance()->getResolution();
-    int width = res.x;
-    int height = res.y;
+    Vec2 viewSize = Application::getInstance()->getViewSize();
+    int width = viewSize.x;
+    int height = viewSize.y;
     FrameBuffer* fb = camera->getFrameBuffer();
     if (nullptr != fb) {
         width = fb->getWidth();

--- a/cocos/renderer/renderer/ForwardRenderer.cpp
+++ b/cocos/renderer/renderer/ForwardRenderer.cpp
@@ -39,6 +39,8 @@
 #include "Light.h"
 #include <algorithm>
 
+#include "CCApplication.h"
+
 #include "math/MathUtil.h"
 
 RENDERER_BEGIN
@@ -95,7 +97,8 @@ void ForwardRenderer::render(Scene* scene)
     for (auto& camera : cameras)
     {
         View* view = requestView();
-        camera->extractView(*view, _width, _height);
+        Vec2 res = Application::getInstance()->getResolution();
+        camera->extractView(*view, res.x, res.y);
     }
 
     for (size_t i = 0, len = _views->getLength(); i < len; ++i) {

--- a/cocos/renderer/renderer/ForwardRenderer.cpp
+++ b/cocos/renderer/renderer/ForwardRenderer.cpp
@@ -92,7 +92,7 @@ void ForwardRenderer::render(Scene* scene)
     updateLights(scene);
     scene->sortCameras();
     auto& cameras = scene->getCameras();
-    Vec2 viewSize = Application::getInstance()->getViewSize();
+    auto &viewSize = Application::getInstance()->getViewSize();
     for (auto& camera : cameras)
     {
         View* view = requestView();
@@ -110,7 +110,7 @@ void ForwardRenderer::render(Scene* scene)
 void ForwardRenderer::renderCamera(Camera* camera, Scene* scene)
 {
     reset();
-    Vec2 viewSize = Application::getInstance()->getViewSize();
+    auto &viewSize = Application::getInstance()->getViewSize();
     int width = viewSize.x;
     int height = viewSize.y;
     FrameBuffer* fb = camera->getFrameBuffer();

--- a/cocos/renderer/renderer/ForwardRenderer.cpp
+++ b/cocos/renderer/renderer/ForwardRenderer.cpp
@@ -74,8 +74,6 @@ ForwardRenderer::~ForwardRenderer()
 bool ForwardRenderer::init(DeviceGraphics* device, std::vector<ProgramLib::Template>& programTemplates, Texture2D* defaultTexture, int width, int height)
 {
     BaseRenderer::init(device, programTemplates, defaultTexture);
-    _width = width;
-    _height = height;
     registerStage("opaque", std::bind(&ForwardRenderer::opaqueStage, this, std::placeholders::_1, std::placeholders::_2));
     registerStage("shadowcast", std::bind(&ForwardRenderer::shadowStage, this, std::placeholders::_1, std::placeholders::_2));
     registerStage("transparent", std::bind(&ForwardRenderer::transparentStage, this, std::placeholders::_1, std::placeholders::_2));
@@ -94,10 +92,10 @@ void ForwardRenderer::render(Scene* scene)
     updateLights(scene);
     scene->sortCameras();
     auto& cameras = scene->getCameras();
+    Vec2 res = Application::getInstance()->getResolution();
     for (auto& camera : cameras)
     {
         View* view = requestView();
-        Vec2 res = Application::getInstance()->getResolution();
         camera->extractView(*view, res.x, res.y);
     }
 
@@ -112,8 +110,9 @@ void ForwardRenderer::render(Scene* scene)
 void ForwardRenderer::renderCamera(Camera* camera, Scene* scene)
 {
     reset();
-    int width = _width;
-    int height = _height;
+    Vec2 res = Application::getInstance()->getResolution();
+    int width = res.x;
+    int height = res.y;
     FrameBuffer* fb = camera->getFrameBuffer();
     if (nullptr != fb) {
         width = fb->getWidth();

--- a/cocos/renderer/renderer/ForwardRenderer.h
+++ b/cocos/renderer/renderer/ForwardRenderer.h
@@ -85,9 +85,6 @@ private:
     Vector<Light*> _ambientLights;
     
     RecyclePool<float>* _arrayPool = nullptr;
-    
-    int _width = 0;
-    int _height = 0;
     std::size_t _numLights = 0;
 };
 

--- a/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
+++ b/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
@@ -78,11 +78,22 @@ Application* app = nullptr;
     [window makeKeyAndVisible];
     
     [[UIApplication sharedApplication] setStatusBarHidden:YES];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+        selector:@selector(statusBarOrientationChanged:)
+        name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
     
     //run the cocos2d-x game scene
     app->start();
     
     return YES;
+}
+
+- (void)statusBarOrientationChanged:(NSNotification *)notification {
+    CGRect bounds = [UIScreen mainScreen].bounds;
+    float scale = [[UIScreen mainScreen] scale];
+    float width = bounds.size.width * scale;
+    float height = bounds.size.height * scale;
+    Application::getInstance()->updateViewSize(width, height);
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {

--- a/templates/js-template-link/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
+++ b/templates/js-template-link/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
@@ -78,11 +78,22 @@ Application* app = nullptr;
     [window makeKeyAndVisible];
     
     [[UIApplication sharedApplication] setStatusBarHidden:YES];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+        selector:@selector(statusBarOrientationChanged:)
+        name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
     
     //run the cocos2d-x game scene
     app->start();
     
     return YES;
+}
+
+- (void)statusBarOrientationChanged:(NSNotification *)notification {
+    CGRect bounds = [UIScreen mainScreen].bounds;
+    float scale = [[UIScreen mainScreen] scale];
+    float width = bounds.size.width * scale;
+    float height = bounds.size.height * scale;
+    Application::getInstance()->updateViewSize(width, height);
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
@@ -71,9 +71,16 @@ Application* app = nullptr;
     [window makeKeyAndVisible];
 
     [[UIApplication sharedApplication] setStatusBarHidden: YES];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+        selector:@selector(statusBarOrientationChanged:)
+        name:UIApplicationDidChangeStatusBarOrientationNotification object:nil];
 
     app->start();
     return YES;
+}
+
+- (void)statusBarOrientationChanged:(NSNotification *)notification {
+    Application::getInstance()->updateViewSize();
 }
 
 

--- a/tools/simulator/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
+++ b/tools/simulator/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
@@ -80,7 +80,11 @@ Application* app = nullptr;
 }
 
 - (void)statusBarOrientationChanged:(NSNotification *)notification {
-    Application::getInstance()->updateViewSize();
+    CGRect bounds = [UIScreen mainScreen].bounds;
+    float scale = [[UIScreen mainScreen] scale];
+    float width = bounds.size.width * scale;
+    float height = bounds.size.height * scale;
+    Application::getInstance()->updateViewSize(width, height);
 }
 
 


### PR DESCRIPTION
这个 pr 将会修复：
- 桌面端屏幕 resize 之后，屏幕适配问题：https://github.com/cocos-creator/2d-tasks/issues/1930
- 部分用户参考 https://forum.cocos.com/t/topic/79780 的方案，在 v2.1.3 iOS 和 Android 上实现了屏幕旋转。在 v2.2.0 上失效的问题

说明：
之前因为只在初始化时更新了 _width 和 _height, window resized 之后也没有实时更新 _width _height，所以导致渲染时 view 的宽高不正确
~~现在改为渲染时，实时获取屏幕宽高，并更新到 view 上~~
现在改为渲染时，从 Application 那里获取缓存的 viewSize，每次 window resize 都更新 viewSize