### PR TITLE
Fix the depth stencil format error on native.

### DIFF
--- a/cocos/base/CCConfiguration.cpp
+++ b/cocos/base/CCConfiguration.cpp
@@ -165,7 +165,7 @@ void Configuration::gatherGPUInfo()
     _supportsDepthTexture = checkForGLExtension("depth_texture");
     _valueDict["gl.supports_DepthTexture"] = Value(_supportsDepthTexture);
 
-    _supportsBGRA8888 = checkForGLExtension("GL_IMG_texture_format_BGRA888");
+    _supportsBGRA8888 = checkForGLExtension("texture_format_BGRA8888");
     _valueDict["gl.supports_BGRA8888"] = Value(_supportsBGRA8888);
 
     _supportsDiscardFramebuffer = checkForGLExtension("GL_EXT_discard_framebuffer");
@@ -185,6 +185,7 @@ void Configuration::gatherGPUInfo()
         _supportsFloatTexture = true;
         _supportsShareableVAO = true;
         _supportsInstancing = true;
+        _supportsDepthTexture = true;
     }
     else {
         _supportsFloatTexture = checkForGLExtension("texture_float");
@@ -247,6 +248,11 @@ int Configuration::getMaxTextureUnits() const
 bool Configuration::supportsNPOT() const
 {
     return _supportsNPOT;
+}
+
+bool Configuration::isOpenglES3() const
+{
+    return _isOpenglES3;
 }
 
 bool Configuration::supportsDepthTexture() const

--- a/cocos/base/CCConfiguration.h
+++ b/cocos/base/CCConfiguration.h
@@ -98,6 +98,12 @@ public:
      */
     bool supportsDepthTexture() const;
 
+    /** Whether or not the version is glES3.
+     *
+     * @return Is true if the version is glES3.
+     */
+    bool isOpenglES3() const;
+
     /** Whether or not PVR Texture Compressed is supported.
      *
      * @return Is true if supports PVR Texture Compressed.

--- a/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
@@ -2294,7 +2294,7 @@ static GLenum convertFloatTextureInternalFormat(GLenum format, GLenum type)
     else if (format == GL_DEPTH_STENCIL)
     {
         Configuration *config = Configuration::getInstance();
-        if (config->supportsDepthTexture()) {
+        if (config->isOpenglES3()) {
             return GL_DEPTH24_STENCIL8;
         }
     }

--- a/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_opengl_manual.cpp
@@ -2290,6 +2290,14 @@ static GLenum convertFloatTextureInternalFormat(GLenum format, GLenum type)
         else if (type == GL_HALF_FLOAT_OES)
             return GL_RGB16F_EXT;
     }
+    // The depth stencil format on gl3 is not same to gl2;
+    else if (format == GL_DEPTH_STENCIL)
+    {
+        Configuration *config = Configuration::getInstance();
+        if (config->supportsDepthTexture()) {
+            return GL_DEPTH24_STENCIL8;
+        }
+    }
 
     //FIXME: support other types, such as GL_ALPHA32F_EXT, GL_LUMINANCE32F_EXT?
 


### PR DESCRIPTION
https://github.com/cocos-creator/3d-tasks/issues/4247

现在 js 层没有走 Webgl2Device，但是原生层走的是 gles3，Depth Stencil Format 的 gl 定义不一致。原生和 adapter 对 gles3 的适配还欠缺很多，后续需要完善 gles3 版本的适配。