### PR TITLE
[3dgfx] se::Object add `__object_id__` in debug mode

### DIFF
--- a/cocos/bindings/jswrapper/v8/Object.cpp
+++ b/cocos/bindings/jswrapper/v8/Object.cpp
@@ -40,6 +40,7 @@ namespace se {
 
     namespace {
         v8::Isolate* __isolate = nullptr;
+        uint32_t _nativeObjectId = 0;
     }
 
     Object::Object()
@@ -314,6 +315,12 @@ namespace se {
             assert(__objectMap->find(this) == __objectMap->end());
             __objectMap->emplace(this, nullptr);
         }
+
+#if CC_DEBUG
+        this->_objectId = ++_nativeObjectId;
+        this->setProperty("__object_id__", se::Value(this->_objectId));
+        this->setProperty("__native_class_name__", se::Value(cls ? cls->getName() : "[noname]"));
+#endif
 
         return true;
     }

--- a/cocos/bindings/jswrapper/v8/Object.h
+++ b/cocos/bindings/jswrapper/v8/Object.h
@@ -378,6 +378,10 @@ namespace se {
         bool _isNativeFunction() const;
         //
 
+    #if CC_DEBUG
+        uint32_t getObjectId() const { return _objectId; }
+    #endif
+
     private:
         static void nativeObjectFinalizeHook(void* nativeObj);
         static void setIsolate(v8::Isolate* isolate);
@@ -397,6 +401,9 @@ namespace se {
         V8FinalizeFunc _finalizeCb;
         internal::PrivateData* _internalData;
 
+    #if CC_DEBUG
+        uint32_t _objectId = 0;
+    #endif
         friend class ScriptEngine;
     };
 


### PR DESCRIPTION
在 Debug 模式中, 在 C++ 中创建的 JS 对象, 设置额外字段

- `__object_id__`
- `__native_class_name__`
