### PR TITLE
v2.3.0 fix native set uniform array out of range

### DIFF
--- a/cocos/renderer/gfx/DeviceGraphics.cpp
+++ b/cocos/renderer/gfx/DeviceGraphics.cpp
@@ -413,7 +413,7 @@ void DeviceGraphics::draw(size_t base, GLsizei count)
             continue;
         
         uniform.dirty = false;
-        uniformInfo.setUniform(uniform.value, uniform.bytes, uniform.elementType, uniform.count);
+        uniformInfo.setUniform(uniform.value, uniform.elementType, uniform.count);
     }
     
     // draw primitives

--- a/cocos/renderer/gfx/DeviceGraphics.cpp
+++ b/cocos/renderer/gfx/DeviceGraphics.cpp
@@ -347,7 +347,7 @@ void DeviceGraphics::setTexture(size_t hashName, Texture* texture, int slot)
     setUniformi(hashName, slot);
 }
 
-void DeviceGraphics::setTextureArray(size_t hashName, const std::vector<Texture*>& textures, const std::vector<int>& slots, size_t fieldCount)
+void DeviceGraphics::setTextureArray(size_t hashName, const std::vector<Texture*>& textures, const std::vector<int>& slots)
 {
     auto len = textures.size();
     if (len >= _caps.maxTextureUnits)
@@ -362,7 +362,7 @@ void DeviceGraphics::setTextureArray(size_t hashName, const std::vector<Texture*
         _nextState->setTexture(slot, textures[i]);
     }
     
-    setUniformiv(hashName, slots.size(), slots.data(), fieldCount);
+    setUniformiv(hashName, slots.size(), slots.data(), slots.size());
 }
 
 void DeviceGraphics::setPrimitiveType(PrimitiveType type)
@@ -438,18 +438,18 @@ void DeviceGraphics::draw(size_t base, GLsizei count)
     _nextState->reset();
 }
 
-void DeviceGraphics::setUniform(size_t hashName, const void* v, size_t bytes, UniformElementType elementType, size_t fieldCount)
+void DeviceGraphics::setUniform(size_t hashName, const void* v, size_t bytes, UniformElementType elementType, size_t elementCount)
 {
     auto iter = _uniforms.find(hashName);
     if (iter == _uniforms.end())
     {
-        _uniforms[hashName] = Uniform(v, bytes, elementType, fieldCount);
+        _uniforms[hashName] = Uniform(v, bytes, elementType, elementCount);
     }
     else
     {
         auto& uniform = iter->second;
         uniform.dirty = true;
-        uniform.setValue(v, bytes, fieldCount);
+        uniform.setValue(v, bytes, elementCount);
     }
 }
 
@@ -476,9 +476,9 @@ void DeviceGraphics::setUniformi(size_t hashName, int i1, int i2, int i3, int i4
     setUniform(hashName, tempValue, 4 * sizeof(int), UniformElementType::INT);
 }
 
-void DeviceGraphics::setUniformiv(size_t hashName, size_t count, const int* value, size_t fieldCount)
+void DeviceGraphics::setUniformiv(size_t hashName, size_t count, const int* value, size_t elementCount)
 {
-    setUniform(hashName, value, count * sizeof(int), UniformElementType::INT, fieldCount);
+    setUniform(hashName, value, count * sizeof(int), UniformElementType::INT, elementCount);
 }
 
 void DeviceGraphics::setUniformf(size_t hashName, float f1)
@@ -504,9 +504,9 @@ void DeviceGraphics::setUniformf(size_t hashName, float f1, float f2, float f3, 
     setUniform(hashName, tempValue, 4 * sizeof(float), UniformElementType::FLOAT);
 }
 
-void DeviceGraphics::setUniformfv(size_t hashName, size_t count, const float* value, size_t fieldCount)
+void DeviceGraphics::setUniformfv(size_t hashName, size_t count, const float* value, size_t elementCount)
 {
-    setUniform(hashName, value, count * sizeof(float), UniformElementType::FLOAT, fieldCount);
+    setUniform(hashName, value, count * sizeof(float), UniformElementType::FLOAT, elementCount);
 }
 
 void DeviceGraphics::setUniformVec2(size_t hashName, const cocos2d::Vec2& value)
@@ -1157,7 +1157,7 @@ DeviceGraphics::Uniform& DeviceGraphics::Uniform::operator=(Uniform&& h)
     return *this;
 }
 
