### PR TITLE
fix videoplayer crash in release mode

### DIFF
--- a/cocos/ui/videoplayer/VideoPlayer-ios.mm
+++ b/cocos/ui/videoplayer/VideoPlayer-ios.mm
@@ -222,7 +222,11 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
         [self seekTo:0];
         [self.playerController.player pause];
         _state = PlayerbackStopped;
-        _videoPlayer->onPlayEvent((int)VideoPlayer::EventType::STOPPED);
+
+        // stop() will be invoked in dealloc, which is invoked by _videoPlayer's destructor,
+        // so do't send the message when _videoPlayer is being deleted.
+        if (_videoPlayer)
+            _videoPlayer->onPlayEvent((int)VideoPlayer::EventType::STOPPED);
     }
 }
 
@@ -230,6 +234,7 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 
 -(void) cleanup
 {
+    _videoPlayer = nullptr;
     [self stop];
     [self removePlayerEventListener];
     [self.playerController.view removeFromSuperview];


### PR DESCRIPTION
崩溃的调用顺序是这样的：
```
VideoPlayer::~VideoPlayer() -> UIVideoViewWrapperIos.dealloc() -> UIVideoViewWrapperIos.clean() -> UIVideoViewWrapperIos.stop() -> VideoPlayer::onPlayEvent()
```

也就是说 VideoPlayer 的析构函数会调用到事件监听的回调函数，但这时的事件监听者可能已经释放了，所以不在析构时去调用监听函数。