### PR TITLE
set editBox fit system window

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -259,6 +259,7 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
                                            ViewGroup.LayoutParams.MATCH_PARENT);
         mFrameLayout = new FrameLayout(this);
         mFrameLayout.setLayoutParams(frameLayoutParams);
+        mFrameLayout.setFitsSystemWindows(true);
 
         Cocos2dxRenderer renderer = this.addSurfaceView();
         this.addDebugInfo(renderer);


### PR DESCRIPTION
resolve https://github.com/cocos-creator/2d-tasks/issues/1529

changeLog:
- 修复安卓 editBox 的完成按钮被虚拟导航栏遮挡的问题