### PR TITLE
Avoid accessing se::Object in non-main thread

### DIFF
--- a/cocos/scripting/js-bindings/manual/jsb_global.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_global.cpp
@@ -827,8 +827,10 @@ bool jsb_global_load_image(const std::string& path, const se::Value& callbackVal
         callbackVal.toObject()->call(seArgs, nullptr);
         return true;
     }
+    
+    std::shared_ptr<se::Value> callbackPtr = std::make_shared<se::Value>(callbackVal);
 
-    auto initImageFunc = [path, callbackVal](const std::string& fullPath, unsigned char* imageData, int imageBytes, const std::string& errorMsg){
+    auto initImageFunc = [path, callbackPtr](const std::string& fullPath, unsigned char* imageData, int imageBytes, const std::string& errorMsg){
         Image* img = new (std::nothrow) Image();
 
         __threadPool->pushTask([=](int tid){
@@ -911,7 +913,7 @@ bool jsb_global_load_image(const std::string& path, const se::Value& callbackVal
                     seArgs.push_back(se::Value(retObj));
                 }
 
-                callbackVal.toObject()->call(seArgs, nullptr);
+                callbackPtr->toObject()->call(seArgs, nullptr);
                 img->release();
             });
 


### PR DESCRIPTION
ref https://github.com/cocos-creator/2d-tasks/issues/2640

avoid copying in non-main thread