### PR TITLE
Add the null decision of SetProperty on the native platform.

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_conversions.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_conversions.cpp
@@ -1821,6 +1821,10 @@ bool seval_to_EffectDefineTemplate(const se::Value& v, std::vector<cocos2d::Valu
 
 bool seval_to_TechniqueParameter_not_constructor(const se::Value& v, cocos2d::renderer::Technique::Parameter* ret, bool directly)
 {
+    if(v.isNull())
+    {
+        return true;
+    }
     assert(ret != nullptr);
     auto paramType = ret->getType();
     switch (paramType)


### PR DESCRIPTION
问题说明：

examples-case 在先进入progress-bar的场景并进行下个场景切换时崩溃。

场景卸载之后，release会调用资源的destroy进行销毁，CCTexture2D持有的_texture会释放。在材质资源进行复用的时候，例如Mask并不需要Texture，所以不会重新设置_texture，但是uniforms里的texture属性还在，这个时候setProperty的value是null。原生层面没有对value进行非空判定，导致崩溃。

修改说明：

原生平台增加了value是否为null的判断