### PR TITLE
fix black screen when return from background

### DIFF
--- a/cocos/platform/ios/CCEAGLView-ios.mm
+++ b/cocos/platform/ios/CCEAGLView-ios.mm
@@ -185,6 +185,13 @@ namespace
 
 - (void) layoutSubviews
 {
+    // On some devices with iOS13, `[_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:(CAEAGLLayer *)self.layer]`
+    // will return false if lock screen when running application, which make framebuffer in invalid state.
+    // FIXME: do binding framebuffer in other place?
+    UIApplicationState state = [[UIApplication sharedApplication] applicationState];
+    if (state == UIApplicationStateBackground)
+        return;
+
     glBindFramebuffer(GL_FRAMEBUFFER, _defaultFramebuffer);
     if (_defaultColorBuffer)
     {


### PR DESCRIPTION
This issue happend by on some iOS devices with iOS13 by doing these operations:
- lock the screen when the application is running
- unlock the screen and return to the application


clone of https://github.com/cocos-creator/cocos2d-x-lite/pull/1918