-void DeviceGraphics::Uniform::setValue(const void* v, size_t valueBytes, size_t fieldCount)
+void DeviceGraphics::Uniform::setValue(const void* v, size_t valueBytes, size_t elementCount)
 {
     if (bytes != valueBytes || !value) {
         if (value)
@@ -1165,7 +1165,7 @@ void DeviceGraphics::Uniform::setValue(const void* v, size_t valueBytes, size_t 
         value = malloc(valueBytes);
         
         bytes = valueBytes;
-        count = fieldCount;
+        count = elementCount;
     }
     
     memcpy(value, v, valueBytes);

--- a/cocos/renderer/gfx/DeviceGraphics.h
+++ b/cocos/renderer/gfx/DeviceGraphics.h
@@ -212,7 +212,7 @@ public:
     /**
      * Sets textures array into GL texture slots then set to the specified uniform
      */
-    void setTextureArray(size_t hashName, const std::vector<Texture*>& textures, const std::vector<int>& slots, size_t fieldCount);
+    void setTextureArray(size_t hashName, const std::vector<Texture*>& textures, const std::vector<int>& slots);
 
     /**
      * Sets a integer to the specified uniform
@@ -233,7 +233,7 @@ public:
     /**
      * Sets a vector of integers to the specified uniform
      */
-    void setUniformiv(size_t hashName, size_t count, const int* value, size_t fieldCount);
+    void setUniformiv(size_t hashName, size_t count, const int* value, size_t elementCount);
     /**
      * Sets a float to the specified uniform
      */
@@ -253,7 +253,7 @@ public:
     /**
      * Sets a vector of floats to the specified uniform
      */
-    void setUniformfv(size_t hashName, size_t count, const float* value, size_t fieldCount);
+    void setUniformfv(size_t hashName, size_t count, const float* value, size_t elementCount);
     /**
      * Sets a Vec2 to the specified uniform
      */
@@ -285,7 +285,7 @@ public:
     /**
      * Sets data specified by data pointer, type and bytes to the given uniform
      */
-    void setUniform(size_t hashName, const void* v, size_t bytes, UniformElementType elementType, size_t fieldCount = 1);
+    void setUniform(size_t hashName, const void* v, size_t bytes, UniformElementType elementType, size_t elementCount = 1);
 
     /**
      * Sets the primitive type for draw calls

--- a/cocos/renderer/gfx/DeviceGraphics.h
+++ b/cocos/renderer/gfx/DeviceGraphics.h
@@ -70,17 +70,18 @@ public:
     
     struct Uniform
     {
-        Uniform(const void* v, size_t bytes, UniformElementType elementType_);
+        Uniform(const void* v, size_t bytes, UniformElementType elementType_, size_t count);
         Uniform(Uniform&& h);
         Uniform();
         ~Uniform();
         
         Uniform& operator=(Uniform&& h);
         
-        void setValue(const void* v, size_t bytes);
+        void setValue(const void* v, size_t bytes, size_t count = 1);
         
         void* value = nullptr;
         size_t bytes = 0;
+        size_t count = 0;
         
         bool dirty;
         UniformElementType elementType;
@@ -211,7 +212,7 @@ public:
     /**
      * Sets textures array into GL texture slots then set to the specified uniform
      */
-    void setTextureArray(size_t hashName, const std::vector<Texture*>& textures, const std::vector<int>& slots);
+    void setTextureArray(size_t hashName, const std::vector<Texture*>& textures, const std::vector<int>& slots, size_t fieldCount);
 
     /**
      * Sets a integer to the specified uniform
@@ -232,7 +233,7 @@ public:
     /**
      * Sets a vector of integers to the specified uniform
      */
-    void setUniformiv(size_t hashName, size_t count, const int* value);
+    void setUniformiv(size_t hashName, size_t count, const int* value, size_t fieldCount);
     /**
      * Sets a float to the specified uniform
      */
@@ -252,7 +253,7 @@ public:
     /**
      * Sets a vector of floats to the specified uniform
      */
-    void setUniformfv(size_t hashName, size_t count, const float* value);
+    void setUniformfv(size_t hashName, size_t count, const float* value, size_t fieldCount);
     /**
      * Sets a Vec2 to the specified uniform
      */
@@ -284,7 +285,7 @@ public:
     /**
      * Sets data specified by data pointer, type and bytes to the given uniform
      */
-    void setUniform(size_t hashName, const void* v, size_t bytes, UniformElementType elementType);
+    void setUniform(size_t hashName, const void* v, size_t bytes, UniformElementType elementType, size_t fieldCount = 1);
 
     /**
      * Sets the primitive type for draw calls

--- a/cocos/renderer/gfx/Program.cpp
+++ b/cocos/renderer/gfx/Program.cpp
@@ -226,8 +226,10 @@ namespace {
 
 RENDERER_BEGIN
 
-void Program::Uniform::setUniform(const void* value, size_t bytes, UniformElementType elementType, size_t fieldCount) const
+void Program::Uniform::setUniform(const void* value, UniformElementType elementType, size_t fieldCount) const
 {
+    // fieldCount may bigger than size.
+    if (size >= 1 && size < fieldCount) fieldCount = size;
     GLsizei count = size == -1 ? 1 : (GLsizei)fieldCount;
     _callback(location, count, value, elementType);
 }

--- a/cocos/renderer/gfx/Program.cpp
+++ b/cocos/renderer/gfx/Program.cpp
@@ -226,9 +226,9 @@ namespace {
 
 RENDERER_BEGIN
 
-void Program::Uniform::setUniform(const void* value, UniformElementType elementType) const
+void Program::Uniform::setUniform(const void* value, size_t bytes, UniformElementType elementType, size_t fieldCount) const
 {
-    GLsizei count = size == -1 ? 1 : size;
+    GLsizei count = size == -1 ? 1 : (GLsizei)fieldCount;
     _callback(location, count, value, elementType);
 }
 

--- a/cocos/renderer/gfx/Program.cpp
+++ b/cocos/renderer/gfx/Program.cpp
@@ -226,11 +226,11 @@ namespace {
 
 RENDERER_BEGIN
 
-void Program::Uniform::setUniform(const void* value, UniformElementType elementType, size_t fieldCount) const
+void Program::Uniform::setUniform(const void* value, UniformElementType elementType, size_t elementCount) const
 {
-    // fieldCount may bigger than size.
-    if (size >= 1 && size < fieldCount) fieldCount = size;
-    GLsizei count = size == -1 ? 1 : (GLsizei)fieldCount;
+    // elementCount may bigger than size.
+    if (size >= 1 && size < elementCount) elementCount = size;
+    GLsizei count = size == -1 ? 1 : (GLsizei)elementCount;
     _callback(location, count, value, elementType);
 }
 

--- a/cocos/renderer/gfx/Program.h
+++ b/cocos/renderer/gfx/Program.h
@@ -102,7 +102,7 @@ public:
         /**
          * Sets the uniform value
          */
-        void setUniform(const void* value, UniformElementType elementType) const;
+        void setUniform(const void* value, size_t bytes, UniformElementType elementType, size_t fieldCount) const;
         /**
          * Sets the callback which will be called when uniform updated
          */

--- a/cocos/renderer/gfx/Program.h
+++ b/cocos/renderer/gfx/Program.h
@@ -102,7 +102,7 @@ public:
         /**
          * Sets the uniform value
          */
-        void setUniform(const void* value, size_t bytes, UniformElementType elementType, size_t fieldCount) const;
+        void setUniform(const void* value, UniformElementType elementType, size_t fieldCount) const;
         /**
          * Sets the callback which will be called when uniform updated
          */

--- a/cocos/renderer/gfx/Program.h
+++ b/cocos/renderer/gfx/Program.h
@@ -102,7 +102,7 @@ public:
         /**
          * Sets the uniform value
          */
-        void setUniform(const void* value, UniformElementType elementType, size_t fieldCount) const;
+        void setUniform(const void* value, UniformElementType elementType, size_t elementCount) const;
         /**
          * Sets the callback which will be called when uniform updated
          */

--- a/cocos/renderer/renderer/BaseRenderer.cpp
+++ b/cocos/renderer/renderer/BaseRenderer.cpp
@@ -249,7 +249,7 @@ void BaseRenderer::setProperty (const Effect::Property* prop)
             
             _device->setTextureArray(propHashName,
                                      prop->getTextureArray(),
-                                     slots);
+                                     slots, prop->getCount());
         }
     }
     else
