### PR TITLE
remove asset folder when rebuild android instant

### DIFF
--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/game/build.gradle
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/game/build.gradle
@@ -98,7 +98,7 @@ android {
 
 android.featureVariants.all { variant ->
     // delete previous files first
-    delete "${buildDir}/intermediates/merged_assets/${variant.dirName}"
+    delete "${buildDir}/intermediates/merged_assets/"
 
     variant.mergeAssets.doLast {
         def sourceDir = "${buildDir}/../../../../.."

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/game/build.gradle
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/game/build.gradle
@@ -98,7 +98,7 @@ android {
 
 android.featureVariants.all { variant ->
     // delete previous files first
-    delete "${buildDir}/intermediates/merged_assets/${variant.dirName}"
+    delete "${buildDir}/intermediates/merged_assets/"
 
     variant.mergeAssets.doLast {
         def sourceDir = "${buildDir}/../../../../.."


### PR DESCRIPTION
重新编译的时候要删除asset_merged目录，不然代码不会更新，之前的代码删除的路径有误，导致instant无法更新js脚本和资源
https://github.com/cocos-creator/2d-tasks/issues/2316
