### PR TITLE
Remove absolute path to avoid as build with absolute path

### DIFF
--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/game/AndroidManifest.xml
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/game/AndroidManifest.xml
@@ -27,18 +27,11 @@
             android:taskAffinity=""
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
 
-            <intent-filter android:order="1" android:autoVerify="true">
+            <intent-filter android:order="1">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
-
-                <data
-                    android:host="${host}"
-                    android:pathPattern="${pathPattern}"
-                    android:scheme="https" />
-
-                <data android:scheme="http"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/jni/CocosAndroid.mk
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/jni/CocosAndroid.mk
@@ -10,9 +10,9 @@ ifeq ($(USE_ARM_MODE),1)
 LOCAL_ARM_MODE := arm
 endif
 
-LOCAL_SRC_FILES := $(LOCAL_PATH)/hellojavascript/main.cpp \
-				   $(LOCAL_PATH)/../../Classes/AppDelegate.cpp \
-				   $(LOCAL_PATH)/../../Classes/jsb_module_register.cpp \
+LOCAL_SRC_FILES := hellojavascript/main.cpp \
+				   ../../Classes/AppDelegate.cpp \
+				   ../../Classes/jsb_module_register.cpp \
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../Classes
 

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/game/AndroidManifest.xml
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/game/AndroidManifest.xml
@@ -27,18 +27,11 @@
             android:taskAffinity=""
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
 
-            <intent-filter android:order="1" android:autoVerify="true">
+            <intent-filter android:order="1">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
-
-                <data
-                    android:host="${host}"
-                    android:pathPattern="${pathPattern}"
-                    android:scheme="https" />
-
-                <data android:scheme="http"/>
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/jni/CocosAndroid.mk
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/jni/CocosAndroid.mk
@@ -10,9 +10,9 @@ ifeq ($(USE_ARM_MODE),1)
 LOCAL_ARM_MODE := arm
 endif
 
-LOCAL_SRC_FILES := $(LOCAL_PATH)/hellojavascript/main.cpp \
-				   $(LOCAL_PATH)/../../Classes/AppDelegate.cpp \
-				   $(LOCAL_PATH)/../../Classes/jsb_module_register.cpp \
+LOCAL_SRC_FILES := hellojavascript/main.cpp \
+				   ../../Classes/AppDelegate.cpp \
+				   ../../Classes/jsb_module_register.cpp \
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../../Classes
 


### PR DESCRIPTION
1.删除几个文件的绝对路径避免 as 编译的的时候也是按照绝对路径生成文件，在windows下导致路径过长
2.删除 android instant 默认的 几个data 配置（creator构建会自己加上），避免使用cocos console编译的时候报错。