### PR TITLE
add tips when port occupied by other process

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/v8/debugger/inspector_socket_server.cc
+++ b/cocos/scripting/js-bindings/jswrapper/v8/debugger/inspector_socket_server.cc
@@ -425,6 +425,12 @@ bool InspectorSocketServer::Start() {
   if (server_sockets_.empty()) {
       SE_LOGE("Starting inspector on %s:%d failed: %s\n",
               host_.c_str(), port_, uv_strerror(err));
+      if(err == UV_EADDRINUSE) {
+          SE_LOGE("[FATAL ERROR]: Port [:%s] is occupied by other processes, try to kill the previous debug process or change the port number in `jsb_enable_debugger`.\n", port_string.c_str());
+      } else {
+          SE_LOGE("[FATAL ERROR]: Failed to bind port [%s], error code: %d.\n", port_string.c_str(), err);
+      }
+      assert(false);//failed to start socket server for chrome debugger
     return false;
   }
   state_ = ServerState::kRunning;


### PR DESCRIPTION
`jsb_enable_debugger` 在前一个进程未结束的时候 会crash. 目前提示的信息过少. 

增加输出信息, 提示开发者处理. 