### PR TITLE
Fix typo error of Label on IOS and Mac platforms.

### DIFF
--- a/cocos/platform/apple/CCCanvasRenderingContext2D-apple.mm
+++ b/cocos/platform/apple/CCCanvasRenderingContext2D-apple.mm
@@ -271,9 +271,6 @@ enum class CanvasTextBaseline {
 
     NSSize dim = [stringWithAttributes boundingRectWithSize:textRect options:(NSStringDrawingOptions)(NSStringDrawingUsesLineFragmentOrigin) context:nil].size;
 
-    dim.width = ceilf(dim.width);
-    dim.height = ceilf(dim.height);
-
     return dim;
 }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2067

修改说明：

修复IOS平台跟Mac平台的文本排版跟Web不一致的问题，测试了安卓平台跟Win32平台的，没有这个问题。

修复前：

![image](https://user-images.githubusercontent.com/39078800/69850551-81419f80-12ba-11ea-9136-6863f43d74ac.png)

修复后：

![image](https://user-images.githubusercontent.com/39078800/69850593-90c0e880-12ba-11ea-9b01-062cad1376ea.png)
