### PR TITLE
Delete precision replace in program define.

### DIFF
--- a/cocos/renderer/renderer/ProgramLib.cpp
+++ b/cocos/renderer/renderer/ProgramLib.cpp
@@ -215,51 +215,10 @@ void ProgramLib::define(const std::string& name, const std::string& vert, const 
     std::string newFrag = frag;
     
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
-    std::string::size_type pos = 0;
-    pos = newVert.find(_precisionVert);
-    if (pos != std::string::npos)
-    {
-        newVert.replace(pos, strlen(_precisionVert), "");
-    }
-    
-    pos = newFrag.find(_precisionFrag);
-    if (pos != std::string::npos)
-    {
-        newFrag.replace(pos, strlen(_precisionFrag), "");
-    }
-    
-    while((pos = newVert.find(_mediump)) != std::string::npos)
-    {
-        newVert.replace(pos, strlen(_mediump), "");
-    }
-    
-    while((pos = newFrag.find(_mediump)) != std::string::npos)
-    {
-        newFrag.replace(pos, strlen(_mediump), "");
-    }
-    
-    while((pos = newVert.find(_lowp)) != std::string::npos)
-    {
-        newVert.replace(pos, strlen(_lowp), "");
-    }
-    
-    while((pos = newFrag.find(_lowp)) != std::string::npos)
-    {
-        newFrag.replace(pos, strlen(_lowp), "");
-    }
-#else
-    std::string::size_type pos = 0;
-    pos = newVert.find(_precisionVert);
-    if (pos == std::string::npos)
-    {
-        newVert = _precisionVertReplace + vert;
-    }
-    
-    pos = newVert.find(_precisionFrag);
-    if (pos == std::string::npos)
-    {
-        newFrag = _precisionFragReplace + frag;
-    }
+    newVert = std::regex_replace(newVert, std::regex("precision\\s+(lowp|mediump|highp).*?;"), "");
+    newVert = std::regex_replace(newVert, std::regex("(lowp|mediump|highp)\\s"), "");
+    newFrag = std::regex_replace(newFrag, std::regex("precision\\s+(lowp|mediump|highp).*?;"), "");
+    newFrag = std::regex_replace(newFrag, std::regex("(lowp|mediump|highp)\\s"), "");
 #endif
     
     // store it

--- a/cocos/renderer/renderer/ProgramLib.cpp
+++ b/cocos/renderer/renderer/ProgramLib.cpp
@@ -215,10 +215,12 @@ void ProgramLib::define(const std::string& name, const std::string& vert, const 
     std::string newFrag = frag;
     
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_WIN32) || (CC_TARGET_PLATFORM == CC_PLATFORM_MAC) || (CC_TARGET_PLATFORM == CC_PLATFORM_LINUX)
-    newVert = std::regex_replace(newVert, std::regex("precision\\s+(lowp|mediump|highp).*?;"), "");
-    newVert = std::regex_replace(newVert, std::regex("(lowp|mediump|highp)\\s"), "");
-    newFrag = std::regex_replace(newFrag, std::regex("precision\\s+(lowp|mediump|highp).*?;"), "");
-    newFrag = std::regex_replace(newFrag, std::regex("(lowp|mediump|highp)\\s"), "");
+    static const std::regex precision("precision\\s+(lowp|mediump|highp).*?;");
+    static const std::regex accuracy("(lowp|mediump|highp)\\s");
+    newVert = std::regex_replace(newVert, precision, "");
+    newVert = std::regex_replace(newVert, accuracy, "");
+    newFrag = std::regex_replace(newFrag, precision, "");
+    newFrag = std::regex_replace(newFrag, accuracy, "");
 #endif
     
     // store it

--- a/cocos/renderer/renderer/ProgramLib.h
+++ b/cocos/renderer/renderer/ProgramLib.h
@@ -86,15 +86,6 @@ private:
     
 private:
     DeviceGraphics* _device = nullptr;
-    const char* _precisionVert = "precision highp float;";
-    const char* _precisionVertReplace = "#ifdef GL_ES\nprecision highp float;\n#endif\n";
-    const char* _precisionFrag = "precision highp float;";
-    const char* _precisionFragReplace = "#ifdef GL_ES\nprecision mediump float;\n#endif\n";
-    const char* _mediumpReplace = "half";
-    const char* _mediump = "mediump";
-    const char* _lowpReplace = "fixed";
-    const char* _lowp = "lowp";
-    
     std::unordered_map<size_t, Template> _templates;
     std::unordered_map<uint64_t, Program*> _cache;
     


### PR DESCRIPTION
1. 在 2.3 版本的编辑器层面，如果 shader 没有声明 precision 会进行编译失败的报错提示，所以代码层面删掉 precision 查询的额外处理。
2. 在 mac 跟 win 平台替换掉 highp/mediump/lowp时，改为通过正则表达式进行查询替换。