### PR TITLE
exclude webview implementation

### DIFF
--- a/cocos/scripting/js-bindings/auto/jsb_webview_auto.cpp
+++ b/cocos/scripting/js-bindings/auto/jsb_webview_auto.cpp
@@ -1,5 +1,5 @@
-#include "scripting/js-bindings/auto/jsb_webview_auto.hpp"
 #if (USE_WEB_VIEW > 0) && (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID || CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
+#include "scripting/js-bindings/auto/jsb_webview_auto.hpp"
 #include "scripting/js-bindings/manual/jsb_conversions.hpp"
 #include "scripting/js-bindings/manual/jsb_global.h"
 #include "ui/webview/WebView.h"

--- a/cocos/ui/webview/WebViewImpl-ios.mm
+++ b/cocos/ui/webview/WebViewImpl-ios.mm
@@ -26,7 +26,7 @@
 #include "platform/CCPlatformConfig.h"
 
 // Webview not available on tvOS
-#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
+#if (USE_WEB_VIEW > 0) && (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)
 
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKUIDelegate.h>
@@ -392,4 +392,4 @@ namespace cocos2d {
     }
 } //namespace cocos2d
 
-#endif // CC_TARGET_PLATFORM == CC_PLATFORM_IOS
+#endif // (USE_WEB_VIEW > 0) && (CC_TARGET_PLATFORM == CC_PLATFORM_IOS) && !defined(CC_TARGET_OS_TVOS)


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2171

如果没有使用 webview 模块，应该剔除掉 webview-ios 的实现，避免苹果审核不通过