### PR TITLE
optimize editBox fit system window

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxActivity.java
@@ -259,7 +259,6 @@ public abstract class Cocos2dxActivity extends Activity implements Cocos2dxHelpe
                                            ViewGroup.LayoutParams.MATCH_PARENT);
         mFrameLayout = new FrameLayout(this);
         mFrameLayout.setLayoutParams(frameLayoutParams);
-        mFrameLayout.setFitsSystemWindows(true);
 
         Cocos2dxRenderer renderer = this.addSurfaceView();
         this.addDebugInfo(renderer);

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -293,6 +293,7 @@ public class Cocos2dxEditBox {
      **************************************************************************************/
     private void addItems(Cocos2dxActivity context, FrameLayout layout) {
         RelativeLayout myLayout = new RelativeLayout(context);
+        myLayout.setFitsSystemWindows(true);
         this.addEditText(context, myLayout);
         this.addButton(context, myLayout);
 


### PR DESCRIPTION
This reverts commit 7274134a1f4bfddb723dd18e3f74bf6624ab71f7.

changeLog:
this commit resolve the problem that the game content only shows in the safe area

related bug feedback: 
https://discuss.cocos2d-x.org/t/cocos-creator-2-4-0-cant-show-full-screen-android-note-10/50747