### PR TITLE
Sync Spine library to fix json crash issue in ios

### DIFF
--- a/cocos/editor-support/spine/Json.cpp
+++ b/cocos/editor-support/spine/Json.cpp
@@ -120,17 +120,23 @@ Json::Json(const char *value) :
 }
 
 Json::~Json() {
-	delete _child;
+    spine::Json* curr = nullptr;
+    spine::Json* next = _child;
+    do {
+        curr = next;
+        if (curr) {
+            next = curr->_next;
+        }
+        delete curr;
+    } while(next);
 
-	if (_valueString) {
-		SpineExtension::free(_valueString, __FILE__, __LINE__);
-	}
+    if (_valueString) {
+        SpineExtension::free(_valueString, __FILE__, __LINE__);
+    }
 
-	if (_name) {
-		SpineExtension::free(_name, __FILE__, __LINE__);
-	}
-
-	delete _next;
+    if (_name) {
+        SpineExtension::free(_name, __FILE__, __LINE__);
+    }
 }
 
 const char *Json::skip(const char *inValue) {


### PR DESCRIPTION
同步 spine 官方 3.8版本修复 关于json析构时，ios 上某些特殊资源会触发 crash的问题
关联issue：https://forum.cocos.org/t/creator-2-2-1-spine-ios/88346

引自spine官方说明：
[cpp] Change traversal order of Json::~Json(). Old order would grow stack much more than needed, leading to crashes when freeing big Json trees.
