### PR TITLE
fixed setOnFileTaskSuccess callback crash error

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_cocos2dx_network_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_cocos2dx_network_manual.cpp
@@ -109,7 +109,7 @@ static bool js_network_Downloader_setOnFileTaskSuccess(se::State& s)
                     if (!succeed) {
                         se::ScriptEngine::getInstance()->clearException();
                     }
-                    jsThis.toObject()->unroot();
+                    thisObj->unroot();
                 };
                 arg0 = lambda;
             }

--- a/cocos/scripting/js-bindings/manual/jsb_cocos2dx_network_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_cocos2dx_network_manual.cpp
@@ -162,7 +162,7 @@ static bool js_network_Downloader_setOnTaskError(se::State& s)
                     if (!succeed) {
                         se::ScriptEngine::getInstance()->clearException();
                     }
-                    jsThis.toObject()->unroot();
+                    thisObj->unroot();
                 };
                 arg0 = lambda;
             }


### PR DESCRIPTION
RE: https://forum.cocos.org/t/cocos-creator-v2-2-1/85555/275?u=337031709
```
thisObj->unroot();
```
![image](https://user-images.githubusercontent.com/35944775/68923038-461e7700-07b8-11ea-9c89-55a9e73defc1.png)

这段代码的意图是将函数指针删去，使用 jsThis.toObject() 的时候，发现没有执行 unroot 进行删除，所以用户在回调里面在又执行一次 setOnFileTaskSuccess 就会导致程序错误 。
此时会报错：
![image](https://user-images.githubusercontent.com/35944775/68923817-2b4d0200-07ba-11ea-8884-c7df21da9142.png)

这里 thisObj 符合要求，故做此修改。