### PR TITLE
[bugfix] Update iOS compile flags for V8

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -3369,7 +3369,6 @@
 				GCC_PREFIX_HEADER = "../cocos/platform/ios/cocos2d-prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					V8_COMPRESS_POINTERS,
 					"V8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64",
 					ENABLE_MINOR_MC,
 					V8_CONCURRENT_MARKING,

--- a/cocos/scripting/js-bindings/jswrapper/v8/Class.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/Class.cpp
@@ -222,6 +222,11 @@ namespace se {
     {
         v8::MaybeLocal<v8::Object> ret = cls->_ctorTemplate.Get(__isolate)->InstanceTemplate()->NewInstance(__isolate->GetCurrentContext());
         assert(!ret.IsEmpty());
+        if(cls->_ctor == nullptr) {
+            v8::Local<v8::Object> local = ret.ToLocalChecked();
+            local->SetAlignedPointerInInternalField(0, nullptr);
+            return local;
+        }
         return ret.ToLocalChecked();
     }
 


### PR DESCRIPTION
- Remove macro `V8_COMPRESS_POINTERS`
- Init `AlignedPointerInInternalField` for `gl` object.