### PR TITLE
fix copyBuffersToTexture

### DIFF
--- a/cocos/renderer/core/gfx/GFXDef.h
+++ b/cocos/renderer/core/gfx/GFXDef.h
@@ -584,6 +584,10 @@ struct GFXBufferTextureCopy {
 };
 typedef vector<GFXBufferTextureCopy>::type GFXBufferTextureCopyList;
 
+struct GFXArrayBufferView{
+    std::vector<uint8_t*> buffer;
+};
+
 struct GFXViewport {
   int left = 0;
   int top = 0;

--- a/cocos/renderer/core/gfx/GFXDef.h
+++ b/cocos/renderer/core/gfx/GFXDef.h
@@ -584,8 +584,8 @@ struct GFXBufferTextureCopy {
 };
 typedef vector<GFXBufferTextureCopy>::type GFXBufferTextureCopyList;
 
-struct GFXBuffers{
-    std::vector<uint8_t*> bufferArray;
+struct GFXArrayBuffer{
+    std::vector<uint8_t*> arrayBuffer;
 };
 
 struct GFXViewport {

--- a/cocos/renderer/core/gfx/GFXDevice.h
+++ b/cocos/renderer/core/gfx/GFXDevice.h
@@ -30,7 +30,7 @@ class CC_CORE_API GFXDevice : public Object {
   virtual GFXBindingLayout* createBindingLayout(const GFXBindingLayoutInfo& info) = 0;
   virtual GFXPipelineState* createPipelineState(const GFXPipelineStateInfo& info) = 0;
   virtual GFXPipelineLayout* createPipelineLayout(const GFXPipelineLayoutInfo& info) = 0;
-  virtual void copyBuffersToTexture(const GFXBuffers& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) = 0;
+  virtual void copyBuffersToTexture(const GFXArrayBuffer& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) = 0;
 
   CC_INLINE GFXAPI gfxAPI() const { return _api; }
   CC_INLINE uint width() { return _width; }

--- a/cocos/renderer/core/gfx/GFXDevice.h
+++ b/cocos/renderer/core/gfx/GFXDevice.h
@@ -30,7 +30,7 @@ class CC_CORE_API GFXDevice : public Object {
   virtual GFXBindingLayout* createBindingLayout(const GFXBindingLayoutInfo& info) = 0;
   virtual GFXPipelineState* createPipelineState(const GFXPipelineStateInfo& info) = 0;
   virtual GFXPipelineLayout* createPipelineLayout(const GFXPipelineLayoutInfo& info) = 0;
-  virtual void copyBuffersToTexture(GFXBuffer* src, GFXTexture* dst, const GFXBufferTextureCopyList& regions) = 0;
+  virtual void copyBuffersToTexture(const GFXArrayBufferView& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) = 0;
 
   CC_INLINE GFXAPI gfxAPI() const { return _api; }
   CC_INLINE uint width() { return _width; }

--- a/cocos/renderer/gfx-gles2/GLES2Commands.cc
+++ b/cocos/renderer/gfx-gles2/GLES2Commands.cc
@@ -1922,7 +1922,7 @@ void GLES2CmdFuncExecuteCmds(GLES2Device* device, GLES2CmdPackage* cmd_package) 
       }
       case GFXCmdType::COPY_BUFFER_TO_TEXTURE: {
         GLES2CmdCopyBufferToTexture* cmd = cmd_package->copyBufferToTextureCmds[cmd_idx];
-        GLES2CmdFuncCopyBuffersToTexture(device, &(cmd->gpuBuffer->buffer), 1, cmd->gpuTexture, cmd->regions);
+        GLES2CmdFuncCopyBuffersToTexture(device, &cmd->gpuBuffer->buffer, cmd->gpuTexture, cmd->regions);
         break;
       }
       default:
@@ -1932,7 +1932,7 @@ void GLES2CmdFuncExecuteCmds(GLES2Device* device, GLES2CmdPackage* cmd_package) 
   }
 }
 
-void GLES2CmdFuncCopyBuffersToTexture(GLES2Device* device, uint8_t** buffers, uint count, GLES2GPUTexture* gpuTexture, const GFXBufferTextureCopyList& regions) {
+void GLES2CmdFuncCopyBuffersToTexture(GLES2Device* device, uint8_t* const* buffers, GLES2GPUTexture* gpuTexture, const GFXBufferTextureCopyList& regions) {
   GLuint glTexture = device->stateCache->glTextures[device->stateCache->texUint];
   if (glTexture != gpuTexture->glTexture) {
     glBindTexture(gpuTexture->glTarget, gpuTexture->glTexture);

--- a/cocos/renderer/gfx-gles2/GLES2Commands.h
+++ b/cocos/renderer/gfx-gles2/GLES2Commands.h
@@ -165,7 +165,7 @@ CC_GLES2_API void GLES2CmdFuncDestroyInputAssembler(GLES2Device* device, GLES2GP
 CC_GLES2_API void GLES2CmdFuncCreateFramebuffer(GLES2Device* device, GLES2GPUFramebuffer* gpuFBO);
 CC_GLES2_API void GLES2CmdFuncDestroyFramebuffer(GLES2Device* device, GLES2GPUFramebuffer* gpuFBO);
 CC_GLES2_API void GLES2CmdFuncExecuteCmds(GLES2Device* device, GLES2CmdPackage* cmd_package);
-CC_GLES2_API void GLES2CmdFuncCopyBuffersToTexture(GLES2Device* device, uint8_t** buffers, uint count, GLES2GPUTexture* gpuTexture, const GFXBufferTextureCopyList& regions);
+CC_GLES2_API void GLES2CmdFuncCopyBuffersToTexture(GLES2Device* device, uint8_t* const* buffers, GLES2GPUTexture* gpuTexture, const GFXBufferTextureCopyList& regions);
 
 NS_CC_END
 

--- a/cocos/renderer/gfx-gles2/GLES2Device.cc
+++ b/cocos/renderer/gfx-gles2/GLES2Device.cc
@@ -17,6 +17,7 @@
 #include "GLES2BindingLayout.h"
 #include "GLES2PipelineLayout.h"
 #include "GLES2PipelineState.h"
+#include <vector>
 
 NS_CC_BEGIN
 
@@ -309,9 +310,9 @@ GFXPipelineLayout* GLES2Device::createPipelineLayout(const GFXPipelineLayoutInfo
     return nullptr;
 }
 
-void GLES2Device::copyBuffersToTexture(GFXBuffer *src, GFXTexture *dst, const GFXBufferTextureCopyList &regions)
+void GLES2Device::copyBuffersToTexture(const GFXArrayBufferView& buffers, GFXTexture *dst, const GFXBufferTextureCopyList &regions)
 {
-    GLES2CmdFuncCopyBuffersToTexture(this, &((GLES2Buffer*)src)->gpuBuffer()->buffer, 1, ((GLES2Texture*)dst)->gpuTexture(), regions);
+    GLES2CmdFuncCopyBuffersToTexture(this, buffers.buffer.data(), ((GLES2Texture*)dst)->gpuTexture(), regions);
 }
 
 NS_CC_END

--- a/cocos/renderer/gfx-gles2/GLES2Device.cc
+++ b/cocos/renderer/gfx-gles2/GLES2Device.cc
@@ -310,9 +310,9 @@ GFXPipelineLayout* GLES2Device::createPipelineLayout(const GFXPipelineLayoutInfo
     return nullptr;
 }
 
-void GLES2Device::copyBuffersToTexture(const GFXBuffers& buffers, GFXTexture *dst, const GFXBufferTextureCopyList &regions)
+void GLES2Device::copyBuffersToTexture(const GFXArrayBuffer& buffers, GFXTexture *dst, const GFXBufferTextureCopyList &regions)
 {
-    GLES2CmdFuncCopyBuffersToTexture(this, buffers.bufferArray.data(), ((GLES2Texture*)dst)->gpuTexture(), regions);
+    GLES2CmdFuncCopyBuffersToTexture(this, buffers.arrayBuffer.data(), ((GLES2Texture*)dst)->gpuTexture(), regions);
 }
 
 NS_CC_END

--- a/cocos/renderer/gfx-gles2/GLES2Device.h
+++ b/cocos/renderer/gfx-gles2/GLES2Device.h
@@ -32,7 +32,7 @@ public:
   GFXBindingLayout* createBindingLayout(const GFXBindingLayoutInfo& info) override;
   virtual GFXPipelineState* createPipelineState(const GFXPipelineStateInfo& info) override;
   virtual GFXPipelineLayout* createPipelineLayout(const GFXPipelineLayoutInfo& info) override;
-  virtual void copyBuffersToTexture(const GFXBuffers& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
+  virtual void copyBuffersToTexture(const GFXArrayBuffer& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
   
   CC_INLINE bool useVAO() const { return _useVAO; }
   CC_INLINE bool useDrawInstanced() const { return _useDrawInstanced; }

--- a/cocos/renderer/gfx-gles2/GLES2Device.h
+++ b/cocos/renderer/gfx-gles2/GLES2Device.h
@@ -32,7 +32,7 @@ public:
   GFXBindingLayout* createBindingLayout(const GFXBindingLayoutInfo& info) override;
   virtual GFXPipelineState* createPipelineState(const GFXPipelineStateInfo& info) override;
   virtual GFXPipelineLayout* createPipelineLayout(const GFXPipelineLayoutInfo& info) override;
-    virtual void copyBuffersToTexture(GFXBuffer* src, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
+    virtual void copyBuffersToTexture(const GFXArrayBufferView& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
   
   CC_INLINE bool useVAO() const { return _useVAO; }
   CC_INLINE bool useDrawInstanced() const { return _useDrawInstanced; }

--- a/cocos/renderer/gfx-gles3/GLES3Commands.cc
+++ b/cocos/renderer/gfx-gles3/GLES3Commands.cc
@@ -1884,7 +1884,7 @@ void GLES3CmdFuncExecuteCmds(GLES3Device* device, GLES3CmdPackage* cmd_package) 
       }
       case GFXCmdType::COPY_BUFFER_TO_TEXTURE: {
         GLES3CmdCopyBufferToTexture* cmd = cmd_package->copyBufferToTextureCmds[cmd_idx];
-        GLES3CmdFuncCopyBuffersToTexture(device, &(cmd->gpuBuffer->buffer), 1, cmd->gpuTexture, cmd->regions);
+        GLES3CmdFuncCopyBuffersToTexture(device, &(cmd->gpuBuffer->buffer), cmd->gpuTexture, cmd->regions);
         break;
       }
       default:
@@ -1894,7 +1894,7 @@ void GLES3CmdFuncExecuteCmds(GLES3Device* device, GLES3CmdPackage* cmd_package) 
   }
 }
 
-void GLES3CmdFuncCopyBuffersToTexture(GLES3Device* device, uint8_t** buffers, uint count, GLES3GPUTexture* gpuTexture, const GFXBufferTextureCopyList& regions) {
+void GLES3CmdFuncCopyBuffersToTexture(GLES3Device* device, uint8_t* const* buffers, GLES3GPUTexture* gpuTexture, const GFXBufferTextureCopyList& regions) {
   GLuint glTexture = device->stateCache->glTextures[device->stateCache->texUint];
   if (glTexture != gpuTexture->glTexture) {
     glBindTexture(gpuTexture->glTarget, gpuTexture->glTexture);

--- a/cocos/renderer/gfx-gles3/GLES3Commands.h
+++ b/cocos/renderer/gfx-gles3/GLES3Commands.h
@@ -165,7 +165,7 @@ CC_GLES3_API void GLES3CmdFuncDestroyInputAssembler(GLES3Device* device, GLES3GP
 CC_GLES3_API void GLES3CmdFuncCreateFramebuffer(GLES3Device* device, GLES3GPUFramebuffer* gpuFBO);
 CC_GLES3_API void GLES3CmdFuncDestroyFramebuffer(GLES3Device* device, GLES3GPUFramebuffer* gpuFBO);
 CC_GLES3_API void GLES3CmdFuncExecuteCmds(GLES3Device* device, GLES3CmdPackage* cmd_package);
-CC_GLES3_API void GLES3CmdFuncCopyBuffersToTexture(GLES3Device* device, uint8_t** buffers, uint count, GLES3GPUTexture* gpuTexture, const GFXBufferTextureCopyList& regions);
+CC_GLES3_API void GLES3CmdFuncCopyBuffersToTexture(GLES3Device* device, uint8_t* const* buffers, GLES3GPUTexture* gpuTexture, const GFXBufferTextureCopyList& regions);
 
 NS_CC_END
 

--- a/cocos/renderer/gfx-gles3/GLES3Device.cc
+++ b/cocos/renderer/gfx-gles3/GLES3Device.cc
@@ -301,10 +301,10 @@ GFXPipelineLayout* GLES3Device::createPipelineLayout(const GFXPipelineLayoutInfo
     return nullptr;
 }
 
-void GLES3Device::copyBuffersToTexture(GFXBuffer* src, GFXTexture* dst, const GFXBufferTextureCopyList& regions)
+void GLES3Device::copyBuffersToTexture(const GFXArrayBufferView& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions)
 {
     
-    GLES3CmdFuncCopyBuffersToTexture(this, &((GLES3Buffer*)src)->gpuBuffer()->buffer, 1, ((GLES3Texture*)dst)->gpuTexture(), regions);
+   GLES3CmdFuncCopyBuffersToTexture(this, buffers.buffer.data(), ((GLES3Texture*)dst)->gpuTexture(), regions);
 }
 
 NS_CC_END

--- a/cocos/renderer/gfx-gles3/GLES3Device.cc
+++ b/cocos/renderer/gfx-gles3/GLES3Device.cc
@@ -301,10 +301,10 @@ GFXPipelineLayout* GLES3Device::createPipelineLayout(const GFXPipelineLayoutInfo
     return nullptr;
 }
 
-void GLES3Device::copyBuffersToTexture(const GFXBuffers& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions)
+void GLES3Device::copyBuffersToTexture(const GFXArrayBuffer& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions)
 {
     
-   GLES3CmdFuncCopyBuffersToTexture(this, buffers.bufferArray.data(), ((GLES3Texture*)dst)->gpuTexture(), regions);
+   GLES3CmdFuncCopyBuffersToTexture(this, buffers.arrayBuffer.data(), ((GLES3Texture*)dst)->gpuTexture(), regions);
 }
 
 NS_CC_END

--- a/cocos/renderer/gfx-gles3/GLES3Device.h
+++ b/cocos/renderer/gfx-gles3/GLES3Device.h
@@ -32,7 +32,7 @@ public:
   GFXBindingLayout* createBindingLayout(const GFXBindingLayoutInfo& info) override;
   virtual GFXPipelineState* createPipelineState(const GFXPipelineStateInfo& info) override;
   virtual GFXPipelineLayout* createPipelineLayout(const GFXPipelineLayoutInfo& info) override;
-    virtual void copyBuffersToTexture(const GFXBuffers& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
+    virtual void copyBuffersToTexture(const GFXArrayBuffer& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
   
   CC_INLINE bool useVAO() const { return _useVAO; }
 

--- a/cocos/renderer/gfx-gles3/GLES3Device.h
+++ b/cocos/renderer/gfx-gles3/GLES3Device.h
@@ -32,7 +32,7 @@ public:
   GFXBindingLayout* createBindingLayout(const GFXBindingLayoutInfo& info);
   virtual GFXPipelineState* createPipelineState(const GFXPipelineStateInfo& info) override;
   virtual GFXPipelineLayout* createPipelineLayout(const GFXPipelineLayoutInfo& info) override;
-    virtual void copyBuffersToTexture(GFXBuffer* src, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
+    virtual void copyBuffersToTexture(const GFXArrayBufferView& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
   
   CC_INLINE bool useVAO() const { return _useVAO; }
 

--- a/cocos/renderer/gfx-metal/MTLDevice.h
+++ b/cocos/renderer/gfx-metal/MTLDevice.h
@@ -29,7 +29,7 @@ public:
     virtual GFXBindingLayout* createBindingLayout(const GFXBindingLayoutInfo& info) override;
     virtual GFXPipelineState* createPipelineState(const GFXPipelineStateInfo& info) override;
     virtual GFXPipelineLayout* createPipelineLayout(const GFXPipelineLayoutInfo& info) override;
-    virtual void copyBuffersToTexture(const GFXBuffers& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
+    virtual void copyBuffersToTexture(const GFXArrayBuffer& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
     
     CC_INLINE void* getMTKView() const { return _mtkView; }
     CC_INLINE void* getMTLDevice() const { return _mtlDevice; }

--- a/cocos/renderer/gfx-metal/MTLDevice.h
+++ b/cocos/renderer/gfx-metal/MTLDevice.h
@@ -29,7 +29,7 @@ public:
     virtual GFXBindingLayout* createBindingLayout(const GFXBindingLayoutInfo& info) override;
     virtual GFXPipelineState* createPipelineState(const GFXPipelineStateInfo& info) override;
     virtual GFXPipelineLayout* createPipelineLayout(const GFXPipelineLayoutInfo& info) override;
-    virtual void copyBuffersToTexture(GFXBuffer* src, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
+    virtual void copyBuffersToTexture(const GFXArrayBufferView& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions) override;
     
     CC_INLINE void* getMTKView() const { return _mtkView; }
     CC_INLINE void* getMTLDevice() const { return _mtlDevice; }

--- a/cocos/renderer/gfx-metal/MTLDevice.mm
+++ b/cocos/renderer/gfx-metal/MTLDevice.mm
@@ -217,9 +217,9 @@ GFXPipelineLayout* CCMTLDevice::createPipelineLayout(const GFXPipelineLayoutInfo
     return nullptr;
 }
 
-void CCMTLDevice::copyBuffersToTexture(const GFXBuffers& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions)
+void CCMTLDevice::copyBuffersToTexture(const GFXArrayBuffer& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions)
 {
-    static_cast<CCMTLTexture*>(dst)->update(buffers.bufferArray.data(), regions[0]);
+    static_cast<CCMTLTexture*>(dst)->update(buffers.arrayBuffer.data(), regions[0]);
 }
 
 NS_CC_END

--- a/cocos/renderer/gfx-metal/MTLDevice.mm
+++ b/cocos/renderer/gfx-metal/MTLDevice.mm
@@ -217,9 +217,9 @@ GFXPipelineLayout* CCMTLDevice::createPipelineLayout(const GFXPipelineLayoutInfo
     return nullptr;
 }
 
-void CCMTLDevice::copyBuffersToTexture(GFXBuffer* src, GFXTexture* dst, const GFXBufferTextureCopyList& regions)
+void CCMTLDevice::copyBuffersToTexture(const GFXArrayBufferView& buffers, GFXTexture* dst, const GFXBufferTextureCopyList& regions)
 {
-    static_cast<CCMTLTexture*>(dst)->update(static_cast<CCMTLBuffer*>(src)->getTransferBuffer(), regions[0]);
+    static_cast<CCMTLTexture*>(dst)->update(buffers.buffer.data(), regions[0]);
 }
 
 NS_CC_END

--- a/cocos/renderer/gfx-metal/MTLTexture.h
+++ b/cocos/renderer/gfx-metal/MTLTexture.h
@@ -19,7 +19,7 @@ public:
     CC_INLINE GFXFormat getConvertedFormat() const { return _convertedFormat; }
     
 private:
-    void update(uint8_t* data, const GFXBufferTextureCopy& region);
+    void update(uint8_t* const* data, const GFXBufferTextureCopy& region);
     
 private:
     id<MTLTexture> _mtlTexture = nil;

--- a/cocos/renderer/gfx-metal/MTLTexture.mm
+++ b/cocos/renderer/gfx-metal/MTLTexture.mm
@@ -116,12 +116,13 @@ void CCMTLTexture::resize(uint width, uint height)
     //TODO
 }
 
-void CCMTLTexture::update(uint8_t* data, const GFXBufferTextureCopy& region)
+//TODO coulsonwang: data is an array of memorys that may store mipmaps.
+void CCMTLTexture::update(uint8_t* const* data, const GFXBufferTextureCopy& region)
 {
     if (!_mtlTexture)
         return;
-    
-    uint8_t* convertedData = convertData(data,
+    int n = 0;
+    uint8_t* convertedData = convertData(data[n],
                                          region.texExtent.width * region.texExtent.height,
                                          _format);
     
@@ -136,7 +137,7 @@ void CCMTLTexture::update(uint8_t* data, const GFXBufferTextureCopy& region)
                      withBytes:convertedData
                    bytesPerRow:GFX_FORMAT_INFOS[(uint)_convertedFormat].size * region.texExtent.width];
     
-    if (convertedData != data)
+    if (convertedData != data[n])
         CC_FREE(convertedData);
 }
 

--- a/cocos/scripting/js-bindings/manual/jsb_module_register.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_module_register.cpp
@@ -94,8 +94,8 @@ bool jsb_register_all_modules()
     se->addRegisterCallback(register_all_engine);
     se->addRegisterCallback(register_all_cocos2dx_manual);
     se->addRegisterCallback(register_platform_bindings);
-    se->addRegisterCallback(register_all_gfx_manual);
     se->addRegisterCallback(register_all_gfx);
+    se->addRegisterCallback(register_all_gfx_manual);
     
     se->addRegisterCallback(register_all_network);
     se->addRegisterCallback(register_all_cocos2dx_network_manual);

--- a/tools/tojs/gfx.ini
+++ b/tools/tojs/gfx.ini
@@ -32,7 +32,7 @@ replace_headers =
 # what classes to produce code for. You can use regular expressions here. When testing the regular
 # expression, it will be enclosed in "^$", like this: "^Menu.*$".
 
-classes = GLES2Device GFXDevice GFXBindingLayout GFXBuffer GFXCommandBuffer GFXFramebuffer GFXInputAssembler GFXPipelineLayout GFXPipelineState GFXQueue GFXRenderPass GFXSampler GFXShader GFXTexture GFXTextureView GFXWindow GFXAPI GFXFeature GFXFormat GFXFormatType GFXType GFXBufferUsageBit GFXBufferFlagBit GFXBufferAccessBit GFXMemoryUsageBit GFXTextureType GFXTextureUsageBit GFXTextureFlagBit GFXSampleCount GFXTextureViewType GFXFilter GFXAddress GFXComparisonFunc GFXStencilOp GFXBlendFactor GFXBlendOp GFXColorMask GFXShaderType GFXLoadOp GFXStoreOp GFXTextureLayout GFXPipelineBindPoint GFXPrimitiveMode GFXPolygonMode GFXShadeModel GFXCullMode GFXDynamicState GFXStencilFace GFXBindingType GFXQueueType GFXCommandBufferType GFXClearFlagBit GFXVsyncMode GFXOffset GFXRect GFXExtent GFXTextureSubres GFXTextureCopy GFXBufferTextureCopy GFXViewport GFXColor GFXDeviceInfo GFXWindowInfo GFXContextInfo GFXBufferInfo GFXDrawInfo GFXIndirectBuffer GFXTextureInfo GFXTextureViewInfo GFXSamplerInfo GFXShaderMacro GFXUniform GFXUniformBlock GFXUniformSampler GFXShaderStage GFXShaderInfo GFXAttribute GFXInputAssemblerInfo GFXColorAttachment GFXDepthStencilAttachment GFXRenderPassInfo GFXFramebufferInfo GFXBinding GFXBindingLayoutInfo GFXBindingUnit GFXPushConstantRange GFXPipelineLayoutInfo GFXInputState GFXRasterizerState GFXDepthStencilState GFXBlendTarget GFXBlendState GFXPipelineStateInfo GFXCommandAllocatorInfo GFXCommandBufferInfo GFXQueueInfo GFXFormatInfo GFXMemoryStatus
+classes = GLES2Device GFXBindingLayout GFXBuffer GFXCommandBuffer GFXFramebuffer GFXInputAssembler GFXPipelineLayout GFXPipelineState GFXQueue GFXRenderPass GFXSampler GFXShader GFXTexture GFXTextureView GFXWindow GFXAPI GFXFeature GFXFormat GFXFormatType GFXType GFXBufferUsageBit GFXBufferFlagBit GFXBufferAccessBit GFXMemoryUsageBit GFXTextureType GFXTextureUsageBit GFXTextureFlagBit GFXSampleCount GFXTextureViewType GFXFilter GFXAddress GFXComparisonFunc GFXStencilOp GFXBlendFactor GFXBlendOp GFXColorMask GFXShaderType GFXLoadOp GFXStoreOp GFXTextureLayout GFXPipelineBindPoint GFXPrimitiveMode GFXPolygonMode GFXShadeModel GFXCullMode GFXDynamicState GFXStencilFace GFXBindingType GFXQueueType GFXCommandBufferType GFXClearFlagBit GFXVsyncMode GFXOffset GFXRect GFXExtent GFXTextureSubres GFXTextureCopy GFXBufferTextureCopy GFXViewport GFXColor GFXDeviceInfo GFXWindowInfo GFXContextInfo GFXBufferInfo GFXDrawInfo GFXIndirectBuffer GFXTextureInfo GFXTextureViewInfo GFXSamplerInfo GFXShaderMacro GFXUniform GFXUniformBlock GFXUniformSampler GFXShaderStage GFXShaderInfo GFXAttribute GFXInputAssemblerInfo GFXColorAttachment GFXDepthStencilAttachment GFXRenderPassInfo GFXFramebufferInfo GFXBinding GFXBindingLayoutInfo GFXBindingUnit GFXPushConstantRange GFXPipelineLayoutInfo GFXInputState GFXRasterizerState GFXDepthStencilState GFXBlendTarget GFXBlendState GFXPipelineStateInfo GFXCommandAllocatorInfo GFXCommandBufferInfo GFXQueueInfo GFXFormatInfo GFXMemoryStatus
 
 classes_need_extend =
 
@@ -58,7 +58,8 @@ skip = GFXBindingLayout::[GFXBindingLayout device bindingUnits],
        GFXTextureView::[GFXTextureView device],
        GFXWindow::[GFXWindow device title left top nativeWidth nativeHeight colorTexture depthStencilTexture],
        GFXCommandAllocator::[device],
-       CCMTLCommandAllocator::[clearCommands]
+       CCMTLCommandAllocator::[clearCommands],
+       GLES2Device::[copyBuffersToTexture]
 
 rename_functions = GFXShader::[hash=id]
 


### PR DESCRIPTION
修改在 [3d-tasks/issues#2473](https://github.com/cocos-creator/3d-tasks/issues/2473) 讨论中的 copyBuffersToTexture 的 API 在 JS 和 C++ 中不统一问题