### PR TITLE
Update ccUTF8.cpp, remove useless const

### DIFF
--- a/cocos/base/ccUTF8.cpp
+++ b/cocos/base/ccUTF8.cpp
@@ -201,7 +201,7 @@ bool utfConvert(
 CC_DLL void UTF8LooseFix(const std::string &in, std::string &out)
 {
     const UTF8 *p = (const UTF8*) in.c_str();
-    const UTF8 const *end = (const UTF8*) (in.c_str() + in.size());
+    const UTF8 *end = (const UTF8*) (in.c_str() + in.size());
     unsigned ucharLen = 0;
     while(p < end) {
         ucharLen = getNumBytesForUTF8(*p);


### PR DESCRIPTION
去掉多余的const

否则编译时会有警告

```
cocos2d-x/cocos/base/ccUTF8.cpp:204:16: warning: duplicate 'const' declaration specifier
```