### PR TITLE
:bug: fix crash when launch from icon after launch from installer

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -310,8 +310,6 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
         Log.d(TAG, "Cocos2dxActivity onCreate: " + this + ", savedInstanceState: " + savedInstanceState);
         super.onCreate(savedInstanceState);
 
-        Utils.setActivity(this);
-
         // Workaround in https://stackoverflow.com/questions/16283079/re-launch-of-activity-on-home-button-but-only-the-first-time/16447508
         if (!isTaskRoot()) {
             // Android launched another instance of the root activity into an existing task
@@ -321,6 +319,8 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
             Log.w(TAG, "[Workaround] Ignore the activity started from icon!");
             return;
         }
+
+        Utils.setActivity(this);
 
         Utils.hideVirtualButton();
 
@@ -391,12 +391,17 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
 
     @Override
     protected void onDestroy() {
+        super.onDestroy();
+
+        // Workaround in https://stackoverflow.com/questions/16283079/re-launch-of-activity-on-home-button-but-only-the-first-time/16447508
+        if (!isTaskRoot()) {
+            return;
+        }
+
         if(gainAudioFocus)
             Cocos2dxAudioFocusManager.unregisterAudioFocusListener(this);
         Cocos2dxHelper.unregisterBatteryLevelReceiver(this);;
         CanvasRenderingContext2DImpl.destroy();
-
-        super.onDestroy();
 
         Log.d(TAG, "Cocos2dxActivity onDestroy: " + this + ", mGLSurfaceView" + mGLSurfaceView);
         if (mGLSurfaceView != null) {

--- a/templates/js-template-default/frameworks/runtime-src/proj.android-studio/src/org/cocos2dx/javascript/AppActivity.java
+++ b/templates/js-template-default/frameworks/runtime-src/proj.android-studio/src/org/cocos2dx/javascript/AppActivity.java
@@ -78,6 +78,12 @@ public class AppActivity extends Cocos2dxActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+
+        // Workaround in https://stackoverflow.com/questions/16283079/re-launch-of-activity-on-home-button-but-only-the-first-time/16447508
+        if (!isTaskRoot()) {
+            return;
+        }
+
         SDKWrapper.getInstance().onDestroy();
 
     }

--- a/templates/js-template-link/frameworks/runtime-src/proj.android-studio/src/org/cocos2dx/javascript/AppActivity.java
+++ b/templates/js-template-link/frameworks/runtime-src/proj.android-studio/src/org/cocos2dx/javascript/AppActivity.java
@@ -78,6 +78,12 @@ public class AppActivity extends Cocos2dxActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
+
+        // Workaround in https://stackoverflow.com/questions/16283079/re-launch-of-activity-on-home-button-but-only-the-first-time/16447508
+        if (!isTaskRoot()) {
+            return;
+        }
+
         SDKWrapper.getInstance().onDestroy();
 
     }


### PR DESCRIPTION
Hi

I just found a crash bug, it can be reproduced with following steps.

1. install app with android installer, DO NOT click "DONE"
2. click the "Open" button to launch the app
3. make the app enter background
4. click the icon to resume the app

when you click the icon to resume the app, it will recreate a new activity, `isTaskRoot` is `false`, so the new activity will be finish directly.
```java
        if (!isTaskRoot()) {
            // Android launched another instance of the root activity into an existing task
            //  so just quietly finish and go away, dropping the user back into the activity
            //  at the top of the stack (ie: the last state of this task)
            finish();
            Log.w(TAG, "[Workaround] Ignore the activity started from icon!");
            return;
        }
```
the `onDestroy` will be called, and will be crash with this line
```java
Cocos2dxHelper.unregisterBatteryLevelReceiver(this);
```

by the way, the following code should be called after `isTaskRoot` checker.
```
Utils.setActivity(this);
```