### PR TITLE
[bugfix] win32 drawtext prefix / v2.4

### DIFF
--- a/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
+++ b/cocos/platform/win32/CCCanvasRenderingContext2D-win32.cpp
@@ -408,7 +408,7 @@ private:
         {
             CC_BREAK_IF(text.empty());
 
-            DWORD dwFmt = DT_SINGLELINE;
+            DWORD dwFmt = DT_SINGLELINE | DT_NOPREFIX;
 
             int bufferLen = 0;
             pwszBuffer = _utf8ToUtf16(text, &bufferLen);
@@ -450,7 +450,7 @@ private:
             CC_BREAK_IF(!pszText || nLen <= 0);
 
             RECT rc = { 0, 0, 0, 0 };
-            DWORD dwCalcFmt = DT_CALCRECT;
+            DWORD dwCalcFmt = DT_CALCRECT | DT_NOPREFIX;
 
             // measure text size
             DrawTextW(_DC, pszText, nLen, &rc, dwCalcFmt);


### PR DESCRIPTION
Win32 turns off processing of prefix characters while drawing text.

ref https://github.com/cocos-creator/cocos2d-x-lite/pull/2527
