### PR TITLE
Catch exception in `jsb.reflection.callStaticMethod`

### DIFF
--- a/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
+++ b/cocos/scripting/js-bindings/manual/JavaScriptJavaBridge.cpp
@@ -216,6 +216,13 @@ bool JavaScriptJavaBridge::CallInfo::execute()
         case JavaScriptJavaBridge::ValueType::STRING:
         {
             m_retjstring = (jstring)m_env->CallStaticObjectMethod(m_classID, m_methodID);
+
+            if(m_env->ExceptionCheck()) {
+                m_env->ExceptionDescribe();
+                m_env->ExceptionClear();
+                m_retjstring = nullptr;
+            }
+
             if (m_retjstring)
             {
                 std::string strValue = cocos2d::StringUtils::getStringUTFCharsJNI(m_env, m_retjstring);


### PR DESCRIPTION
JNI `CallStaticObjectMethod` 可能抛出异常, 需要捕获

```
F/art     ( 2666): art/runtime/check_jni.cc:65] JNI DETECTED ERROR IN APPLICATION: java_string == null
F/art     ( 2666): art/runtime/check_jni.cc:65]     in call to GetStringChars
F/art     ( 2666): art/runtime/check_jni.cc:65]     from void org.cocos2dx.lib.Cocos2dxRenderer.nativeRender()
F/art     ( 2666): art/runtime/check_jni.cc:65] "GLThread 122" prio=5 tid=14 Runnable
F/art     ( 2666): art/runtime/check_jni.cc:65]   | group="main" sCount=0 dsCount=0 obj=0x12c23a30 self=0xb4434000
F/art     ( 2666): art/runtime/check_jni.cc:65]   | sysTid=2685 nice=0 cgrp=default sched=0/0 handle=0xb4454f00
F/art     ( 2666): art/runtime/check_jni.cc:65]   | state=R schedstat=( 3434188421 253084888 9006 ) utm=270 stm=72 core=2 HZ=100
F/art     ( 2666): art/runtime/check_jni.cc:65]   | stack=0xa3ac5000-0xa3ac7000 stackSize=1036KB
F/art     ( 2666): art/runtime/check_jni.cc:65]   | held mutexes= "mutator lock"(shared held)
F/art     ( 2666): art/runtime/check_jni.cc:65]   native: #00 pc 000063eb  /system/lib/libbacktrace_libc++.so (UnwindCurrent::Unwind(unsigned int, ucontext*)+91)
F/art     ( 2666): art/runtime/check_jni.cc:65]   native: #01 pc 00002f31  /system/lib/libbacktrace_libc++.so (Backtrace::Unwind(unsigned int, ucontext*)+33)
F/art     ( 2666): art/runtime/check_jni.cc:65]   native: #02 pc 0042c44a  /system/lib/libart.so (art::DumpNativeStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, int, char const*, art::mirror::ArtMethod*)+122)
F/art     ( 2666): art/runtime/check_jni.cc:65]   native: #03 pc 003e7fb7  /system/lib/libart.so (art::Thread::DumpStack(std::__1::basic_ostream<char, std::__1::char_traits<char> >&) const+263)
F/art     ( 2666): art/runtime/check_jni.cc:65]   native: #04 pc 000f9724  /system/lib/libart.so (art::JniAbort(char const*, char const*)+1588)
F/art     ( 2666): art/runtime/check_jni.cc:65]   native: #05 pc 000fa272  /system/lib/libart.so (art::JniAbortF(char const*, char const*, ...)+98)
F/art     ( 2666): art/runtime/check_jni.cc:65]   native: #06 pc 002fcf61  /system/lib/l
```