### PR TITLE
don't pop up view when soft keyboard is shown

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -42,8 +42,8 @@ import android.util.Log;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.cocos2dx.lib.Cocos2dxHelper.Cocos2dxHelperListener;
@@ -64,7 +64,7 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
     // ===========================================================
     private static Cocos2dxActivity sContext = null;
 
-    protected RelativeLayout mFrameLayout = null;
+    protected FrameLayout mFrameLayout = null;
     
     private Cocos2dxGLSurfaceView mGLSurfaceView = null;
     private int[] mGLContextAttrs = null;
@@ -255,7 +255,7 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
         ViewGroup.LayoutParams frameLayoutParams =
                 new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
                                            ViewGroup.LayoutParams.MATCH_PARENT);
-        mFrameLayout = new RelativeLayout(this);
+        mFrameLayout = new FrameLayout(this);
         mFrameLayout.setLayoutParams(frameLayoutParams);
 
         Cocos2dxRenderer renderer = this.addSurfaceView();

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -39,9 +39,7 @@ import android.text.InputFilter;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.util.DisplayMetrics;
 import android.util.Log;
-import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -51,6 +49,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -243,12 +242,14 @@ public class Cocos2dxEditBox {
                             Cocos2dxEditBox.this.hide();
                         }
                     }
+
+                    Cocos2dxEditBox.this.adjustEditTextAndButtonTopMargin(r.bottom);
                 }
             });
         }
     }
 
-    public Cocos2dxEditBox(Cocos2dxActivity context, RelativeLayout layout) {
+    public Cocos2dxEditBox(Cocos2dxActivity context, FrameLayout layout) {
         Cocos2dxEditBox.sThis = this;
         mActivity = context;
         this.addItems(context, layout);
@@ -266,7 +267,7 @@ public class Cocos2dxEditBox {
     /***************************************************************************************
      Private functions.
      **************************************************************************************/
-    private void addItems(Cocos2dxActivity context, RelativeLayout layout) {
+    private void addItems(Cocos2dxActivity context, FrameLayout layout) {
         RelativeLayout myLayout = new RelativeLayout(context);
         this.addEditText(context, myLayout);
         this.addButton(context, myLayout);
@@ -325,6 +326,11 @@ public class Cocos2dxEditBox {
                     Cocos2dxEditBox.this.hide();
             }
         });
+    }
+
+    private void adjustEditTextAndButtonTopMargin(int topMargin) {
+        RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mEditText.getLayoutParams();
+        layoutParams.topMargin = topMargin;
     }
 
     private Drawable getRoundRectShape() {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -82,6 +82,7 @@ public class Cocos2dxEditBox {
         private float mLineWidth = 2f;
         private boolean keyboardVisible = false;
         private int mScreenHeight;
+        private int mTopMargin = 0;
 
         public  Cocos2dxEditText(Cocos2dxActivity context){
             super(context);
@@ -243,9 +244,19 @@ public class Cocos2dxEditBox {
                         }
                     }
 
-                    Cocos2dxEditBox.this.adjustEditTextAndButtonTopMargin(r.bottom);
+                    if (Cocos2dxEditText.this.mTopMargin == 0 && r.bottom != getRootView().getHeight()) {
+                        Cocos2dxEditText.this.setTopMargin(r.bottom);
+                    }
                 }
             });
+        }
+
+        private void setTopMargin(int topMargin) {
+            mTopMargin = topMargin;
+            RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mEditText.getLayoutParams();
+            layoutParams.topMargin = mTopMargin;
+            setLayoutParams(layoutParams);
+            requestLayout();
         }
     }
 
@@ -326,11 +337,6 @@ public class Cocos2dxEditBox {
                     Cocos2dxEditBox.this.hide();
             }
         });
