### PR TITLE
send pause/resume event instead of background/foreground event

### DIFF
--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -105,8 +105,8 @@ public:
     virtual ~Application();
     
     virtual bool applicationDidFinishLaunching();
-    virtual void applicationDidEnterBackground();
-    virtual void applicationWillEnterForeground();
+    virtual void onPause();
+    virtual void onResume();
     
     inline void* getView() const { return _view; }
     inline std::shared_ptr<Scheduler> getScheduler() const { return _scheduler; }

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -128,12 +128,12 @@ bool Application::applicationDidFinishLaunching()
     return true;
 }
 
-void Application::applicationDidEnterBackground()
+void Application::onPause()
 {
 
 }
 
-void Application::applicationWillEnterForeground()
+void Application::onResume()
 {
 
 }

--- a/cocos/platform/android/jni/JniImp.cpp
+++ b/cocos/platform/android/jni/JniImp.cpp
@@ -285,7 +285,7 @@ extern "C"
             return;
         }
         if (g_app)
-            g_app->applicationDidEnterBackground();
+            g_app->onPause();
     }
 
     JNIEXPORT void JNICALL JNI_RENDER(nativeOnResume)()
@@ -294,7 +294,7 @@ extern "C"
             return;
         }
         if (g_app)
-            g_app->applicationWillEnterForeground();
+            g_app->onResume();
     }
 
     JNIEXPORT void JNICALL JNI_RENDER(nativeInsertText)(JNIEnv* env, jobject thiz, jstring text)

--- a/cocos/platform/desktop/CCGLView-desktop.cpp
+++ b/cocos/platform/desktop/CCGLView-desktop.cpp
@@ -437,9 +437,9 @@ void GLView::onGLFWCharCallback(GLFWwindow* /*window*/, unsigned int character)
 void GLView::onGLFWWindowIconifyCallback(GLFWwindow* /*window*/, int iconified)
 {
     if (iconified == GL_TRUE)
-        _application->applicationDidEnterBackground();
+        _application->onPause();
     else
-        _application->applicationWillEnterForeground();
+        _application->onResume();
 }
 
 void GLView::onGLFWWindowSizeFunCallback(GLFWwindow *window, int width, int height)

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -366,11 +366,11 @@ bool Application::applicationDidFinishLaunching()
     return true;
 }
 
-void Application::applicationDidEnterBackground()
+void Application::onPause()
 {
 }
 
-void Application::applicationWillEnterForeground()
+void Application::onResume()
 {
 }
 

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -292,11 +292,11 @@ bool Application::applicationDidFinishLaunching()
     return true;
 }
 
-void Application::applicationDidEnterBackground()
+void Application::onPause()
 {
 }
 
-void Application::applicationWillEnterForeground()
+void Application::onResume()
 {
 }
 

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -395,11 +395,11 @@ bool Application::applicationDidFinishLaunching()
     return true;
 }
 
-void Application::applicationDidEnterBackground()
+void Application::onPause()
 {
 }
 
-void Application::applicationWillEnterForeground()
+void Application::onResume()
 {
 }
 

--- a/cocos/scripting/js-bindings/event/CustomEventTypes.h
+++ b/cocos/scripting/js-bindings/event/CustomEventTypes.h
@@ -26,3 +26,6 @@
 
 #define EVENT_COME_TO_FOREGROUND    "event_come_to_foreground"
 #define EVENT_COME_TO_BACKGROUND    "event_come_to_background"
+
+#define EVENT_ON_PAUSE    "event_on_pause"
+#define EVENT_ON_RESUME   "event_on_resume"

--- a/cocos/scripting/js-bindings/event/EventDispatcher.cpp
+++ b/cocos/scripting/js-bindings/event/EventDispatcher.cpp
@@ -325,26 +325,26 @@ static void dispatchEnterBackgroundOrForegroundEvent(const char* funcName)
     }
 }
 
-void EventDispatcher::dispatchEnterBackgroundEvent()
+void EventDispatcher::dispatchOnPauseEvent()
 {
     // dispatch to Native
     CustomEvent event;
-    event.name = EVENT_COME_TO_BACKGROUND;
+    event.name = EVENT_ON_PAUSE;
     EventDispatcher::dispatchCustomEvent(event);
 
     // dispatch to JavaScript
-    dispatchEnterBackgroundOrForegroundEvent("onHide");
+    dispatchEnterBackgroundOrForegroundEvent("onPause");
 }
 
