### PR TITLE
use negative value of acc.z

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxHelper.java
@@ -569,7 +569,9 @@ public class Cocos2dxHelper {
         Cocos2dxAccelerometer.DeviceMotionEvent event = Cocos2dxHelper.sCocos2dxAccelerometer.getDeviceMotionEvent();
         sDeviceMotionValues[0] = event.acceleration.x;
         sDeviceMotionValues[1] = event.acceleration.y;
-        sDeviceMotionValues[2] = event.acceleration.z;
+        // Issue https://github.com/cocos-creator/2d-tasks/issues/2532
+        // use negative event.acceleration.z to match iOS value
+        sDeviceMotionValues[2] = - event.acceleration.z;
 
         sDeviceMotionValues[3] = event.accelerationIncludingGravity.x;
         sDeviceMotionValues[4] = event.accelerationIncludingGravity.y;


### PR DESCRIPTION
ref https://github.com/cocos-creator/2d-tasks/issues/2532

Android 重力感应 `acc.z` 和 iOS 中的同一值相反