-    }
-
-    private void adjustEditTextAndButtonTopMargin(int topMargin) {
-        RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) mEditText.getLayoutParams();
-        layoutParams.topMargin = topMargin;
     }
 
     private Drawable getRoundRectShape() {

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoHelper.java
@@ -33,7 +33,7 @@ import android.util.Log;
 import android.util.SparseArray;
 import android.view.View;
 import android.widget.FrameLayout;
-import android.widget.RelativeLayout;
+import android.widget.LinearLayout;
 
 import org.cocos2dx.lib.Cocos2dxVideoView.OnVideoEventListener;
 
@@ -44,13 +44,13 @@ import java.util.concurrent.FutureTask;
 
 public class Cocos2dxVideoHelper {
 
-    private RelativeLayout mLayout = null;
+    private FrameLayout mLayout = null;
     private Cocos2dxActivity mActivity = null;  
     private static SparseArray<Cocos2dxVideoView> sVideoViews = null;
     static VideoHandler mVideoHandler = null;
     private static Handler sHandler = null;
     
-    Cocos2dxVideoHelper(Cocos2dxActivity activity,RelativeLayout layout)
+    Cocos2dxVideoHelper(Cocos2dxActivity activity, FrameLayout layout)
     {
         mActivity = activity;
         mLayout = layout;

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxVideoView.java
@@ -25,19 +25,13 @@ import android.content.res.AssetFileDescriptor;
 import android.content.res.Resources;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
-import android.media.MediaPlayer.OnErrorListener;
 import android.net.Uri;
 import android.util.Log;
-import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.widget.FrameLayout;
-import android.widget.MediaController.MediaPlayerControl;
-import android.widget.RelativeLayout;
-
 import java.io.IOException;
-import java.net.IDN;
 import java.util.Map;
 
 public class Cocos2dxVideoView extends SurfaceView {
@@ -337,8 +331,8 @@ public class Cocos2dxVideoView extends SurfaceView {
 
         getHolder().setFixedSize(mVisibleWidth, mVisibleHeight);
 
-        RelativeLayout.LayoutParams lParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
-                RelativeLayout.LayoutParams.MATCH_PARENT);
+        FrameLayout.LayoutParams lParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT);
         lParams.leftMargin = mVisibleLeft;
         lParams.topMargin = mVisibleTop;
         setLayoutParams(lParams);

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
@@ -28,11 +28,10 @@ package org.cocos2dx.lib;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.util.Log;
-import android.view.Gravity;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import android.widget.RelativeLayout;
+import android.widget.FrameLayout;
 
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -164,8 +163,8 @@ public class Cocos2dxWebView extends WebView {
     }
 
     public void setWebViewRect(int left, int top, int maxWidth, int maxHeight) {
-        RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
-                RelativeLayout.LayoutParams.MATCH_PARENT);
+        FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT);
         layoutParams.leftMargin = left;
         layoutParams.topMargin = top;
         layoutParams.width = maxWidth;

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebViewHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebViewHelper.java
@@ -32,7 +32,6 @@ import android.util.SparseArray;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
-import android.widget.RelativeLayout;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -43,12 +42,12 @@ public class Cocos2dxWebViewHelper {
     private static final String TAG = Cocos2dxWebViewHelper.class.getSimpleName();
     private static Handler sHandler;
     private static Cocos2dxActivity sCocos2dxActivity;
-    private static RelativeLayout sLayout;
+    private static FrameLayout sLayout;
 
     private static SparseArray<Cocos2dxWebView> webViews;
     private static int viewTag = 0;
 
-    public Cocos2dxWebViewHelper(RelativeLayout layout) {
+    public Cocos2dxWebViewHelper(FrameLayout layout) {
         Cocos2dxWebViewHelper.sLayout = layout;
         Cocos2dxWebViewHelper.sHandler = new Handler(Looper.myLooper());
 


### PR DESCRIPTION
Activity 使用 RelativeLayout 时，键盘弹出时会上推，所以改成 FrameLayout，这个和 -x 是一样的。键盘弹出时，通过调整 EditText 对应的 Layout 的 topMargin 来修改输入框的位置。同时删除了一些多余的 import。