### PR TITLE
fixed downloader.onProgress call error

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxDownloader.java
@@ -218,7 +218,7 @@ public class Cocos2dxDownloader {
                                     while ((len = is.read(buf)) != -1) {
                                         current += len;
                                         fos.write(buf, 0, len);
-                                        downloader.onProgress(id, current, len, total);
+                                        downloader.onProgress(id, len, current, total);
                                     }
                                     fos.flush();
 
@@ -256,7 +256,7 @@ public class Cocos2dxDownloader {
                                     while ((len = is.read(buf)) != -1) {
                                         current += len;
                                         buffer.write(buf, 0, len);
-                                        downloader.onProgress(id, current, len, total);
+                                        downloader.onProgress(id, len, current, total);
                                     }
                                     downloader.onFinish(id, 0, null, buffer.toByteArray());
                                     downloader.runNextTaskIfExists();


### PR DESCRIPTION
RE: https://github.com/cocos-creator/2d-tasks/issues/2028 .
根据调试了代码调用上下文，len 的功能应该是 ：the number of bytes to write. 也就是要写入的字节数。
![image](https://user-images.githubusercontent.com/35944775/68016081-b6180200-fcce-11e9-912e-8ef7582a78b5.png)

![image](https://user-images.githubusercontent.com/35944775/68016032-954fac80-fcce-11e9-8349-c8ab432dd1b6.png)

而 len 是 onProgress 需要接受的参数 downloadBytes。
![image](https://user-images.githubusercontent.com/35944775/68016184-faa39d80-fcce-11e9-93d5-d613c3b0e135.png)
len 也是 nativeOnProgress 需要的 dl
![image](https://user-images.githubusercontent.com/35944775/68016272-2e7ec300-fccf-11e9-958b-5b7feaa1677d.png)

在 native 上测试正常。