### PR TITLE
[2.4.4] fix: do not update vertexbuffer with empty array

### DIFF
--- a/cocos/renderer/gfx/IndexBuffer.cpp
+++ b/cocos/renderer/gfx/IndexBuffer.cpp
@@ -86,9 +86,12 @@ void IndexBuffer::update(uint32_t offset, const void* data, size_t dataByteLengt
         return;
     }
     
-    if (dataByteLength == 0) return;
-
-    if (data && dataByteLength + offset > _bytes)
+    if (data == nullptr || dataByteLength == 0)
+    {
+        return;
+    }
+    
+    if (dataByteLength + offset > _bytes)
     {
         if (offset) {
             RENDERER_LOGE("Failed to update index buffer data, bytes exceed.");

--- a/cocos/renderer/gfx/IndexBuffer.h
+++ b/cocos/renderer/gfx/IndexBuffer.h
@@ -117,10 +117,6 @@ public:
      * Gets byte size of the index buffer
      */
     inline uint32_t getBytes() const { return _bytes; }
-    /**
-     * Sets byte size of the index buffer
-     */
-    inline void setBytes(uint32_t bytes) { _bytes = bytes; }
 
     using FetchDataCallback = std::function<uint8_t*(size_t*)>;
     void setFetchDataCallback(const FetchDataCallback& cb) { _fetchDataCallback = cb; }

--- a/cocos/renderer/gfx/VertexBuffer.cpp
+++ b/cocos/renderer/gfx/VertexBuffer.cpp
@@ -76,13 +76,18 @@ void VertexBuffer::setFormat(VertexFormat* format)
 
 void VertexBuffer::update(uint32_t offset, const void* data, size_t dataByteLength)
 {
+    if(data == nullptr || dataByteLength == 0)
+    {
+        return;
+    }
+
     if (_glID == 0)
     {
         RENDERER_LOGE("The buffer is destroyed");
         return;
     }
 
-    if (data && dataByteLength + offset > _bytes)
+    if (dataByteLength + offset > _bytes)
     {
         if (offset) {
             RENDERER_LOGE("Failed to update index buffer data, bytes exceed.");

--- a/cocos/renderer/gfx/VertexBuffer.h
+++ b/cocos/renderer/gfx/VertexBuffer.h
@@ -110,10 +110,6 @@ public:
      * Gets byte size of the vertex buffer
      */
     inline uint32_t getBytes() const { return _bytes; }
-    /**
-     * Sets byte size of the vertex buffer
-     */
-    inline void setBytes(uint32_t bytes) { _bytes = bytes; }
 
     using FetchDataCallback = std::function<uint8_t*(size_t*)>;
     void setFetchDataCallback(const FetchDataCallback& cb) { _fetchDataCallback = cb; }

--- a/cocos/renderer/scene/MeshBuffer.cpp
+++ b/cocos/renderer/scene/MeshBuffer.cpp
@@ -179,11 +179,9 @@ void MeshBuffer::switchBuffer(uint32_t vertexCount)
     {
         DeviceGraphics* device = _batcher->getFlow()->getDevice();
         _vb = VertexBuffer::create(device, _vertexFmt, Usage::DYNAMIC, nullptr, 0, 0);
-        _vb->setBytes(_vDataCount * VDATA_BYTE);
         _vbArr.pushBack(_vb);
         
         _ib = IndexBuffer::create(device, IndexFormat::UINT16, Usage::STATIC, nullptr, 0, 0);
-        _ib->setBytes(_iDataCount * IDATA_BYTE);
         _ibArr.pushBack(_ib);
     }
 }

--- a/cocos/scripting/js-bindings/manual/jsb_gfx_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_gfx_manual.cpp
@@ -428,26 +428,6 @@ static bool js_gfx_VertexBuffer_prop_getNumVertices(se::State& s)
 }
 SE_BIND_PROP_GET(js_gfx_VertexBuffer_prop_getNumVertices)
 
-static bool js_gfx_VertexBuffer_prop_setBytes(se::State& s)
-{
-    cocos2d::renderer::VertexBuffer* cobj = (cocos2d::renderer::VertexBuffer*)s.nativeThisObject();
-    SE_PRECONDITION2(cobj, false, "js_gfx_VertexBuffer_prop_setBytes : Invalid Native Object");
-    const auto& args = s.args();
-    size_t argc = args.size();
-    CC_UNUSED bool ok = true;
-    if (argc == 1) {
-        uint32_t count = 0;
-        ok = seval_to_uint32(args[0], &count);
-        SE_PRECONDITION2(ok, false, "Convert arg0 offset failed!");
-        cobj->setBytes(count);
-        return true;
-    }
-
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
-    return false;
-}
-SE_BIND_PROP_SET(js_gfx_VertexBuffer_prop_setBytes)
-
 static bool js_gfx_VertexBuffer_prop_getBytes(se::State& s)
 {
     cocos2d::renderer::VertexBuffer* cobj = (cocos2d::renderer::VertexBuffer*)s.nativeThisObject();
@@ -728,26 +708,6 @@ static bool js_gfx_IndexBuffer_prop_getBytesPerIndex(se::State& s)
 }
 SE_BIND_PROP_GET(js_gfx_IndexBuffer_prop_getBytesPerIndex)
 
-static bool js_gfx_IndexBuffer_prop_setBytes(se::State& s)
-{
-    cocos2d::renderer::IndexBuffer* cobj = (cocos2d::renderer::IndexBuffer*)s.nativeThisObject();
-    SE_PRECONDITION2(cobj, false, "js_gfx_IndexBuffer_prop_setBytes : Invalid Native Object");
-    const auto& args = s.args();
-    size_t argc = args.size();
-    CC_UNUSED bool ok = true;
-    if (argc == 1) {
-        uint32_t count = 0;
-        ok = seval_to_uint32(args[0], &count);
-        SE_PRECONDITION2(ok, false, "Convert arg0 offset failed!");
-        cobj->setBytes(count);
-        return true;
-    }
-
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 1);
-    return false;
-}
-SE_BIND_PROP_SET(js_gfx_IndexBuffer_prop_setBytes)
-
 static bool js_gfx_IndexBuffer_prop_getBytes(se::State& s)
 {
     cocos2d::renderer::IndexBuffer* cobj = (cocos2d::renderer::IndexBuffer*)s.nativeThisObject();
@@ -904,8 +864,6 @@ bool jsb_register_gfx_manual(se::Object* global)
     __jsb_cocos2d_renderer_VertexBuffer_proto->defineFunction("update", _SE(js_gfx_VertexBuffer_update));
     __jsb_cocos2d_renderer_VertexBuffer_proto->defineProperty("_format", nullptr, _SE(js_gfx_VertexBuffer_prop_setFormat));
     __jsb_cocos2d_renderer_VertexBuffer_proto->defineProperty("_usage", _SE(js_gfx_VertexBuffer_prop_getUsage), _SE(js_gfx_VertexBuffer_prop_setUsage));
-    __jsb_cocos2d_renderer_VertexBuffer_proto->defineProperty("_bytes", _SE(js_gfx_VertexBuffer_prop_getBytes), _SE(js_gfx_VertexBuffer_prop_setBytes));
-    __jsb_cocos2d_renderer_VertexBuffer_proto->defineProperty("_numVertices", _SE(js_gfx_VertexBuffer_prop_getNumVertices), _SE(js_gfx_VertexBuffer_prop_setNumVertices));
     __jsb_cocos2d_renderer_VertexBuffer_proto->defineFunction("self", _SE(js_gfx_VertexBuffer_self));
 
     __jsb_cocos2d_renderer_IndexBuffer_proto->defineFunction("init", _SE(js_gfx_IndexBuffer_init));

--- a/cocos/scripting/js-bindings/manual/jsb_gfx_manual.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_gfx_manual.cpp
@@ -864,6 +864,8 @@ bool jsb_register_gfx_manual(se::Object* global)
     __jsb_cocos2d_renderer_VertexBuffer_proto->defineFunction("update", _SE(js_gfx_VertexBuffer_update));
     __jsb_cocos2d_renderer_VertexBuffer_proto->defineProperty("_format", nullptr, _SE(js_gfx_VertexBuffer_prop_setFormat));
     __jsb_cocos2d_renderer_VertexBuffer_proto->defineProperty("_usage", _SE(js_gfx_VertexBuffer_prop_getUsage), _SE(js_gfx_VertexBuffer_prop_setUsage));
+    __jsb_cocos2d_renderer_VertexBuffer_proto->defineProperty("_bytes", _SE(js_gfx_VertexBuffer_prop_getBytes), nullptr);
+    __jsb_cocos2d_renderer_VertexBuffer_proto->defineProperty("_numVertices", _SE(js_gfx_VertexBuffer_prop_getNumVertices), _SE(js_gfx_VertexBuffer_prop_setNumVertices));
     __jsb_cocos2d_renderer_VertexBuffer_proto->defineFunction("self", _SE(js_gfx_VertexBuffer_self));
 
     __jsb_cocos2d_renderer_IndexBuffer_proto->defineFunction("init", _SE(js_gfx_IndexBuffer_init));
@@ -871,7 +873,7 @@ bool jsb_register_gfx_manual(se::Object* global)
     __jsb_cocos2d_renderer_IndexBuffer_proto->defineProperty("_format", _SE(js_gfx_IndexBuffer_prop_getFormat), _SE(js_gfx_IndexBuffer_prop_setFormat));
     __jsb_cocos2d_renderer_IndexBuffer_proto->defineProperty("_usage", _SE(js_gfx_IndexBuffer_prop_getUsage), _SE(js_gfx_IndexBuffer_prop_setUsage));
     __jsb_cocos2d_renderer_IndexBuffer_proto->defineProperty("_bytesPerIndex", _SE(js_gfx_IndexBuffer_prop_getBytesPerIndex), _SE(js_gfx_IndexBuffer_prop_setBytesPerIndex));
-    __jsb_cocos2d_renderer_IndexBuffer_proto->defineProperty("_bytes", _SE(js_gfx_IndexBuffer_prop_getBytes), _SE(js_gfx_IndexBuffer_prop_setBytes));
+    __jsb_cocos2d_renderer_IndexBuffer_proto->defineProperty("_bytes", _SE(js_gfx_IndexBuffer_prop_getBytes), nullptr);
     __jsb_cocos2d_renderer_IndexBuffer_proto->defineProperty("_numIndices", _SE(js_gfx_IndexBuffer_prop_getNumIndices), _SE(js_gfx_IndexBuffer_prop_setNumIndices));
     __jsb_cocos2d_renderer_IndexBuffer_proto->defineFunction("self", _SE(js_gfx_IndexBuffer_self));
 


### PR DESCRIPTION
- do not update buffer with empty data
- remove `VertexBuffer::setBytes IndexBuffer::setBytes`