### PR TITLE
fix measureText on iOS

### DIFF
--- a/cocos/platform/apple/CCCanvasRenderingContext2D-apple.mm
+++ b/cocos/platform/apple/CCCanvasRenderingContext2D-apple.mm
@@ -610,8 +610,12 @@ void CanvasRenderingContext2D::strokeText(const std::string& text, float x, floa
 
 cocos2d::Size CanvasRenderingContext2D::measureText(const std::string& text)
 {
+    auto cStr = [NSString stringWithUTF8String:text.c_str()];
+    if (!cStr) {
+        return cocos2d::Size::ZERO;
+    }
 //    SE_LOGD("CanvasRenderingContext2D::measureText: %s\n", text.c_str());
-    CGSize size = [_impl measureText: [NSString stringWithUTF8String:text.c_str()]];
+    CGSize size = [_impl measureText: cStr];
     return cocos2d::Size(size.width, size.height);
 }
 


### PR DESCRIPTION
changeLog:
- 修复 iOS 平台 measureText 奔溃的问题

相关论坛反馈：https://forum.cocos.org/t/cocos-creator-2-2-1-editbox/87584

js 层在做字符串裁剪的时候，由于不能确定哪些字符占两个字节，所以可能会裁剪掉一些 两个字节的字符
传过来到 c++ 层就是一个非法字符，所以这里 measureText 的时候应该判断下字符的有效性