@@ -259,11 +259,11 @@ void BaseRenderer::setProperty (const Effect::Property* prop)
             Effect::Property::Type::INT2 == propType ||
             Effect::Property::Type::INT4 == propType)
         {
-            _device->setUniformiv(propHashName, bytes / sizeof(int), (const int*)prop->getValue());
+            _device->setUniformiv(propHashName, bytes / sizeof(int), (const int*)prop->getValue(), prop->getCount());
         }
         else
         {
-            _device->setUniformfv(propHashName, bytes / sizeof(float), (const float*)prop->getValue());
+            _device->setUniformfv(propHashName, bytes / sizeof(float), (const float*)prop->getValue(), prop->getCount());
         }
     }
 }

--- a/cocos/renderer/renderer/BaseRenderer.cpp
+++ b/cocos/renderer/renderer/BaseRenderer.cpp
@@ -249,7 +249,7 @@ void BaseRenderer::setProperty (const Effect::Property* prop)
             
             _device->setTextureArray(propHashName,
                                      prop->getTextureArray(),
-                                     slots, prop->getCount());
+                                     slots);
         }
     }
     else

--- a/cocos/renderer/renderer/ForwardRenderer.cpp
+++ b/cocos/renderer/renderer/ForwardRenderer.cpp
@@ -225,8 +225,8 @@ void ForwardRenderer::submitLightsUniforms()
             *(colors + index + 2) = colorVec3.z;
             *(colors + index + 3) = 0;
         }
