### PR TITLE
fix Socket.IO crash

### DIFF
--- a/cocos/network/SocketIO.cpp
+++ b/cocos/network/SocketIO.cpp
@@ -456,7 +456,7 @@ void SIOClientImpl::handshakeResponse(HttpClient* /*sender*/, HttpResponse *resp
     sprintf(statusString, "HTTP Status Code: %ld, tag = %s", statusCode, response->getHttpRequest()->getTag());
     CCLOGINFO("response code: %ld", statusCode);
 
-    if (!response->isSucceed())
+    if (!response->isSucceed() || statusCode >= 400)
     {
         CCLOGERROR("SIOClientImpl::handshake() failed");
         CCLOGERROR("error buffer: %s", response->getErrorBuffer());


### PR DESCRIPTION
修复, 
在
- SIO 服务器关闭
- 本机有代理

的情况下会的现崩溃. 

