### PR TITLE
Support split spine texture

### DIFF
--- a/cocos/editor-support/spine/SkeletonJson.cpp
+++ b/cocos/editor-support/spine/SkeletonJson.cpp
@@ -507,9 +507,10 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 						case AttachmentType_Region: {
 							attachment = _attachmentLoader->newRegionAttachment(*skin, attachmentName, attachmentPath);
 							if (!attachment) {
-								delete skeletonData;
-								setError(root, "Error reading attachment: ", skinAttachmentName);
-								return NULL;
+								// delete skeletonData;
+								// setError(root, "Error reading attachment: ", skinAttachmentName);
+								// return NULL;
+                                continue;
 							}
 
 							RegionAttachment *region = static_cast<RegionAttachment *>(attachment);
@@ -540,9 +541,10 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 							attachment = _attachmentLoader->newMeshAttachment(*skin, attachmentName, attachmentPath);
 
 							if (!attachment) {
-								delete skeletonData;
-								setError(root, "Error reading attachment: ", skinAttachmentName);
-								return NULL;
+								// delete skeletonData;
+								// setError(root, "Error reading attachment: ", skinAttachmentName);
+								// return NULL;
+                                continue;
 							}
 
 							MeshAttachment *mesh = static_cast<MeshAttachment *>(attachment);
@@ -666,15 +668,17 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 		LinkedMesh *linkedMesh = _linkedMeshes[i];
 		Skin *skin = linkedMesh->_skin.length() == 0 ? skeletonData->getDefaultSkin() : skeletonData->findSkin(linkedMesh->_skin);
 		if (skin == NULL) {
-			delete skeletonData;
-			setError(root, "Skin not found: ", linkedMesh->_skin.buffer());
-			return NULL;
+			// delete skeletonData;
+			// setError(root, "Skin not found: ", linkedMesh->_skin.buffer());
+			// return NULL;
+            continue;
 		}
 		Attachment *parent = skin->getAttachment(linkedMesh->_slotIndex, linkedMesh->_parent);
 		if (parent == NULL) {
-			delete skeletonData;
-			setError(root, "Parent mesh not found: ", linkedMesh->_parent.buffer());
-			return NULL;
+			// delete skeletonData;
+			// setError(root, "Parent mesh not found: ", linkedMesh->_parent.buffer());
+			// return NULL;
+            continue;
 		}
 		linkedMesh->_mesh->_deformAttachment = linkedMesh->_inheritDeform ? static_cast<VertexAttachment*>(parent) : linkedMesh->_mesh;
 		linkedMesh->_mesh->setParentMesh(static_cast<MeshAttachment *>(parent));
@@ -717,9 +721,10 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 		for (animationMap = animations->_child; animationMap; animationMap = animationMap->_next) {
 			Animation *animation = readAnimation(animationMap, skeletonData);
 			if (!animation) {
-				delete skeletonData;
-				delete root;
-				return NULL;
+				// delete skeletonData;
+				// delete root;
+				// return NULL;
+                continue;
 			}
 			skeletonData->_animations[animationsIndex++] = animation;
 		}
@@ -1049,8 +1054,9 @@ Animation *SkeletonJson::readAnimation(Json *root, SkeletonData *skeletonData) {
 
 				if (!baseAttachment) {
 					ContainerUtil::cleanUpVectorOfPointers(timelines);
-					setError(NULL, "Attachment not found: ", timelineMap->_name);
-					return NULL;
+					// setError(NULL, "Attachment not found: ", timelineMap->_name);
+					// return NULL;
+                    continue;
 				}
 
 				VertexAttachment *attachment = static_cast<VertexAttachment *>(baseAttachment);

--- a/cocos/editor-support/spine/SkeletonJson.cpp
+++ b/cocos/editor-support/spine/SkeletonJson.cpp
@@ -1056,7 +1056,7 @@ Animation *SkeletonJson::readAnimation(Json *root, SkeletonData *skeletonData) {
 					ContainerUtil::cleanUpVectorOfPointers(timelines);
 					// setError(NULL, "Attachment not found: ", timelineMap->_name);
 					// return NULL;
-                    continue;
+					continue;
 				}
 
 				VertexAttachment *attachment = static_cast<VertexAttachment *>(baseAttachment);

--- a/cocos/editor-support/spine/SkeletonJson.cpp
+++ b/cocos/editor-support/spine/SkeletonJson.cpp
@@ -510,7 +510,7 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 								// delete skeletonData;
 								// setError(root, "Error reading attachment: ", skinAttachmentName);
 								// return NULL;
-                                continue;
+								continue;
 							}
 
 							RegionAttachment *region = static_cast<RegionAttachment *>(attachment);
@@ -544,7 +544,7 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 								// delete skeletonData;
 								// setError(root, "Error reading attachment: ", skinAttachmentName);
 								// return NULL;
-                                continue;
+								continue;
 							}
 
 							MeshAttachment *mesh = static_cast<MeshAttachment *>(attachment);
@@ -671,14 +671,14 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 			// delete skeletonData;
 			// setError(root, "Skin not found: ", linkedMesh->_skin.buffer());
 			// return NULL;
-            continue;
+			continue;
 		}
 		Attachment *parent = skin->getAttachment(linkedMesh->_slotIndex, linkedMesh->_parent);
 		if (parent == NULL) {
 			// delete skeletonData;
 			// setError(root, "Parent mesh not found: ", linkedMesh->_parent.buffer());
 			// return NULL;
-            continue;
+			continue;
 		}
 		linkedMesh->_mesh->_deformAttachment = linkedMesh->_inheritDeform ? static_cast<VertexAttachment*>(parent) : linkedMesh->_mesh;
 		linkedMesh->_mesh->setParentMesh(static_cast<MeshAttachment *>(parent));
@@ -724,7 +724,7 @@ SkeletonData *SkeletonJson::readSkeletonData(const char *json) {
 				// delete skeletonData;
 				// delete root;
 				// return NULL;
-                continue;
+				continue;
 			}
 			skeletonData->_animations[animationsIndex++] = animation;
 		}


### PR DESCRIPTION
支持部件贴图拆分，增强换装功能。
（原spine runtime当缺少某部件贴图时，会报错，这里修改为直接跳过或返回空值，当用户想换装时，可根据需要只提供某个部件的贴图图集）
关联pr：https://github.com/cocos-creator/engine/pull/5711