### PR TITLE
Assert evalString in main thread

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.hpp
@@ -29,6 +29,7 @@
 #if SCRIPT_ENGINE_TYPE == SCRIPT_ENGINE_JSC
 
 #include "Base.h"
+#include <thread>
 
 namespace se {
 
@@ -305,6 +306,8 @@ namespace se {
         ExceptionCallback _exceptionCallback;
 
         uint32_t _vmId;
+
+        std::thread::id _engineThreadId;
 
         bool _isGarbageCollecting;
         bool _isValid;

--- a/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.mm
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.mm
@@ -235,6 +235,8 @@ namespace se {
         SE_LOGD("Initializing JavaScriptCore \n");
         ++_vmId;
 
+        _engineThreadId = std::this_thread::get_id();
+
         for (const auto& hook : _beforeInitHookArray)
         {
             hook();
@@ -561,6 +563,9 @@ namespace se {
 
     bool ScriptEngine::evalString(const char* script, ssize_t length/* = -1 */, Value* ret/* = nullptr */, const char* fileName/* = nullptr */)
     {
+        // `evalString` should run in main thread
+        assert(_engineThreadId == std::this_thread::get_id());
+
         assert(script != nullptr);
         if (length < 0)
             length = strlen(script);

--- a/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.mm
+++ b/cocos/scripting/js-bindings/jswrapper/jsc/ScriptEngine.mm
@@ -563,8 +563,12 @@ namespace se {
 
     bool ScriptEngine::evalString(const char* script, ssize_t length/* = -1 */, Value* ret/* = nullptr */, const char* fileName/* = nullptr */)
     {
-        // `evalString` should run in main thread
-        assert(_engineThreadId == std::this_thread::get_id());
+        if(_engineThreadId != std::this_thread::get_id())
+        {
+            // `evalString` should run in main thread
+            assert(false);
+            return false;
+        }
 
         assert(script != nullptr);
         if (length < 0)

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -367,6 +367,8 @@ namespace se {
         SE_LOGD("Initializing V8, version: %s\n", v8::V8::GetVersion());
         ++_vmId;
 
+        _engineThreadId = std::this_thread::get_id();
+
         for (const auto& hook : _beforeInitHookArray)
         {
             hook();
@@ -617,6 +619,9 @@ namespace se {
 
     bool ScriptEngine::evalString(const char* script, ssize_t length/* = -1 */, Value* ret/* = nullptr */, const char* fileName/* = nullptr */)
     {
+        // `evalString` should run in main thread
+        assert(_engineThreadId == std::this_thread::get_id());
+
         assert(script != nullptr);
         if (length < 0)
             length = strlen(script);

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -619,8 +619,12 @@ namespace se {
 
     bool ScriptEngine::evalString(const char* script, ssize_t length/* = -1 */, Value* ret/* = nullptr */, const char* fileName/* = nullptr */)
     {
-        // `evalString` should run in main thread
-        assert(_engineThreadId == std::this_thread::get_id());
+        if(_engineThreadId != std::this_thread::get_id())
+        {
+            // `evalString` should run in main thread
+            assert(false);
+            return false;
+        }
 
         assert(script != nullptr);
         if (length < 0)

--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.hpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.hpp
@@ -31,6 +31,8 @@
 #include "Base.h"
 #include "../Value.hpp"
 
+#include <thread>
+
 #if SE_ENABLE_INSPECTOR
 namespace node {
     namespace inspector {
@@ -320,6 +322,8 @@ namespace se {
         node::Environment* _env;
         node::IsolateData* _isolateData;
 #endif
+
+        std::thread::id _engineThreadId;
 
         std::string _debuggerServerAddr;
         uint32_t _debuggerServerPort;


### PR DESCRIPTION
Prevent `evalString` from being called in other threads. 