### PR TITLE
[bugfix] win32 drawtext prefix

### DIFF
--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -402,7 +402,7 @@ private:
         {
             CC_BREAK_IF(text.empty());
 
-            DWORD dwFmt = DT_SINGLELINE;
+            DWORD dwFmt = DT_SINGLELINE | DT_NOPREFIX;
 
             int bufferLen = 0;
             pwszBuffer = _utf8ToUtf16(text, &bufferLen);
@@ -444,7 +444,7 @@ private:
             CC_BREAK_IF(!pszText || nLen <= 0);
 
             RECT rc = { 0, 0, 0, 0 };
-            DWORD dwCalcFmt = DT_CALCRECT;
+            DWORD dwCalcFmt = DT_CALCRECT | DT_NOPREFIX;
 
             // measure text size
             DrawTextW(_DC, pszText, nLen, &rc, dwCalcFmt);

--- a/cocos/scripting/js-bindings/docs/JSB2.0-learning-en.md
+++ b/cocos/scripting/js-bindings/docs/JSB2.0-learning-en.md
@@ -1042,7 +1042,7 @@ Change to：
 #### Windows
 
 * Compile, run the game (or run directly in the Creator simulator)
-* Open with Chrome: [chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=127.0.0.1:6086/00010002-0003-4004-8005-000600070008](chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=127.0.0.1:6086/00010002-0003-4004-8005-000600070008)
+* Open with Chrome: [devtools://devtools/bundled/js_app.html?v8only=true&ws=127.0.0.1:6086/00010002-0003-4004-8005-000600070008](devtools://devtools/bundled/js_app.html?v8only=true&ws=127.0.0.1:6086/00010002-0003-4004-8005-000600070008)
 
 Breakpoint debugging：
 ![](v8-win32-debug.jpg)
@@ -1057,7 +1057,7 @@ Profile
 
 * Make sure your Android device is on the same network as your PC or Mac
 * Compile and run your game
-* Open with Chrome: [chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=xxx.xxx.xxx.xxx:6086/00010002-0003-4004-8005-000600070008](chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=xxx.xxx.xxx.xxx:6086/00010002-0003-4004-8005-000600070008), `xxx.xxx.xxx.xxx` is the IP address of Android device
+* Open with Chrome: [devtools://devtools/bundled/js_app.html?v8only=true&ws=xxx.xxx.xxx.xxx:6086/00010002-0003-4004-8005-000600070008](devtools://devtools/bundled/js_app.html?v8only=true&ws=xxx.xxx.xxx.xxx:6086/00010002-0003-4004-8005-000600070008), `xxx.xxx.xxx.xxx` is the IP address of Android device
 * The remote debugging interface is the same as debugging Windows.
 
 

--- a/cocos/scripting/js-bindings/docs/JSB2.0-learning-zh.md
+++ b/cocos/scripting/js-bindings/docs/JSB2.0-learning-zh.md
@@ -1030,7 +1030,7 @@ classes_owned_by_cpp =
 #### Windows
 
 * 编译、运行游戏（或在 Creator 中直接使用模拟器运行）
-* 用 Chrome 浏览器打开[chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=127.0.0.1:6086/00010002-0003-4004-8005-000600070008](chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=127.0.0.1:6086/00010002-0003-4004-8005-000600070008)
+* 用 Chrome 浏览器打开[devtools://devtools/bundled/js_app.html?v8only=true&ws=127.0.0.1:6086/00010002-0003-4004-8005-000600070008](devtools://devtools/bundled/js_app.html?v8only=true&ws=127.0.0.1:6086/00010002-0003-4004-8005-000600070008)
 
 断点调试：
 ![](v8-win32-debug.jpg)
@@ -1045,7 +1045,7 @@ Profile
 
 * 保证 Android 设备与 PC 或者 Mac 在同一个局域网中
 * 编译，运行游戏
-* 用 Chrome 浏览器打开[chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=xxx.xxx.xxx.xxx:6086/00010002-0003-4004-8005-000600070008](chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=xxx.xxx.xxx.xxx:6086/00010002-0003-4004-8005-000600070008), 其中 `xxx.xxx.xxx.xxx` 为局域网中 Android 设备的 IP 地址
+* 用 Chrome 浏览器打开[devtools://devtools/bundled/js_app.html?v8only=true&ws=xxx.xxx.xxx.xxx:6086/00010002-0003-4004-8005-000600070008](devtools://devtools/bundled/js_app.html?v8only=true&ws=xxx.xxx.xxx.xxx:6086/00010002-0003-4004-8005-000600070008), 其中 `xxx.xxx.xxx.xxx` 为局域网中 Android 设备的 IP 地址
 * 调试界面与 Windows 相同
 
 

--- a/cocos/scripting/js-bindings/jswrapper/v8/debugger/inspector_socket_server.cc
+++ b/cocos/scripting/js-bindings/jswrapper/v8/debugger/inspector_socket_server.cc
@@ -108,7 +108,7 @@ void PrintDebuggerReadyMessage(const std::string& host,
     return;
   }
   for (const std::string& id : ids) {
-    SE_LOGD("Debugger listening..., visit [ chrome-devtools://devtools/bundled/js_app.html?v8only=true&ws=%s ] in chrome browser to debug!\n",
+    SE_LOGD("Debugger listening..., visit [ devtools://devtools/bundled/js_app.html?v8only=true&ws=%s ] in chrome browser to debug!\n",
             FormatWsAddress(host, port, id, false).c_str());
   }
   SE_LOGD("For help see %s\n",
@@ -385,7 +385,7 @@ void InspectorSocketServer::SendListResponse(InspectorSocket* socket) {
       int port = SocketSession::ServerPortForClient(socket);
       GetSocketHost(&socket->tcp, &host);
       std::ostringstream frontend_url;
-      frontend_url << "chrome-devtools://devtools/bundled";
+      frontend_url << "devtools://devtools/bundled";
       frontend_url << "/js_app.html?experiments=true&v8only=true&ws=";
       frontend_url << FormatWsAddress(host, port, id, false);
       target_map["devtoolsFrontendUrl"] += frontend_url.str();


### PR DESCRIPTION
Win32 turns off processing of prefix characters while drawing text.