### PR TITLE
native tiledmap usernode render issue

### DIFF
--- a/cocos/renderer/scene/ModelBatcher.hpp
+++ b/cocos/renderer/scene/ModelBatcher.hpp
@@ -129,7 +129,6 @@ public:
     void setCullingMask(int cullingMask) { _cullingMask = cullingMask; }
     void setCurrentEffect(EffectVariant* effect);
     void setUseModel(bool useModel) { _useModel = useModel; }
-private:
     void changeCommitState(CommitState state);
 private:
     int _modelOffset = 0;

--- a/cocos/renderer/scene/assembler/TiledMapAssembler.cpp
+++ b/cocos/renderer/scene/assembler/TiledMapAssembler.cpp
@@ -81,6 +81,7 @@ void TiledMapAssembler::beforeFillBuffers(std::size_t index)
             }
         }
     }
+    _batcher->changeCommitState(ModelBatcher::Common);
 }
 
 void TiledMapAssembler::fillBuffers(NodeProxy* node, ModelBatcher* batcher, std::size_t index)


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/2563
被遮蔽节点有可能使用spine等非通用渲染模式，所以中途渲染完这些节点后，渲染状态需要恢复