### PR TITLE
[bugfix] [gfx] skip old template name

### DIFF
--- a/tools/cocos-console/bin/plugin_new.js
+++ b/tools/cocos-console/bin/plugin_new.js
@@ -109,12 +109,9 @@ class CCPluginNEW extends cocos_cli_1.CCPlugin {
         if (template_names.length == 1) {
             return template_names[0];
         }
-        let dirs = template_names.filter(x => x.indexOf(tpn) >= 0);
+        let dirs = template_names.filter(x => x === `template-${tpn}`);
         if (dirs.length == 0) {
             console.error(`can not find template ${tpn} in ${template_names.join(",")}`);
-        }
-        if (dirs.length > 1) {
-            console.error(`find multiple template dirs in for ${tpn}`);
         }
         return dirs[0];
     }

--- a/tools/cocos-console/bin/plugin_new.ts
+++ b/tools/cocos-console/bin/plugin_new.ts
@@ -117,12 +117,9 @@ export class CCPluginNEW extends CCPlugin {
         if (template_names.length == 1) {
             return template_names[0];
         }
-        let dirs = template_names.filter(x => x.indexOf(tpn) >= 0)
+        let dirs = template_names.filter(x => x === `template-${tpn}`);
         if (dirs.length == 0) {
             console.error(`can not find template ${tpn} in ${template_names.join(",")}`);
-        }
-        if (dirs.length > 1) {
-            console.error(`find multiple template dirs in for ${tpn}`);
         }
         return dirs[0];
     }


### PR DESCRIPTION
Skip template folders like `js-template-link/js-template-default`, which expected to be deleted when switching to the current branch. 