-        _device->setUniformfv(cc_dirLightDirection, count * 4, directions);
-        _device->setUniformfv(cc_dirLightColor, count * 4, colors);
+        _device->setUniformfv(cc_dirLightDirection, count * 4, directions, count);
+        _device->setUniformfv(cc_dirLightColor, count * 4, colors, count);
     }
     
     if (_pointLights.size() > 0)
@@ -252,8 +252,8 @@ void ForwardRenderer::submitLightsUniforms()
             *(colors + index + 2) = colorVec3.z;
             *(colors + index + 3) = 0;
         }
-        _device->setUniformfv(cc_pointLightPositionAndRange, count * 4, positionAndRanges);
-        _device->setUniformfv(cc_pointLightColor, count * 4, colors);
+        _device->setUniformfv(cc_pointLightPositionAndRange, count * 4, positionAndRanges, count);
+        _device->setUniformfv(cc_pointLightColor, count * 4, colors, count);
     }
     
     if (_spotLights.size() > 0)
@@ -287,9 +287,9 @@ void ForwardRenderer::submitLightsUniforms()
             *(colors + index + 2) = colorVec3.z;
             *(colors + index + 3) = 0;
         }
-        _device->setUniformfv(cc_spotLightDirection, count * 4, directions);
-        _device->setUniformfv(cc_spotLightPositionAndRange, count * 4, positionAndRanges);
-        _device->setUniformfv(cc_spotLightColor, count * 4, colors);
+        _device->setUniformfv(cc_spotLightDirection, count * 4, directions, count);
+        _device->setUniformfv(cc_spotLightPositionAndRange, count * 4, positionAndRanges, count);
+        _device->setUniformfv(cc_spotLightColor, count * 4, colors, count);
     }
     
     if (_ambientLights.size() > 0) {
@@ -306,7 +306,7 @@ void ForwardRenderer::submitLightsUniforms()
             *(colors + index + 2) = colorVec3.z;
             *(colors + index + 3) = 0;
         }
-        _device->setUniformfv(cc_ambientLightColor, count * 4, colors);
+        _device->setUniformfv(cc_ambientLightColor, count * 4, colors, count);
     }
 }
 
@@ -319,7 +319,7 @@ void ForwardRenderer::submitShadowStageUniforms(const View& view)
     shadowInfo[3] = view.shadowLight->getShadowDarkness();
     
     _device->setUniformMat4(cc_shadow_map_lightViewProjMatrix, view.matViewProj);
-    _device->setUniformfv(cc_shadow_map_info, 4, shadowInfo);
+    _device->setUniformfv(cc_shadow_map_info, 4, shadowInfo, 1);
     _device->setUniformf(cc_shadow_map_bias, view.shadowLight->getShadowBias());
 }
 
@@ -342,8 +342,8 @@ void ForwardRenderer::submitOtherStagesUniforms()
         *(shadowLightInfo + index + 3) = light->getShadowDarkness();
     }
     
-    _device->setUniformfv(cc_shadow_lightViewProjMatrix, count * 16, shadowLightProjs);
-    _device->setUniformfv(cc_shadow_info, count * 4, shadowLightInfo);
+    _device->setUniformfv(cc_shadow_lightViewProjMatrix, count * 16, shadowLightProjs, count);
+    _device->setUniformfv(cc_shadow_info, count * 4, shadowLightInfo, count);
 }
 
 bool ForwardRenderer::compareItems(const StageItem &a, const StageItem &b)


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/2300

由于3D模型的vertex shader用到了uniform array，设置uniform array的时候，count用的是uniform数组的长度，而源数据可能并没有那么多，造成了越界。