### PR TITLE
Fix crash when playing audio under mac/ios

### DIFF
--- a/cocos/audio/apple/AudioEngine-inl.h
+++ b/cocos/audio/apple/AudioEngine-inl.h
@@ -82,6 +82,7 @@ private:
 
     //audioID,AudioInfo
     std::unordered_map<int, AudioPlayer*>  _audioPlayers;
+    std::unordered_map<int, AudioPlayer*>  _threadAudioPlayers;
     std::mutex _threadMutex;
 
     bool _lazyInitLoop;


### PR DESCRIPTION
use `_threadAudioPlayers` instead of `_audioPlayers` for audio thread callback `AudioEngineImpl::myAlSourceNotificationCallback` iterate all playing audio players.
Avoid crashes when accessing `_audioPlayers` in the main and child threads when playing multiple audio.