### PR TITLE
fixed crash bug when reading .skel(spine binary)

### DIFF
--- a/cocos/editor-support/spine/SkeletonBinary.cpp
+++ b/cocos/editor-support/spine/SkeletonBinary.cpp
@@ -488,6 +488,9 @@ Attachment *SkeletonBinary::readAttachment(DataInput *input, Skin *skin, int slo
 		String path(readStringRef(input, skeletonData));
 		if (path.isEmpty()) path = name;
 		RegionAttachment *region = _attachmentLoader->newRegionAttachment(*skin, String(name), String(path));
+		if (region == NULL){
+			return NULL;
+		}
 		region->_path = path;
 		region->_rotation = readFloat(input);
 		region->_x = readFloat(input) * _scale;

--- a/cocos/editor-support/spine/SkeletonJson.cpp
+++ b/cocos/editor-support/spine/SkeletonJson.cpp
@@ -780,6 +780,9 @@ Animation *SkeletonJson::readAnimation(Json *root, SkeletonData *skeletonData) {
 	Json *ik = Json::getItem(root, "ik");
 	Json *transform = Json::getItem(root, "transform");
 	Json *paths = Json::getItem(root, "path");
+	if (paths == NULL) {
+           paths = Json::getItem(root, "paths");
+	}
 	Json *deform = Json::getItem(root, "deform");
 	Json *drawOrder = Json::getItem(root, "drawOrder");
 	Json *events = Json::getItem(root, "events");


### PR DESCRIPTION
spine导出纹理图集时如果勾中了 忽略空白图片， 有些图片就不会出现在.atlas中，在解析.skel二进制文件过程会导致程序crash