-void EventDispatcher::dispatchEnterForegroundEvent()
+void EventDispatcher::dispatchOnResumeEvent()
 {
     // dispatch to Native
     CustomEvent event;
-    event.name = EVENT_COME_TO_FOREGROUND;
+    event.name = EVENT_ON_RESUME;
     EventDispatcher::dispatchCustomEvent(event);
 
     // dispatch to JavaScript
-    dispatchEnterBackgroundOrForegroundEvent("onShow");
+    dispatchEnterBackgroundOrForegroundEvent("onResume");
 }
 
 uint32_t EventDispatcher::addCustomEventListener(const std::string& eventName, const CustomEventListener& listener)

--- a/cocos/scripting/js-bindings/event/EventDispatcher.h
+++ b/cocos/scripting/js-bindings/event/EventDispatcher.h
@@ -120,8 +120,8 @@ public:
     static void dispatchKeyboardEvent(const struct KeyboardEvent& keyboardEvent);
     static void dispatchTickEvent(float dt);
     static void dispatchResizeEvent(int width, int height);
-    static void dispatchEnterBackgroundEvent();
-    static void dispatchEnterForegroundEvent();
+    static void dispatchOnPauseEvent();
+    static void dispatchOnResumeEvent();
 
     using CustomEventListener = std::function<void(const CustomEvent&)>;
     static uint32_t addCustomEventListener(const std::string& eventName, const CustomEventListener& listener);

--- a/templates/js-template-android-instant/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-android-instant/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -96,19 +96,13 @@ bool AppDelegate::applicationDidFinishLaunching()
 }
 
 // This function will be called when the app is inactive. When comes a phone call,it's be invoked too
-void AppDelegate::applicationDidEnterBackground()
+void AppDelegate::onPause()
 {
-    CustomEvent event;
-    event.name = EVENT_COME_TO_BACKGROUND;
-    EventDispatcher::dispatchCustomEvent(event);
-    EventDispatcher::dispatchEnterBackgroundEvent();
+    EventDispatcher::dispatchOnPauseEvent();
 }
 
 // this function will be called when the app is active again
-void AppDelegate::applicationWillEnterForeground()
+void AppDelegate::onResume()
 {
-    CustomEvent event;
-    event.name = EVENT_COME_TO_FOREGROUND;
-    EventDispatcher::dispatchCustomEvent(event);
-    EventDispatcher::dispatchEnterForegroundEvent();
+    EventDispatcher::dispatchOnResumeEvent();
 }

--- a/templates/js-template-android-instant/frameworks/runtime-src/Classes/AppDelegate.h
+++ b/templates/js-template-android-instant/frameworks/runtime-src/Classes/AppDelegate.h
@@ -44,14 +44,12 @@ public:
     virtual bool applicationDidFinishLaunching() override;
     
     /**
-     @brief  The function be called when the application enter background
-     @param  the pointer of the application
+     @brief  The function be called when the application is paused
      */
-    virtual void applicationDidEnterBackground() override;
+    virtual void onPause() override;
     
     /**
-     @brief  The function be called when the application enter foreground
-     @param  the pointer of the application
+     @brief  The function be called when the application is resumed
      */
-    virtual void applicationWillEnterForeground() override;
+    virtual void onResume() override;
 };

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -76,13 +76,13 @@ bool AppDelegate::applicationDidFinishLaunching()
 }
 
 // This function will be called when the app is inactive. When comes a phone call,it's be invoked too
-void AppDelegate::applicationDidEnterBackground()
+void AppDelegate::onPause()
 {
-    EventDispatcher::dispatchEnterBackgroundEvent();
+    EventDispatcher::dispatchOnPauseEvent();
 }
 
 // this function will be called when the app is active again
-void AppDelegate::applicationWillEnterForeground()
+void AppDelegate::onResume()
 {
-    EventDispatcher::dispatchEnterForegroundEvent();
+    EventDispatcher::dispatchOnResumeEvent();
 }

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.h
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.h
@@ -44,14 +44,12 @@ public:
     virtual bool applicationDidFinishLaunching() override;
     
     /**
-     @brief  The function be called when the application enter background
-     @param  the pointer of the application
+     @brief  The function be called when the application is paused
      */
