### PR TITLE
fix zip file read not thread safe

### DIFF
--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -620,6 +620,7 @@ unsigned char *ZipFile::getFileData(const std::string &fileName, ssize_t *size)
         CC_BREAK_IF(!_data->zipFile);
         CC_BREAK_IF(fileName.empty());
 
+        std::lock_guard<std::mutex> lock(_readMutex);
         ZipFilePrivate::FileListContainer::const_iterator it = _data->fileList.find(fileName);
         CC_BREAK_IF(it ==  _data->fileList.end());
 

--- a/cocos/base/ZipUtils.cpp
+++ b/cocos/base/ZipUtils.cpp
@@ -654,6 +654,7 @@ bool ZipFile::getFileData(const std::string &fileName, ResizableBuffer* buffer)
         CC_BREAK_IF(!_data->zipFile);
         CC_BREAK_IF(fileName.empty());
 
+        std::lock_guard<std::mutex> lock(_readMutex);
         ZipFilePrivate::FileListContainer::const_iterator it = _data->fileList.find(fileName);
         CC_BREAK_IF(it ==  _data->fileList.end());
 

--- a/cocos/base/ZipUtils.h
+++ b/cocos/base/ZipUtils.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "base/ccMacros.h"
 #include "platform/CCFileUtils.h"
 #include <string>
+#include <mutex>
 
 #if (CC_TARGET_PLATFORM == CC_PLATFORM_ANDROID)
 #include "platform/android/CCFileUtils-android.h"
@@ -287,6 +288,7 @@ typedef struct unz_file_info_s unz_file_info;
 
         /** Internal data like zip file pointer / file list array and so on */
         ZipFilePrivate *_data;
+        std::mutex _readMutex;
     };
 } // end of namespace cocos2d
 


### PR DESCRIPTION
资源加载可能是通过AsyncTaskPool的某个线程读取文件，但是unzip读取不是线程安全的，所以这里需要加锁。