### PR TITLE
optimize editBox layout

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -82,7 +82,6 @@ public class Cocos2dxEditBox {
         private int mLineColor = DARK_GREEN;
         private float mLineWidth = 2f;
         private boolean keyboardVisible = false;
-        private int mScreenHeight;
         private int mTopMargin = 0;
         private int mOrientation;
 
@@ -91,8 +90,6 @@ public class Cocos2dxEditBox {
             //remove focus border
             this.setBackground(null);
             this.setTextColor(Color.BLACK);
-            mScreenHeight = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).
-                    getDefaultDisplay().getHeight();
             mPaint = new Paint();
             mPaint.setStrokeWidth(mLineWidth);
             mPaint.setStyle(Paint.Style.FILL);
@@ -244,21 +241,21 @@ public class Cocos2dxEditBox {
                 public void onGlobalLayout() {
                     Rect r = new Rect();
                     getWindowVisibleDisplayFrame(r);
-                    int heightDiff = getRootView().getHeight() - (r.bottom - r.top);
+                    int screenHeight = getRootView().getHeight();
+                    int heightDiff = screenHeight - r.height();
                     // if more than a quarter of the screen, its probably a keyboard
-                    if (heightDiff > mScreenHeight/4) {
+                    if (heightDiff > screenHeight / 4) {
                         if (!keyboardVisible) {
                             keyboardVisible = true;
+                            if (Cocos2dxEditText.this.mTopMargin == 0 && r.bottom != screenHeight) {
+                                Cocos2dxEditText.this.setTopMargin(r.bottom);
+                            }
                         }
                     } else {
                         if (keyboardVisible) {
                             keyboardVisible = false;
                             Cocos2dxEditBox.this.hide();
                         }
-                    }
-
-                    if (Cocos2dxEditText.this.mTopMargin == 0 && r.bottom != getRootView().getHeight()) {
-                        Cocos2dxEditText.this.setTopMargin(r.bottom);
                     }
                 }
             });

--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxEditBox.java
@@ -83,7 +83,6 @@ public class Cocos2dxEditBox {
         private float mLineWidth = 2f;
         private boolean keyboardVisible = false;
         private int mTopMargin = 0;
-        private int mOrientation;
 
         public  Cocos2dxEditText(Cocos2dxActivity context){
             super(context);
@@ -94,7 +93,6 @@ public class Cocos2dxEditBox {
             mPaint.setStrokeWidth(mLineWidth);
             mPaint.setStyle(Paint.Style.FILL);
             mPaint.setColor(mLineColor);
-            mOrientation = this.getResources().getConfiguration().orientation;
 
             mTextWatcher = new TextWatcher() {
                 @Override
@@ -128,16 +126,6 @@ public class Cocos2dxEditBox {
                     getScrollX() + this.getWidth(),
                     this.getHeight() - padB / 2 - mLineWidth, mPaint);
             super.onDraw(canvas);
-        }
-
-        @Override
-        protected void onConfigurationChanged(Configuration newConfig) {
-            super.onConfigurationChanged(newConfig);
-            int newOrientation = newConfig.orientation;
-            if (mOrientation != newOrientation) {
-                mOrientation = newOrientation;
-                mTopMargin = 0;  // clear top margin cache
-            }
         }
 
         /***************************************************************************************
@@ -247,7 +235,7 @@ public class Cocos2dxEditBox {
                     if (heightDiff > screenHeight / 4) {
                         if (!keyboardVisible) {
                             keyboardVisible = true;
-                            if (Cocos2dxEditText.this.mTopMargin == 0 && r.bottom != screenHeight) {
+                            if (r.bottom != screenHeight) {
                                 Cocos2dxEditText.this.setTopMargin(r.bottom);
                             }
                         }


### PR DESCRIPTION
resolve: 
https://github.com/cocos-creator/2d-tasks/issues/2962
https://github.com/cocos-creator/2d-tasks/issues/2811

changeLog:
- 修复安卓平台，EditBox 会将游戏画面往上推的问题
- fix softkeyboard push up the GLSurfaceView on Android platform


NOTE: remove `mScreenHeight` in Cocos2dxEditBox,   
`((WindowManager)context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getHeight()` is deprecated,   
now use `getRootView().getHeight()` instead.

<img width="679" alt="WechatIMG1" src="https://user-images.githubusercontent.com/17872773/86445147-76655680-bd44-11ea-8927-2ae9f34c711d.png">

