### PR TITLE
2.3.1 Native Effect and ProgramLib memory leak

### DIFF
--- a/cocos/renderer/renderer/EffectVariant.cpp
+++ b/cocos/renderer/renderer/EffectVariant.cpp
@@ -46,7 +46,9 @@ void EffectVariant::setEffect(Effect *effect)
     _passes.clear();
     for (size_t i = 0, l = passes.size(); i < l; i++) {
         Pass* pass = passes.at(i);
-        _passes.pushBack(new Pass(pass->getProgramName(), pass));
+        Pass* newPass = new Pass(pass->getProgramName(), pass);
+        newPass->autorelease();
+        _passes.pushBack(newPass);
     }
 }
 
@@ -59,6 +61,7 @@ void EffectVariant::copy(const EffectVariant* effect)
     _passes.clear();
     for (size_t i = 0, l = passes.size(); i < l; i++) {
         Pass* pass = new Pass();
+        pass->autorelease();
         pass->copy(*passes.at(i));
         _passes.pushBack(pass);
     }

--- a/cocos/renderer/renderer/ProgramLib.cpp
+++ b/cocos/renderer/renderer/ProgramLib.cpp
@@ -172,6 +172,15 @@ ProgramLib::ProgramLib(DeviceGraphics* device, std::vector<Template>& templates)
 
 ProgramLib::~ProgramLib()
 {
+    for (auto it = _cache.begin(); it != _cache.end(); it++)
+    {
+        if (it->second)
+        {
+            it->second->release();
+        }
+    }
+    _cache.clear();
+
     RENDERER_SAFE_RELEASE(_device);
     _device = nullptr;
 }

--- a/cocos/scripting/js-bindings/jswrapper/v8/debugger/inspector_io.cc
+++ b/cocos/scripting/js-bindings/jswrapper/v8/debugger/inspector_io.cc
@@ -235,6 +235,11 @@ InspectorIo::~InspectorIo() {
   uv_sem_destroy(&thread_start_sem_);
   uv_close(reinterpret_cast<uv_handle_t*>(&main_thread_req_->first),
            ReleasePairOnAsyncClose);
+  if (main_thread_req_)
+  {
+      delete main_thread_req_;
+      main_thread_req_ = nullptr;
+  }
 }
 
 bool InspectorIo::Start() {

--- a/cocos/scripting/js-bindings/manual/jsb_conversions.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_conversions.cpp
@@ -1669,6 +1669,7 @@ bool seval_to_EffectTechnique(const se::Value& v, cocos2d::renderer::Technique**
     if (obj->getProperty("_passes", &value) && value.isObject()) {
         ccvaluevector_to_EffectPass(value.toObject(), &passes);
         *ret = new (std::nothrow) cocos2d::renderer::Technique(name, passes);
+        (*ret)->autorelease();
         return true;
     }
     


### PR DESCRIPTION
issuer：https://github.com/cocos-creator/2d-tasks/issues/2537

测试restart时发现几处材质和Shader相关代码存在内存泄漏。