### PR TITLE
Revert "fix multiply register audioEngine onEnterBackground event "

### DIFF
--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -174,13 +174,13 @@ void AudioEngine::end()
 
     if (_onPauseListenerID != 0)
     {
-        EventDispatcher::removeCustomEventListener(EVENT_COME_TO_BACKGROUND, _onPauseListenerID);
+        EventDispatcher::removeCustomEventListener(EVENT_ON_PAUSE, _onPauseListenerID);
         _onPauseListenerID = 0;
     }
 
     if (_onResumeListenerID != 0)
     {
-        EventDispatcher::removeCustomEventListener(EVENT_COME_TO_FOREGROUND, _onResumeListenerID);
+        EventDispatcher::removeCustomEventListener(EVENT_ON_RESUME, _onResumeListenerID);
         _onResumeListenerID = 0;
     }
 }
@@ -195,8 +195,8 @@ bool AudioEngine::lazyInit()
             _audioEngineImpl = nullptr;
            return false;
         }
-        _onPauseListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_BACKGROUND, AudioEngine::onEnterBackground);
-        _onResumeListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_FOREGROUND, AudioEngine::onEnterForeground);
+        _onPauseListenerID = EventDispatcher::addCustomEventListener(EVENT_ON_PAUSE, AudioEngine::onPause);
+        _onResumeListenerID = EventDispatcher::addCustomEventListener(EVENT_ON_RESUME, AudioEngine::onResume);
     }
 
 #if (CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID)
@@ -353,7 +353,7 @@ void AudioEngine::resumeAll()
     }
 }
 
-void AudioEngine::onEnterBackground(const CustomEvent &event) {
+void AudioEngine::onPause(const CustomEvent &event) {
     auto itEnd = _audioIDInfoMap.end();
     for (auto it = _audioIDInfoMap.begin(); it != itEnd; ++it)
     {
@@ -365,7 +365,7 @@ void AudioEngine::onEnterBackground(const CustomEvent &event) {
     }
 }
 
-void AudioEngine::onEnterForeground(const CustomEvent &event) {
+void AudioEngine::onResume(const CustomEvent &event) {
     auto itEnd = _breakAudioID.end();
     for (auto it = _breakAudioID.begin(); it != itEnd; ++it) {
         _audioEngineImpl->resume(*it);

--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -175,11 +175,13 @@ void AudioEngine::end()
     if (_onPauseListenerID != 0)
     {
         EventDispatcher::removeCustomEventListener(EVENT_COME_TO_BACKGROUND, _onPauseListenerID);
+        _onPauseListenerID = 0;
     }
 
     if (_onResumeListenerID != 0)
     {
         EventDispatcher::removeCustomEventListener(EVENT_COME_TO_FOREGROUND, _onResumeListenerID);
+        _onResumeListenerID = 0;
     }
 }
 
@@ -193,6 +195,8 @@ bool AudioEngine::lazyInit()
             _audioEngineImpl = nullptr;
            return false;
         }
+        _onPauseListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_BACKGROUND, AudioEngine::onEnterBackground);
+        _onResumeListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_FOREGROUND, AudioEngine::onEnterForeground);
     }
 
 #if (CC_TARGET_PLATFORM != CC_PLATFORM_ANDROID)
@@ -201,9 +205,6 @@ bool AudioEngine::lazyInit()
         s_threadPool = new (std::nothrow) AudioEngineThreadPool();
     }
 #endif
-
-    _onPauseListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_BACKGROUND, AudioEngine::onEnterBackground);
-    _onResumeListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_FOREGROUND, AudioEngine::onEnterForeground);
 
     return true;
 }

--- a/cocos/audio/AudioEngine.cpp
+++ b/cocos/audio/AudioEngine.cpp
@@ -68,6 +68,8 @@ AudioEngine::ProfileHelper* AudioEngine::_defaultProfileHelper = nullptr;
 std::unordered_map<int, AudioEngine::AudioInfo> AudioEngine::_audioIDInfoMap;
 AudioEngineImpl* AudioEngine::_audioEngineImpl = nullptr;
 
+uint32_t AudioEngine::_onPauseListenerID = 0;
+uint32_t AudioEngine::_onResumeListenerID = 0;
 std::vector<int> AudioEngine::_breakAudioID;
 
 AudioEngine::AudioEngineThreadPool* AudioEngine::s_threadPool = nullptr;
@@ -169,6 +171,16 @@ void AudioEngine::end()
 
     delete _defaultProfileHelper;
     _defaultProfileHelper = nullptr;
+
+    if (_onPauseListenerID != 0)
+    {
+        EventDispatcher::removeCustomEventListener(EVENT_COME_TO_BACKGROUND, _onPauseListenerID);
+    }
+
+    if (_onResumeListenerID != 0)
+    {
+        EventDispatcher::removeCustomEventListener(EVENT_COME_TO_FOREGROUND, _onResumeListenerID);
+    }
 }
 
 bool AudioEngine::lazyInit()
@@ -189,6 +201,9 @@ bool AudioEngine::lazyInit()
         s_threadPool = new (std::nothrow) AudioEngineThreadPool();
     }
 #endif
+
+    _onPauseListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_BACKGROUND, AudioEngine::onEnterBackground);
+    _onResumeListenerID = EventDispatcher::addCustomEventListener(EVENT_COME_TO_FOREGROUND, AudioEngine::onEnterForeground);
 
     return true;
 }
