### PR TITLE
Fix a problem of Mask on the native platform.

### DIFF
--- a/cocos/renderer/scene/assembler/MaskAssembler.cpp
+++ b/cocos/renderer/scene/assembler/MaskAssembler.cpp
@@ -85,6 +85,7 @@ void MaskAssembler::postHandle(NodeProxy *node, ModelBatcher *batcher, Scene *sc
     batcher->flush();
     batcher->flushIA();
     StencilManager::getInstance()->exitMask();
+    batcher->setCurrentEffect(nullptr);
 }
 
 RENDERER_END

--- a/cocos/renderer/scene/assembler/MaskAssembler.cpp
+++ b/cocos/renderer/scene/assembler/MaskAssembler.cpp
@@ -84,8 +84,8 @@ void MaskAssembler::postHandle(NodeProxy *node, ModelBatcher *batcher, Scene *sc
 {
     batcher->flush();
     batcher->flushIA();
+    batcher->setCurrentEffect(getEffect(0));
     StencilManager::getInstance()->exitMask();
-    batcher->setCurrentEffect(nullptr);
 }
 
 RENDERER_END


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#1972

修改说明：
因为Mask结束之后ModelBatcher中的材质没有重置, 导致Mask的子节点跟后续节点自动合批。

目前js层的Mask及ModelBatcher改动比较大，原生还没完全同步，涉及的内容比较多，在后续版本统一同步。