### PR TITLE
fix editbox indicator jump to end on iOS

### DIFF
--- a/cocos/ui/edit-box/EditBox-ios.mm
+++ b/cocos/ui/edit-box/EditBox-ios.mm
@@ -369,7 +369,6 @@ namespace
     }
 
     callJSFunc("input", [textField.text UTF8String]);
-    setText(textField.text);
 }
 
 -(BOOL) textFieldShouldReturn:(UITextField *)textField
@@ -407,7 +406,6 @@ namespace
         textView.text = [textView.text substringToIndex:g_maxLength];
 
     callJSFunc("input", [textView.text UTF8String]);
-    setText(textView.text);
 }
 @end
 


### PR DESCRIPTION
changeLog:
- 修复 iOS 端 editBox 编辑文字，光标自动跳转到末端的问题
- 修复 iOS 下 editBox 韩文联想被打断的问题 https://github.com/cocos-creator/2d-tasks/issues/2400