### PR TITLE
fix issue that webview scheme filter can not work

### DIFF
--- a/cocos/ui/webview/WebViewImpl-ios.mm
+++ b/cocos/ui/webview/WebViewImpl-ios.mm
@@ -220,14 +220,15 @@
 
 #pragma mark - WKNavigationDelegate
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
-    NSString *url = [webView.URL absoluteString];
-    if ([[webView.URL scheme] isEqualToString:self.jsScheme]) {
-        self.onJsCallback([url UTF8String]);
+    NSString *url = [[navigationAction request].URL.absoluteString stringByRemovingPercentEncoding];
+    NSString* scheme = [navigationAction request].URL.scheme;
+    if ([scheme isEqualToString:self.jsScheme]) {
+        self.onJsCallback(url.UTF8String);
         decisionHandler(WKNavigationActionPolicyCancel);
         return;
     }
     if (self.shouldStartLoading && url) {
-        if (self.shouldStartLoading([url UTF8String]) )
+        if (self.shouldStartLoading(url.UTF8String) )
             decisionHandler(WKNavigationActionPolicyAllow);
         else
             decisionHandler(WKNavigationActionPolicyCancel);


### PR DESCRIPTION
之前使用了错误的 url 导致判断不正确。在网页跳转时，应该使用跳转地址，而不是最开始访问的地址。