### PR TITLE
Fix crash below android4.4 when the class cannot be found

### DIFF
--- a/cocos/platform/android/jni/JniHelper.cpp
+++ b/cocos/platform/android/jni/JniHelper.cpp
@@ -49,9 +49,10 @@ jclass _getClassID(const char *className) {
                                                    cocos2d::JniHelper::loadclassMethod_methodID,
                                                    _jstrClassName);
 
-    if (nullptr == _clazz) {
+    if (nullptr == _clazz || env->ExceptionCheck()) {
         LOGE("Classloader failed to find class of %s", className);
         env->ExceptionClear();
+        _clazz = nullptr;
     }
 
     env->DeleteLocalRef(_jstrClassName);


### PR DESCRIPTION
If this class does not exist, devices below Android 4.4 may crash