### PR TITLE
fix audio engine crash when enter foreground

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.h
+++ b/cocos/audio/apple/AudioEngine-inl.h
@@ -66,6 +66,7 @@ public:
     void update(float dt);
 
 private:
+    bool _checkAudioIdValid(int audioID);
     void _play2d(AudioCache *cache, int audioID);
     ALuint findValidSource();
 

--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -482,6 +482,9 @@ ALuint AudioEngineImpl::findValidSource()
 
 void AudioEngineImpl::setVolume(int audioID,float volume)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return;
+    }
     auto player = _audioPlayers[audioID];
     player->_volume = volume;
 
@@ -497,6 +500,9 @@ void AudioEngineImpl::setVolume(int audioID,float volume)
 
 void AudioEngineImpl::setLoop(int audioID, bool loop)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return;
+    }
     auto player = _audioPlayers[audioID];
 
     if (player->_ready) {
@@ -522,6 +528,9 @@ void AudioEngineImpl::setLoop(int audioID, bool loop)
 
 bool AudioEngineImpl::pause(int audioID)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return false;
+    }
     bool ret = true;
     alSourcePause(_audioPlayers[audioID]->_alSource);
 
@@ -536,6 +545,9 @@ bool AudioEngineImpl::pause(int audioID)
 
 bool AudioEngineImpl::resume(int audioID)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return false;
+    }
     bool ret = true;
     alSourcePlay(_audioPlayers[audioID]->_alSource);
 
@@ -550,6 +562,9 @@ bool AudioEngineImpl::resume(int audioID)
 
 void AudioEngineImpl::stop(int audioID)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return;
+    }
     auto player = _audioPlayers[audioID];
     player->destroy();
 
@@ -570,6 +585,9 @@ void AudioEngineImpl::stopAll()
 
 float AudioEngineImpl::getDuration(int audioID)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return AudioEngine::TIME_UNKNOWN;
+    }
     auto player = _audioPlayers[audioID];
     if(player->_ready){
         return player->_audioCache->_duration;
@@ -592,6 +610,9 @@ float AudioEngineImpl::getDurationFromFile(const std::string &filePath)
 float AudioEngineImpl::getCurrentTime(int audioID)
 {
     float ret = 0.0f;
+    if (!_checkAudioIdValid(audioID)) {
+        return ret;
+    }
     auto player = _audioPlayers[audioID];
     if(player->_ready){
         if (player->_streamingSource) {
@@ -611,6 +632,9 @@ float AudioEngineImpl::getCurrentTime(int audioID)
 
 bool AudioEngineImpl::setCurrentTime(int audioID, float time)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return false;
+    }
     bool ret = false;
     auto player = _audioPlayers[audioID];
 
@@ -645,6 +669,9 @@ bool AudioEngineImpl::setCurrentTime(int audioID, float time)
 
 void AudioEngineImpl::setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return;
+    }
     _audioPlayers[audioID]->_finishCallbak = callback;
 }
 
@@ -713,6 +740,11 @@ void AudioEngineImpl::uncache(const std::string &filePath)
 void AudioEngineImpl::uncacheAll()
 {
     _audioCaches.clear();
+}
+
+bool AudioEngineImpl::_checkAudioIdValid(int audioID) {
+    auto player = _audioPlayers[audioID];
+    return player != nullptr;
 }
 
 #endif

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -292,6 +292,9 @@ void AudioEngineImpl::_play2d(AudioCache *cache, int audioID)
 
 void AudioEngineImpl::setVolume(int audioID,float volume)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return;
+    }
     auto player = _audioPlayers[audioID];
     player->_volume = volume;
 
@@ -307,6 +310,9 @@ void AudioEngineImpl::setVolume(int audioID,float volume)
 
 void AudioEngineImpl::setLoop(int audioID, bool loop)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return;
+    }
     auto player = _audioPlayers[audioID];
 
     if (player->_ready) {
@@ -332,6 +338,9 @@ void AudioEngineImpl::setLoop(int audioID, bool loop)
 
 bool AudioEngineImpl::pause(int audioID)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return false;
+    }
     bool ret = true;
     alSourcePause(_audioPlayers[audioID]->_alSource);
 
@@ -346,6 +355,9 @@ bool AudioEngineImpl::pause(int audioID)
 
 bool AudioEngineImpl::resume(int audioID)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return false;
+    }
     bool ret = true;
     alSourcePlay(_audioPlayers[audioID]->_alSource);
 
@@ -360,6 +372,9 @@ bool AudioEngineImpl::resume(int audioID)
 
 void AudioEngineImpl::stop(int audioID)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return;
+    }
     auto player = _audioPlayers[audioID];
     player->destroy();
     //Note: Don't set the flag to false here, it should be set in 'update' function.
@@ -389,6 +404,9 @@ void AudioEngineImpl::stopAll()
 
 float AudioEngineImpl::getDuration(int audioID)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return AudioEngine::TIME_UNKNOWN;
+    }
     auto player = _audioPlayers[audioID];
     if(player->_ready){
         return player->_audioCache->_duration;
@@ -411,6 +429,9 @@ float AudioEngineImpl::getDurationFromFile(const std::string &filePath)
 float AudioEngineImpl::getCurrentTime(int audioID)
 {
     float ret = 0.0f;
+    if (!_checkAudioIdValid(audioID)) {
+        return ret;
+    }
     auto player = _audioPlayers[audioID];
     if(player->_ready){
         if (player->_streamingSource) {
@@ -430,6 +451,9 @@ float AudioEngineImpl::getCurrentTime(int audioID)
 
 bool AudioEngineImpl::setCurrentTime(int audioID, float time)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return false;
+    }
     bool ret = false;
     auto player = _audioPlayers[audioID];
 
@@ -464,6 +488,9 @@ bool AudioEngineImpl::setCurrentTime(int audioID, float time)
 
 void AudioEngineImpl::setFinishCallback(int audioID, const std::function<void (int, const std::string &)> &callback)
 {
+    if (!_checkAudioIdValid(audioID)) {
+        return;
+    }
     _audioPlayers[audioID]->_finishCallbak = callback;
 }
 
@@ -533,6 +560,11 @@ void AudioEngineImpl::uncache(const std::string &filePath)
 void AudioEngineImpl::uncacheAll()
 {
     _audioCaches.clear();
+}
+
+bool AudioEngineImpl::_checkAudioIdValid(int audioID) {
+    auto player = _audioPlayers[audioID];
+    return player != nullptr;
 }
 
 #endif

--- a/cocos/audio/win32/AudioEngine-win32.h
+++ b/cocos/audio/win32/AudioEngine-win32.h
@@ -67,6 +67,7 @@ public:
     void update(float dt);
 
 private:
+    bool _checkAudioIdValid(int audioID);
     void _play2d(AudioCache *cache, int audioID);
 
     ALuint _alSources[MAX_AUDIOINSTANCES];


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2038

changeLog:
- 修复 audioEngine 切换前后台导致的崩溃问题

进入后台，有可能音效刚好播放结束，刚好被移除了，这时候需要同步 _breakAudioID
防止进入前台后，播放已经移除了的 Audio