### PR TITLE
fix bug: path constraints data was ignored when parsing the skeleton …

### DIFF
--- a/cocos/editor-support/spine/SkeletonJson.cpp
+++ b/cocos/editor-support/spine/SkeletonJson.cpp
@@ -780,6 +780,9 @@ Animation *SkeletonJson::readAnimation(Json *root, SkeletonData *skeletonData) {
 	Json *ik = Json::getItem(root, "ik");
 	Json *transform = Json::getItem(root, "transform");
 	Json *paths = Json::getItem(root, "path");
+	if (paths == NULL) {
+           paths = Json::getItem(root, "paths");
+	}
 	Json *deform = Json::getItem(root, "deform");
 	Json *drawOrder = Json::getItem(root, "drawOrder");
 	Json *events = Json::getItem(root, "events");


### PR DESCRIPTION
spine 3.6.53版本导出的spine json文件里的路径动画在原生平台上没有被正确解析，导致路径动画失效。