### PR TITLE
avoid a NULL point crash when ScriptEngine::cleanup .

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/ScriptEngine.cpp
@@ -281,7 +281,7 @@ namespace se {
             thiz->_isErrorHandleWorking = true;
 
             Value errorHandler;
-            if (thiz->_globalObj->getProperty("__errorHandler", &errorHandler) && errorHandler.isObject() && errorHandler.toObject()->isFunction())
+            if (thiz->_globalObj && thiz->_globalObj->getProperty("__errorHandler", &errorHandler) && errorHandler.isObject() && errorHandler.toObject()->isFunction())
             {
                 ValueArray args;
                 args.push_back(resouceNameVal);


### PR DESCRIPTION
crash stack.

appScience-mobile	se::Object::getProperty(char const*, se::Value*) + 64
1 appScience-mobile	se::Object::getProperty(char const*, se::Value*) + 64
2 appScience-mobile	se::ScriptEngine::onMessageCallback(v8::Local<v8::Message>, v8::Local<v8::Value>) + 1080
3 appScience-mobile	v8::internal::MessageHandler::ReportMessageNoExceptions(v8::internal::Isolate*, v8::internal::MessageLocation const*, v8::internal::Handle<v8::internal::Object>, v8::Local<v8::Value>) + 344
4 appScience-mobile	v8::internal::MessageHandler::ReportMessage(v8::internal::Isolate*, v8::internal::MessageLocation const*, v8::internal::Handle<v8::internal::JSMessageObject>) + 808
5 appScience-mobile	v8::internal::Isolate::ReportPendingMessagesImpl(bool) + 344
6 appScience-mobile	v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) + 568
7 appScience-mobile	v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) + 200
8 appScience-mobile	v8::Object::CallAsFunction(v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) + 528
9 appScience-mobile	se::Object::call(std::__1::vector<se::Value, std::__1::allocator<se::Value> > const&, se::Object*, se::Value*) + 292
10 appScience-mobile	_ZNSt3__110__function6__funcIZL37js_video_VideoPlayer_addEventListenerRN2se5StateEE3$_0NS_9allocatorIS5_EEFvvEEclEv + 112
11 appScience-mobile	cocos2d::VideoPlayer::onPlayEvent(int) + 280
12 appScience-mobile	-[UIVideoViewWrapperIos cleanup] + 28
13 appScience-mobile	-[UIVideoViewWrapperIos dealloc] + 32
14 appScience-mobile	cocos2d::VideoPlayer::~VideoPlayer() + 48
15 appScience-mobile	cocos2d::VideoPlayer::~VideoPlayer() + 12
16 appScience-mobile	js_cocos2d_VideoPlayer_finalizeRegistry(void*) + 64
17 appScience-mobile	se::Object::cleanup() + 80
18 appScience-mobile	se::ScriptEngine::cleanup() + 180
19 appScience-mobile	se::ScriptEngine::~ScriptEngine() + 20
20 appScience-mobile	se::ScriptEngine::destroyInstance() + 28
21 appScience-mobile	cocos2d::Application::~Application() + 40
22 appScience-mobile	AppDelegate::~AppDelegate() (AppDelegate.cpp:52)
23 appScience-mobile	-[AppController applicationWillTerminate:] (AppController.mm:342)
24 UIKitCore	-[UIApplication _terminateWithStatus:] + 244
25 UIKitCore	-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:] + 124
26 UIKitCore	-[_UISceneLifecycleMultiplexer forceExitWithTransitionContext:scene:] + 216
27 UIKitCore	-[UIApplication workspaceShouldExit:withTransitionContext:] + 212
28 FrontBoardServices	-[FBSUIApplicationWorkspaceShim workspaceShouldExit:withTransitionContext:] + 84
29 FrontBoardServices	___83-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:withAcknowledgement:]_block_invoke_2 + 76
30 FrontBoardServices	-[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:] + 232
31 FrontBoardServices	___83-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:withAcknowledgement:]_block_invoke + 124
32 libdispatch.dylib	__dispatch_client_callout + 16
33 libdispatch.dylib	__dispatch_block_invoke_direct$VARIANT$mp + 224
34 FrontBoardServices	___FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 40
35 FrontBoardServices	-[FBSSerialQueue _queue_performNextIfPossible] + 404
36 FrontBoardServices	-[FBSSerialQueue _performNextFromRunLoopSource] + 28
37 CoreFoundation	___CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
38 CoreFoundation	___CFRunLoopDoSource0 + 80
39 CoreFoundation	___CFRunLoopDoSources0 + 180
40 CoreFoundation	___CFRunLoopRun + 1080
41 CoreFoundation	CFRunLoopRunSpecific + 464
42 GraphicsServices	GSEventRunModal + 104
43 UIKitCore	UIApplicationMain + 1936
44 appScience-mobile	main (main.m:8)
45 libdyld.dylib	_start + 4