### PR TITLE
Fix crash when playing audio under mac/ios or windows platform

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.mm
+++ b/cocos/audio/apple/AudioEngine-inl.mm
@@ -692,8 +692,8 @@ void AudioEngineImpl::update(float dt)
 
         if (player->_removeByAudioEngine)
         {
-            AudioEngine::remove(audioID);
             _threadMutex.lock();
+            AudioEngine::remove(audioID);
             it = _audioPlayers.erase(it);
             _threadMutex.unlock();
             delete player;
@@ -707,8 +707,8 @@ void AudioEngineImpl::update(float dt)
                 filePath = *audioInfo.filePath;
             }
 
-            AudioEngine::remove(audioID);
             _threadMutex.lock();
+            AudioEngine::remove(audioID);
             it = _audioPlayers.erase(it);
             _threadMutex.unlock();
 

--- a/cocos/audio/win32/AudioEngine-win32.cpp
+++ b/cocos/audio/win32/AudioEngine-win32.cpp
@@ -511,8 +511,8 @@ void AudioEngineImpl::update(float dt)
 
         if (player->_removeByAudioEngine)
         {
-            AudioEngine::remove(audioID);
             _threadMutex.lock();
+            AudioEngine::remove(audioID);
             it = _audioPlayers.erase(it);
             _threadMutex.unlock();
             delete player;
@@ -526,9 +526,8 @@ void AudioEngineImpl::update(float dt)
                 filePath = *audioInfo.filePath;
             }
 
-            AudioEngine::remove(audioID);
-            
             _threadMutex.lock();
+            AudioEngine::remove(audioID);
             it = _audioPlayers.erase(it);
             _threadMutex.unlock();
 


### PR DESCRIPTION
AudioEngine::_audioIDInfoMap may modified in sub thread or main thread, this may cause crashes when playing multiple sound effects.
