### PR TITLE
Reset the OPACITY_DIRTY when the vertex data is updated.

### DIFF
--- a/cocos/renderer/scene/assembler/Assembler.cpp
+++ b/cocos/renderer/scene/assembler/Assembler.cpp
@@ -110,6 +110,8 @@ void Assembler::updateVerticesRange(std::size_t iaIndex, int start, int count)
     IARenderData& ia = _iaDatas[iaIndex];
     ia.verticesStart = start;
     ia.verticesCount = count;
+    
+    enableDirty(AssemblerBase::VERTICES_OPACITY_CHANGED);
 }
 
 void Assembler::updateEffect(std::size_t iaIndex, Effect* effect)


### PR DESCRIPTION
反馈自论坛：

https://forum.cocos.org/t/cocos-creator-v2-2-1-rc-2/85555/437?u=cary

问题说明：

原生层面做了Opacity处理的优化，只有在节点或者Assembler的Opacity状态为Dirty的时候才会更新顶点数据中的Color值。动态更新顶点数据的组件，例如BMFont，RadialFill，MotionStreak， Mesh, Ttiled等，在Js层重新填充了顶点数据，顶点中的颜色值如果不是通过Assembler的updateColor来更新节点颜色的，color.a 被重置，然后在原生层不会再重新更新Opacity到顶点颜色中，所以在这里有更新顶点数据，就重置一下 Opacity的Dirty状态。

也可以在Js层改，保证所有这样使用的组件都通过updateColor来更新颜色就可以，adapter层会修改Flag，不过需要重复遍历，所以直接在这里改了。