### PR TITLE
upgrade libfreetype to 2.10.0 & recompile v8/android/x86

### DIFF
--- a/cocos/2d/CCFontAtlas.cpp
+++ b/cocos/2d/CCFontAtlas.cpp
@@ -232,7 +232,7 @@ namespace cocos2d {
             opt.y = 0;
             opt.width = _WIDTH;
             opt.height = _HEIGHT;
-            opt.imageDataLength = _buffer.size();
+            opt.imageDataLength = (uint32_t)_buffer.size();
             _texture->updateSubImage(opt);
         }
         else if (_dirtyFlag & DIRTY_RECT)
@@ -266,7 +266,6 @@ namespace cocos2d {
 
     bool FontAtlas::init()
     {
-        int pixelSize = PixelModeSize(_pixelMode);
         _textureFrame.reinit(_pixelMode, _width, _height);
         _letterMap.clear();
         return true;

--- a/cocos/2d/CCFontFreetype.cpp
+++ b/cocos/2d/CCFontFreetype.cpp
@@ -205,7 +205,7 @@ namespace cocos2d {
             free(outside);
             free(inside);
 #endif
-            return std::move(out);
+            return out;
         }
 
 
@@ -245,10 +245,11 @@ namespace cocos2d {
 
     bool FontFreeType::loadFont()
     {
-        _fontData = std::move(FileUtils::getInstance()->getDataFromFile(_fontName));
+        _fontData = FileUtils::getInstance()->getDataFromFile(_fontName);
 
         if (FT_New_Memory_Face(getFTLibrary(), _fontData.getBytes(), _fontData.getSize(), 0, &_face))
         {
+            cocos2d::log("[error] failed to parse font %s", _fontName.c_str());
             return false;
         }
 
@@ -388,8 +389,8 @@ namespace cocos2d {
 
         int dms = std::max(3, (int)std::max(0.2 * bmWidth, 0.2 * bmHeight));
 
-        int size = PixelModeSize(mode) * bmWidth * bmHeight;
-        std::vector<uint8_t> data = std::move(makeDistanceMap(bitmap.buffer, bmWidth, bmHeight, dms));
+//        int size = PixelModeSize(mode) * bmWidth * bmHeight;
+        std::vector<uint8_t> data = makeDistanceMap(bitmap.buffer, bmWidth, bmHeight, dms);
         auto* ret = new GlyphBitmap(data, bmWidth + 2 * dms, bmHeight + 2 * dms, Rect(x, y, w + 2 * dms, h +  2 * dms), adv, mode, dms);
 
         return std::shared_ptr<GlyphBitmap>(ret);

--- a/cocos/2d/CCLabelLayout.cpp
+++ b/cocos/2d/CCLabelLayout.cpp
@@ -473,6 +473,9 @@ namespace cocos2d {
         _layoutInfo = info;
         _retinaFontSize = std::max(fontSize, retinaFontSize);
         _fontAtlas = TTFLabelAtlasCache::getInstance()->load(font, _retinaFontSize, info);
+        if(!_fontAtlas) {
+            return false;
+        }
         _fontScale = fontSize / _fontAtlas->getFontSize();
         _groups = std::make_shared<TextRenderGroup>();
         if (info->shadowBlur >= 0)
@@ -512,7 +515,10 @@ namespace cocos2d {
 
     bool LabelLayout::updateContent()
     {
-
+        if(!_fontAtlas)
+        {
+            return false;
+        }
         auto *atlas = _fontAtlas->getFontAtlas();
         auto *ttf = _fontAtlas->getTTF();
 
@@ -777,6 +783,9 @@ namespace cocos2d {
     void LabelLayout::fillAssembler(renderer::CustomAssembler *assembler, EffectVariant *templateEffect)
     {
         assembler->reset();
+        if(!_groups) {
+            return;
+        }
         _groups->reset();
         int groupIndex = 0;
         if (_textSpace.empty())

--- a/cocos/2d/CCTTFLabelAtlasCache.cpp
+++ b/cocos/2d/CCTTFLabelAtlasCache.cpp
@@ -69,13 +69,17 @@ namespace cocos2d {
     }
 
 
-    void TTFLabelAtals::init()
+    bool TTFLabelAtals::init()
     {
         assert(FileUtils::getInstance()->isFileExist(_fontName));
         _ttfFont = std::make_shared<FontFreeType>(_fontName, _fontSize, _info);
-        _ttfFont->loadFont();
+        
+        if(!_ttfFont->loadFont()){
+            return false;
+        }
         _fontAtlas = std::make_shared<FontAtlas>(PixelMode::A8, FTT_TEXTURE_SIZE, FTT_TEXTURE_SIZE, _info->outlineSize > 0 || _info->bold);
         _fontAtlas->init();
+        return true;
     }
 
     TTFLabelAtlasCache * TTFLabelAtlasCache::getInstance()
@@ -108,6 +112,10 @@ namespace cocos2d {
         if (!atlas)
         {
             atlas = std::make_shared<TTFLabelAtals>(font, fontSize, info);
+            if(!atlas->init())
+            {
+                return nullptr;
+            }
             atlasWeak = atlas;
         }
 #else
@@ -115,6 +123,10 @@ namespace cocos2d {
         if (!atlas)
         {
             atlas = std::make_shared<TTFLabelAtals>(font, fontSize, info);
+            if(!atlas->init())
+            {
+                return nullptr;
+            }
         }
 #endif
         return atlas;

--- a/cocos/2d/CCTTFLabelAtlasCache.h
+++ b/cocos/2d/CCTTFLabelAtlasCache.h
@@ -46,14 +46,13 @@ namespace cocos2d {
         
         TTFLabelAtals(const std::string &, float, LabelLayoutInfo *info);
 
+        
         inline FontAtlas * getFontAtlas() const { return _fontAtlas.get(); }
         inline FontFreeType * getTTF() const { return _ttfFont.get(); }
 
         float getFontSize() const { return _fontSize; }
 
-    private:
-
-        void init();
+        bool init();
 
     private:
         std::string _fontName;

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -90,17 +90,11 @@ scripting/js-bindings/event/EventDispatcher.cpp \
 ../external/sources/edtaa3func/edtaa3func.h \
 ui/edit-box/EditBox-android.cpp \
 2d/CCFontAtlas.cpp \
-2d/CCFontAtlas.h \
 2d/CCFontFreetype.cpp \
-2d/CCFontFreetype.h \
 2d/CCLabelLayout.cpp \
-2d/CCLabelLayout.h \
 2d/CCTTFLabelAtlasCache.cpp \
-2d/CCTTFLabelAtlasCache.h \
 2d/CCTTFLabelRenderer.cpp \
-2d/CCTTFLabelRenderer.h \
-2d/CCTTFTypes.cpp \
-2d/CCTTFTypes.h 
+2d/CCTTFTypes.cpp
 
 # v8 debugger source files, always enable it
 LOCAL_SRC_FILES += \

--- a/external/config.json
+++ b/external/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "v23-7",
+    "version": "v24-1",
     "zip_file_size": "115677698",
     "repo_name": "cocos2d-x-lite-external",
     "repo_parent": "https://github.com/cocos-creator/"


### PR DESCRIPTION
- recompile v8/android/x86
- upgrade libfreetype to 2.10.0
- add nullcheck when failing to load fonts
- add error log
- fix compiler warnings