### PR TITLE
fix spine cache mode render buffer overflow

### DIFF
--- a/cocos/editor-support/spine-creator-support/SkeletonCache.cpp
+++ b/cocos/editor-support/spine-creator-support/SkeletonCache.cpp
@@ -424,6 +424,7 @@ namespace spine {
                 
                 trianglesTwoColor.indexCount = (int)_clipper->getClippedTriangles().size();
                 ibSize = trianglesTwoColor.indexCount * sizeof(unsigned short);
+                ib.checkSpace(ibSize, true);
                 trianglesTwoColor.indices = (unsigned short*)ib.getCurBuffer();
                 memcpy(trianglesTwoColor.indices, _clipper->getClippedTriangles().buffer(), sizeof(unsigned short) * _clipper->getClippedTriangles().size());
                 


### PR DESCRIPTION
修复 spine 在cache模式下，使用裁剪动画，且裁剪造成顶点数量增加时，超过一定数量，会存在缓冲区溢出的问题。