### PR TITLE
fix multiply register audioEngine onEnterBackground event

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -344,6 +344,7 @@ void AudioEngine::onEnterBackground() {
         if (it->second.state == AudioState::PLAYING)
         {
             _audioEngineImpl->pause(it->first);
+            it->second.state = AudioState::PAUSED;
             _breakAudioID.push_back(it->first);
         }
     }
@@ -352,7 +353,7 @@ void AudioEngine::onEnterBackground() {
 void AudioEngine::onEnterForeground() {
     auto itEnd = _breakAudioID.end();
     for (auto it = _breakAudioID.begin(); it != itEnd; ++it) {
-        _audioEngineImpl->resume(*it);
+        AudioEngine::resume(*it);
     }
     _breakAudioID.clear();
 }

--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -68,8 +68,6 @@ AudioEngine::ProfileHelper* AudioEngine::_defaultProfileHelper = nullptr;
 std::unordered_map<int, AudioEngine::AudioInfo> AudioEngine::_audioIDInfoMap;
 AudioEngineImpl* AudioEngine::_audioEngineImpl = nullptr;
 
-uint32_t AudioEngine::_onPauseListenerID = 0;
-uint32_t AudioEngine::_onResumeListenerID = 0;
 std::vector<int> AudioEngine::_breakAudioID;
 
 AudioEngine::AudioEngineThreadPool* AudioEngine::s_threadPool = nullptr;
@@ -171,16 +169,6 @@ void AudioEngine::end()
 
     delete _defaultProfileHelper;
     _defaultProfileHelper = nullptr;
-
-    if (_onPauseListenerID != 0)
-    {
-        EventDispatcher::removeCustomEventListener(EVENT_COME_TO_BACKGROUND, _onPauseListenerID);
-    }
-
-    if (_onResumeListenerID != 0)
-    {
-        EventDispatcher::removeCustomEventListener(EVENT_COME_TO_FOREGROUND, _onResumeListenerID);
-    }
 }
 
 bool AudioEngine::lazyInit()
@@ -201,9 +189,6 @@ bool AudioEngine::lazyInit()
         s_threadPool = new (std::nothrow) AudioEngineThreadPool();
     }
 #endif
-
-    _onPauseListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_BACKGROUND, AudioEngine::onEnterBackground);
-    _onResumeListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_FOREGROUND, AudioEngine::onEnterForeground);
 
     return true;
 }
@@ -352,7 +337,7 @@ void AudioEngine::resumeAll()
     }
 }
 
-void AudioEngine::onEnterBackground(const CustomEvent &event) {
+void AudioEngine::onEnterBackground() {
     auto itEnd = _audioIDInfoMap.end();
     for (auto it = _audioIDInfoMap.begin(); it != itEnd; ++it)
     {
@@ -364,7 +349,7 @@ void AudioEngine::onEnterBackground(const CustomEvent &event) {
     }
 }
 
-void AudioEngine::onEnterForeground(const CustomEvent &event) {
+void AudioEngine::onEnterForeground() {
     auto itEnd = _breakAudioID.end();
     for (auto it = _breakAudioID.begin(); it != itEnd; ++it) {
         _audioEngineImpl->resume(*it);

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -317,6 +317,9 @@ public:
      */
     static bool isEnabled();
     
+    static void onEnterBackground();
+    static void onEnterForeground();
+    
 protected:
     static void addTask(const std::function<void()>& task);
     static void remove(int audioID);
@@ -376,12 +379,7 @@ protected:
     static bool _isEnabled;
     
 private:
-    static uint32_t _onPauseListenerID;
-    static uint32_t _onResumeListenerID;
     static std::vector<int> _breakAudioID;
-    
-    static void onEnterBackground(const CustomEvent&);
-    static void onEnterForeground(const CustomEvent&);
     
     friend class AudioEngineImpl;
 };

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -80,12 +80,14 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
+    // Ensure that handle AudioEngine enter background after all enter background events are handled
     AudioEngine::onEnterBackground();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
+    // Ensure that handle AudioEngine enter foreground before all enter foreground events are handled
     AudioEngine::onEnterForeground();
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -27,6 +27,7 @@
 
 #include "cocos2d.h"
 
+#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/manual/jsb_module_register.hpp"
 #include "cocos/scripting/js-bindings/manual/jsb_global.h"
 #include "cocos/scripting/js-bindings/jswrapper/SeApi.h"
@@ -79,10 +80,12 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
+    AudioEngine::onEnterBackground();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
+    AudioEngine::onEnterForeground();
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -79,12 +79,14 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
+    // Ensure that handle AudioEngine enter background after all enter background events are handled
     AudioEngine::onEnterBackground();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
+    // Ensure that handle AudioEngine enter foreground before all enter foreground events are handled
     AudioEngine::onEnterForeground();
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -27,6 +27,7 @@
 
 #include "cocos2d.h"
 
+#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/manual/jsb_module_register.hpp"
 #include "cocos/scripting/js-bindings/manual/jsb_global.h"
 #include "cocos/scripting/js-bindings/jswrapper/SeApi.h"
@@ -78,10 +79,12 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
+    AudioEngine::onEnterBackground();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
+    AudioEngine::onEnterForeground();
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -66,12 +66,14 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
+    // Ensure that handle AudioEngine enter background after all enter background events are handled
     AudioEngine::onEnterBackground();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
+    // Ensure that handle AudioEngine enter foreground before all enter foreground events are handled
     AudioEngine::onEnterForeground();
     EventDispatcher::dispatchEnterForegroundEvent();
 }

--- a/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -26,6 +26,8 @@
 #include "AppDelegate.h"
 
 #include "cocos2d.h"
+
+#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/event/EventDispatcher.h"
 
 #include "ide-support/CodeIDESupport.h"
@@ -64,10 +66,12 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
+    AudioEngine::onEnterBackground();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
+    AudioEngine::onEnterForeground();
     EventDispatcher::dispatchEnterForegroundEvent();
 }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2058

changeLog:
- 修复原生 audioEngine 多次注册进入前后台事件回调的问题

确保  AudioEngine::onEnterBackground() 在所有 enterBackgroundEvent 回调之后处理
AudioEngine::onEnterForeground() 在所有 enterForegroundEvent 回调 之前处理