-    virtual void applicationDidEnterBackground() override;
+    virtual void onPause() override;
     
     /**
-     @brief  The function be called when the application enter foreground
-     @param  the pointer of the application
+     @brief  The function be called when the application is resumed
      */
-    virtual void applicationWillEnterForeground() override;
+    virtual void onResume() override;
 };

--- a/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
+++ b/templates/js-template-default/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
@@ -101,6 +101,7 @@ Application* app = nullptr;
      Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
      Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
      */
+    app->onPause();
     [[SDKWrapper getInstance] applicationWillResignActive:application];
 }
 
@@ -108,6 +109,7 @@ Application* app = nullptr;
     /*
      Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
      */
+    app->onResume();
     [[SDKWrapper getInstance] applicationDidBecomeActive:application];
 }
 
@@ -117,17 +119,13 @@ Application* app = nullptr;
      If your application supports background execution, called instead of applicationWillTerminate: when the user quits.
      */
     [[SDKWrapper getInstance] applicationDidEnterBackground:application];
-    app->applicationDidEnterBackground();
-    
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
     /*
      Called as part of  transition from the background to the inactive state: here you can undo many of the changes made on entering the background.
      */
-    [[SDKWrapper getInstance] applicationWillEnterForeground:application];
-    app->applicationWillEnterForeground();
-    
+    [[SDKWrapper getInstance] applicationWillEnterForeground:application];    
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -75,13 +75,13 @@ bool AppDelegate::applicationDidFinishLaunching()
 }
 
 // This function will be called when the app is inactive. When comes a phone call,it's be invoked too
-void AppDelegate::applicationDidEnterBackground()
+void AppDelegate::onPause()
 {
-    EventDispatcher::dispatchEnterBackgroundEvent();
+    EventDispatcher::dispatchOnPauseEvent();
 }
 
 // this function will be called when the app is active again
-void AppDelegate::applicationWillEnterForeground()
+void AppDelegate::onResume()
 {
-    EventDispatcher::dispatchEnterForegroundEvent();
+    EventDispatcher::dispatchOnResumeEvent();
 }

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.h
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.h
@@ -44,14 +44,12 @@ public:
     virtual bool applicationDidFinishLaunching() override;
     
     /**
-     @brief  The function be called when the application enter background
-     @param  the pointer of the application
+     @brief  The function be called when the application is paused
      */
-    virtual void applicationDidEnterBackground() override;
+    virtual void onPause() override;
     
     /**
-     @brief  The function be called when the application enter foreground
-     @param  the pointer of the application
+     @brief  The function be called when the application is resumed
      */
-    virtual void applicationWillEnterForeground() override;
+    virtual void onResume() override;
 };

--- a/templates/js-template-link/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
+++ b/templates/js-template-link/frameworks/runtime-src/proj.ios_mac/ios/AppController.mm
@@ -101,6 +101,7 @@ Application* app = nullptr;
      Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
      Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
      */
+    app->onPause();
     [[SDKWrapper getInstance] applicationWillResignActive:application];
 }
 
@@ -108,6 +109,7 @@ Application* app = nullptr;
     /*
      Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
      */
+    app->onResume();
     [[SDKWrapper getInstance] applicationDidBecomeActive:application];
 }
 
@@ -116,18 +118,14 @@ Application* app = nullptr;
      Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
      If your application supports background execution, called instead of applicationWillTerminate: when the user quits.
      */
-    [[SDKWrapper getInstance] applicationDidEnterBackground:application];
-    app->applicationDidEnterBackground();
-    
+    [[SDKWrapper getInstance] applicationDidEnterBackground:application]; 
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
     /*
      Called as part of  transition from the background to the inactive state: here you can undo many of the changes made on entering the background.
      */
-    [[SDKWrapper getInstance] applicationWillEnterForeground:application];
-    app->applicationWillEnterForeground();
-    
+    [[SDKWrapper getInstance] applicationWillEnterForeground:application]; 
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application


### PR DESCRIPTION
JS 引擎需要对应的修改为监听 `onPause`, `onResume` 事件。