### PR TITLE
fix scheduler

### DIFF
--- a/cocos/platform/CCApplication.h
+++ b/cocos/platform/CCApplication.h
@@ -193,7 +193,7 @@ private:
     void createView(const std::string& name, int width, int height);
     
     static Application* _instance;
-    static std::shared_ptr<Scheduler> _scheduler;
+    std::shared_ptr<Scheduler> _scheduler;
     
     void* _view = nullptr;
     void* _delegate = nullptr;

--- a/cocos/platform/android/CCApplication-android.cpp
+++ b/cocos/platform/android/CCApplication-android.cpp
@@ -75,7 +75,6 @@ extern "C" {
 }
 
 Application* Application::_instance = nullptr;
-std::shared_ptr<Scheduler> Application::_scheduler = nullptr;
 
 Application::Application(const std::string& name, int width, int height)
 {

--- a/cocos/platform/ios/CCApplication-ios.mm
+++ b/cocos/platform/ios/CCApplication-ios.mm
@@ -204,7 +204,6 @@ namespace
 NS_CC_BEGIN
 
 Application* Application::_instance = nullptr;
-std::shared_ptr<Scheduler> Application::_scheduler = nullptr;
 
 Application::Application(const std::string& name, int width, int height)
 {

--- a/cocos/platform/mac/CCApplication-mac.mm
+++ b/cocos/platform/mac/CCApplication-mac.mm
@@ -59,7 +59,6 @@ namespace
 }
 
 Application* Application::_instance = nullptr;
-std::shared_ptr<Scheduler> Application::_scheduler = nullptr;
 
 #define CAST_VIEW(view)    ((GLView*)view)
 

--- a/cocos/platform/win32/CCApplication-win32.cpp
+++ b/cocos/platform/win32/CCApplication-win32.cpp
@@ -99,7 +99,6 @@ namespace
 NS_CC_BEGIN
 
 Application* Application::_instance = nullptr;
-std::shared_ptr<Scheduler> Application::_scheduler = nullptr;
 
 Application::Application(const std::string& name, int width, int height)
 {


### PR DESCRIPTION
static全局变量`_scheduler` 和 全局变量`__objectMap` 析构顺序不定会导致程序退出时异常
`_scheduler`完全不需要设置成全局变量，这里将其设置为Application的成员变量，析构发生在全局变量`__objectMap`析构之前才正确。

`jsb_global_load_image`加载图片代码
`Application::getInstance()->getScheduler()->performFunctionInCocosThread([=](){
                se::AutoHandleScope hs;
                se::ValueArray seArgs;
                se::Value dataVal;
//...
`
该匿名函数会捕获参数`const se::Value& callbackVal`的拷贝。
如果此时用户关闭游戏， `_scheduler::_functionsToPerform` 在析构时会调用`se::~Object()` 调用到`auto iter = __objectMap.find(this);`这行时产生崩溃（__objectMap这里已经被析构了）

0x0000000100efd064 _ZNSt3__112__hash_tableINS_17__hash_value_typeIPN2se6ObjectEPvEENS_22__unordered_map_hasherIS4_S6_NS_4hashIS4_EELb1EEENS_21__unordered_map_equalIS4_S6_NS_8equal_toIS4_EELb1EEENS_9allocatorIS6_EEE4findIS4_EENS_15__hash_iteratorIPNS_11__hash_nodeIS6_S5_EEEERKT_ + 96
1	0x0000000100efd064 _ZNSt3__112__hash_tableINS_17__hash_value_typeIPN2se6ObjectEPvEENS_22__unordered_map_hasherIS4_S6_NS_4hashIS4_EELb1EEENS_21__unordered_map_equalIS4_S6_NS_8equal_toIS4_EELb1EEENS_9allocatorIS6_EEE4findIS4_EENS_15__hash_iteratorIPNS_11__hash_nodeIS6_S5_EEEERKT_ + 96
2	0x0000000100ef76a4 _ZNSt3__113unordered_mapIPN2se6ObjectEPvNS_4hashIS3_EENS_8equal_toIS3_EENS_9allocatorINS_4pairIKS3_S4_EEEEE4findERSB_ + 32
3	0x0000000100ef75e0 _ZN2se6ObjectD2Ev + 144
4	0x0000000100ef77c8 _ZN2se6ObjectD1Ev + 32
5	0x0000000100ef7800 _ZN2se6ObjectD0Ev + 32
6	0x0000000100f03b18 _ZN2se10RefCounter6decRefEv + 72
7	0x0000000100b216bc _ZN2se5Value5resetENS0_4TypeE + 192
8	0x0000000100b226c8 _ZN2se5ValueD2Ev + 40
9	0x0000000100b21510 _ZN2se5ValueD1Ev + 32
10	0x0000000100be6310 _ZZZZ21jsb_global_load_imageRKNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERKN2se5ValueEENK3$_4clES7_PhiENKUliE_clEiENUlvE_D2Ev + 32
11	0x0000000100be2bcc _ZZZZ21jsb_global_load_imageRKNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERKN2se5ValueEENK3$_4clES7_PhiENKUliE_clEiENUlvE_D1Ev + 32
12	0x0000000100be416c _ZNSt3__122__compressed_pair_elemIZZZ21jsb_global_load_imageRKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERKN2se5ValueEENK3$_4clES8_PhiENKUliE_clEiEUlvE_Li0ELb0EED2Ev + 32
13	0x0000000100be442c _ZNSt3__117__compressed_pairIZZZ21jsb_global_load_imageRKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERKN2se5ValueEENK3$_4clES8_PhiENKUliE_clEiEUlvE_NS4_ISG_EEED2Ev + 32
14	0x0000000100be43f4 _ZNSt3__117__compressed_pairIZZZ21jsb_global_load_imageRKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERKN2se5ValueEENK3$_4clES8_PhiENKUliE_clEiEUlvE_NS4_ISG_EEED1Ev + 32
15	0x0000000100be52d4 _ZNSt3__110__function12__alloc_funcIZZZ21jsb_global_load_imageRKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERKN2se5ValueEENK3$_4clES9_PhiENKUliE_clEiEUlvE_NS5_ISH_EEFvvEE7destroyEv + 24
16	0x0000000100be3b04 _ZNSt3__110__function6__funcIZZZ21jsb_global_load_imageRKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEERKN2se5ValueEENK3$_4clES9_PhiENKUliE_clEiEUlvE_NS5_ISH_EEFvvEE18destroy_deallocateEv + 76
17	0x000000010079b860 _ZNSt3__110__function12__value_funcIFvvEED2Ev + 108
18	0x000000010079b7dc _ZNSt3__110__function12__value_funcIFvvEED1Ev + 32
19	0x000000010079b7a4 _ZNSt3__18functionIFvvEED2Ev + 32
20	0x0000000100797260 _ZNSt3__18functionIFvvEED1Ev + 32
21	0x0000000100eb2e70 _ZNSt3__19allocatorINS_8functionIFvvEEEE7destroyEPS3_ + 28
22	0x0000000100eb2e48 _ZNSt3__116allocator_traitsINS_9allocatorINS_8functionIFvvEEEEEE9__destroyIS4_EEvNS_17integral_constantIbLb1EEERS5_PT_ + 32
23	0x0000000100eb2e1c _ZNSt3__116allocator_traitsINS_9allocatorINS_8functionIFvvEEEEEE7destroyIS4_EEvRS5_PT_ + 32
24	0x0000000100eb2dd4 _ZNSt3__113__vector_baseINS_8functionIFvvEEENS_9allocatorIS3_EEE17__destruct_at_endEPS3_ + 104
25	0x0000000100eb2d04 _ZNSt3__113__vector_baseINS_8functionIFvvEEENS_9allocatorIS3_EEE5clearEv + 32
26	0x0000000100eb2b50 _ZNSt3__113__vector_baseINS_8functionIFvvEEENS_9allocatorIS3_EEED2Ev + 44
27	0x0000000100b62644 _ZNSt3__16vectorINS_8functionIFvvEEENS_9allocatorIS3_EEED2Ev + 48
28	0x0000000100b5ee18 _ZNSt3__16vectorINS_8functionIFvvEEENS_9allocatorIS3_EEED1Ev + 32
29	0x0000000100b5eeb0 _ZN7cocos2d9SchedulerD2Ev + 72
30	0x0000000100b5ef7c _ZN7cocos2d9SchedulerD1Ev + 32
31	0x00000001009ccf94 _ZNSt3__120__shared_ptr_emplaceIN7cocos2d9SchedulerENS_9allocatorIS2_EEE16__on_zero_sharedEv + 32
32	0x0000000100caf838 _ZNSt3__114__shared_count16__release_sharedEv + 60
33	0x0000000100caf7e4 _ZNSt3__119__shared_weak_count16__release_sharedEv + 32
34	0x0000000100caf7b4 _ZNSt3__110shared_ptrIN7cocos2d9SchedulerEED2Ev + 48
35	0x0000000100caa480 _ZNSt3__110shared_ptrIN7cocos2d9SchedulerEED1Ev + 32
36 libsystem_c.dylib	0x0000000190dca4c8 __cxa_finalize_ranges + 384
37 libsystem_c.dylib	0x0000000190dca7d8 exit + 24