@@ -337,23 +352,22 @@ void AudioEngine::resumeAll()
     }
 }
 
-void AudioEngine::onEnterBackground() {
+void AudioEngine::onEnterBackground(const CustomEvent &event) {
     auto itEnd = _audioIDInfoMap.end();
     for (auto it = _audioIDInfoMap.begin(); it != itEnd; ++it)
     {
         if (it->second.state == AudioState::PLAYING)
         {
             _audioEngineImpl->pause(it->first);
-            it->second.state = AudioState::PAUSED;
             _breakAudioID.push_back(it->first);
         }
     }
 }
 
-void AudioEngine::onEnterForeground() {
+void AudioEngine::onEnterForeground(const CustomEvent &event) {
     auto itEnd = _breakAudioID.end();
     for (auto it = _breakAudioID.begin(); it != itEnd; ++it) {
-        AudioEngine::resume(*it);
+        _audioEngineImpl->resume(*it);
     }
     _breakAudioID.clear();
 }

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -317,9 +317,6 @@ public:
      */
     static bool isEnabled();
     
-    static void onEnterBackground();
-    static void onEnterForeground();
-    
 protected:
     static void addTask(const std::function<void()>& task);
     static void remove(int audioID);
@@ -379,7 +376,12 @@ protected:
     static bool _isEnabled;
     
 private:
+    static uint32_t _onPauseListenerID;
+    static uint32_t _onResumeListenerID;
     static std::vector<int> _breakAudioID;
+    
+    static void onEnterBackground(const CustomEvent&);
+    static void onEnterForeground(const CustomEvent&);
     
     friend class AudioEngineImpl;
 };

--- a/cocos/audio/include/AudioEngine.h
+++ b/cocos/audio/include/AudioEngine.h
@@ -380,8 +380,8 @@ private:
     static uint32_t _onResumeListenerID;
     static std::vector<int> _breakAudioID;
     
-    static void onEnterBackground(const CustomEvent&);
-    static void onEnterForeground(const CustomEvent&);
+    static void onPause(const CustomEvent&);
+    static void onResume(const CustomEvent&);
     
     friend class AudioEngineImpl;
 };

--- a/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-default/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -27,7 +27,6 @@
 
 #include "cocos2d.h"
 
-#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/manual/jsb_module_register.hpp"
 #include "cocos/scripting/js-bindings/manual/jsb_global.h"
 #include "cocos/scripting/js-bindings/jswrapper/SeApi.h"
@@ -80,14 +79,10 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::onPause()
 {
     EventDispatcher::dispatchOnPauseEvent();
-    // Ensure that handle AudioEngine enter background after all enter background events are handled
-    AudioEngine::onEnterBackground();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::onResume()
 {
-    // Ensure that handle AudioEngine enter foreground before all enter foreground events are handled
-    AudioEngine::onEnterForeground();
     EventDispatcher::dispatchOnResumeEvent();
 }

--- a/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/templates/js-template-link/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -27,7 +27,6 @@
 
 #include "cocos2d.h"
 
-#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/manual/jsb_module_register.hpp"
 #include "cocos/scripting/js-bindings/manual/jsb_global.h"
 #include "cocos/scripting/js-bindings/jswrapper/SeApi.h"
@@ -79,14 +78,10 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::onPause()
 {
     EventDispatcher::dispatchOnPauseEvent();
-    // Ensure that handle AudioEngine enter background after all enter background events are handled
-    AudioEngine::onEnterBackground(); 
 }
 
 // this function will be called when the app is active again
 void AppDelegate::onResume()
 {
-    // Ensure that handle AudioEngine enter foreground before all enter foreground events are handled
-    AudioEngine::onEnterForeground();
     EventDispatcher::dispatchOnResumeEvent();
 }

--- a/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
+++ b/tools/simulator/frameworks/runtime-src/Classes/AppDelegate.cpp
@@ -26,8 +26,6 @@
 #include "AppDelegate.h"
 
 #include "cocos2d.h"
-
-#include "cocos/audio/include/AudioEngine.h"
 #include "cocos/scripting/js-bindings/event/EventDispatcher.h"
 
 #include "ide-support/CodeIDESupport.h"
@@ -66,14 +64,10 @@ bool AppDelegate::applicationDidFinishLaunching()
 void AppDelegate::applicationDidEnterBackground()
 {
     EventDispatcher::dispatchEnterBackgroundEvent();
-    // Ensure that handle AudioEngine enter background after all enter background events are handled
-    AudioEngine::onEnterBackground();
 }
 
 // this function will be called when the app is active again
 void AppDelegate::applicationWillEnterForeground()
 {
-    // Ensure that handle AudioEngine enter foreground before all enter foreground events are handled
-    AudioEngine::onEnterForeground();
     EventDispatcher::dispatchEnterForegroundEvent();
 }


### PR DESCRIPTION
revert pr https://github.com/cocos-creator/cocos2d-x-lite/pull/1925
之前和 @minggo 讨论，这里没有必要把 audioEngine onEnterBackground onEnterForeground 的回调放到所有回调的最后处理

还是放到事件监听里去处理这个事情

同时得防止 lazyInit 里重复注册事件监听