### PR TITLE
Fix ios video seek to inaccurate

### DIFF
--- a/cocos/ui/videoplayer/VideoPlayer-ios.mm
+++ b/cocos/ui/videoplayer/VideoPlayer-ios.mm
@@ -157,7 +157,8 @@ typedef NS_ENUM(NSInteger, PlayerbackState) {
 -(void) seekTo:(float)sec
 {
     if (self.playerController.player)
-        [self.playerController.player seekToTime:CMTimeMake(sec, 1)];
+        [self.playerController.player seekToTime:CMTimeMake(sec * 600, 600) toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
+
 }
 
 -(float) currentTime


### PR DESCRIPTION
ios上视频跳转，只能精确到秒，并不准确，修改过后可以精确到0.01秒