### PR TITLE
fix crash and refine codes

### DIFF
--- a/cocos/bindings/auto/jsb_pipeline_auto.cpp
+++ b/cocos/bindings/auto/jsb_pipeline_auto.cpp
@@ -400,6 +400,24 @@ bool js_register_pipeline_RenderPipelineInfo(se::Object* obj)
 se::Object* __jsb_cc_pipeline_RenderPipeline_proto = nullptr;
 se::Class* __jsb_cc_pipeline_RenderPipeline_class = nullptr;
 
+static bool js_pipeline_RenderPipeline_getDefaultTexture(se::State& s)
+{
+    cc::pipeline::RenderPipeline* cobj = (cc::pipeline::RenderPipeline*)s.nativeThisObject();
+    SE_PRECONDITION2(cobj, false, "js_pipeline_RenderPipeline_getDefaultTexture : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        cc::gfx::Texture* result = cobj->getDefaultTexture();
+        ok &= native_ptr_to_seval(result, &s.rval());
+        SE_PRECONDITION2(ok, false, "js_pipeline_RenderPipeline_getDefaultTexture : Error processing arguments");
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_pipeline_RenderPipeline_getDefaultTexture)
+
 static bool js_pipeline_RenderPipeline_activate(se::State& s)
 {
     cc::pipeline::RenderPipeline* cobj = (cc::pipeline::RenderPipeline*)s.nativeThisObject();
@@ -555,6 +573,7 @@ bool js_register_pipeline_RenderPipeline(se::Object* obj)
 
     cls->defineProperty("descriptorSet", _SE(js_pipeline_RenderPipeline_getDescriptorSet), nullptr);
     cls->defineProperty("descriptorSetLayout", _SE(js_pipeline_RenderPipeline_getDescriptorSetLayout), nullptr);
+    cls->defineFunction("getDefaultTexture", _SE(js_pipeline_RenderPipeline_getDefaultTexture));
     cls->defineFunction("activate", _SE(js_pipeline_RenderPipeline_activate));
     cls->defineFunction("render", _SE(js_pipeline_RenderPipeline_render));
     cls->defineFunction("setValue", _SE(js_pipeline_RenderPipeline_setValue));
@@ -874,23 +893,26 @@ static bool js_pipeline_ForwardPipeline_setShadows(se::State& s)
 }
 SE_BIND_FUNC(js_pipeline_ForwardPipeline_setShadows)
 
-static bool js_pipeline_ForwardPipeline_getShadowFramebuffer(se::State& s)
+static bool js_pipeline_ForwardPipeline_setShadowFramebuffer(se::State& s)
 {
     cc::pipeline::ForwardPipeline* cobj = (cc::pipeline::ForwardPipeline*)s.nativeThisObject();
-    SE_PRECONDITION2(cobj, false, "js_pipeline_ForwardPipeline_getShadowFramebuffer : Invalid Native Object");
+    SE_PRECONDITION2(cobj, false, "js_pipeline_ForwardPipeline_setShadowFramebuffer : Invalid Native Object");
     const auto& args = s.args();
     size_t argc = args.size();
     CC_UNUSED bool ok = true;
-    if (argc == 0) {
-        std::unordered_map<const cc::pipeline::Light *, cc::gfx::Framebuffer *>& result = cobj->getShadowFramebuffer();
-        ok &= native_ptr_to_seval(result, &s.rval());
-        SE_PRECONDITION2(ok, false, "js_pipeline_ForwardPipeline_getShadowFramebuffer : Error processing arguments");
+    if (argc == 2) {
+        const cc::pipeline::Light* arg0 = nullptr;
+        cc::gfx::Framebuffer* arg1 = nullptr;
+        ok &= seval_to_native_ptr(args[0], &arg0);
+        ok &= seval_to_native_ptr(args[1], &arg1);
+        SE_PRECONDITION2(ok, false, "js_pipeline_ForwardPipeline_setShadowFramebuffer : Error processing arguments");
+        cobj->setShadowFramebuffer(arg0, arg1);
         return true;
     }
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 2);
     return false;
 }
-SE_BIND_FUNC(js_pipeline_ForwardPipeline_getShadowFramebuffer)
+SE_BIND_FUNC(js_pipeline_ForwardPipeline_setShadowFramebuffer)
 
 static bool js_pipeline_ForwardPipeline_setSkybox(se::State& s)
 {
@@ -930,6 +952,24 @@ static bool js_pipeline_ForwardPipeline_setAmbient(se::State& s)
 }
 SE_BIND_FUNC(js_pipeline_ForwardPipeline_setAmbient)
 
+static bool js_pipeline_ForwardPipeline_getShadowFramebufferMap(se::State& s)
+{
+    cc::pipeline::ForwardPipeline* cobj = (cc::pipeline::ForwardPipeline*)s.nativeThisObject();
+    SE_PRECONDITION2(cobj, false, "js_pipeline_ForwardPipeline_getShadowFramebufferMap : Invalid Native Object");
+    const auto& args = s.args();
+    size_t argc = args.size();
+    CC_UNUSED bool ok = true;
+    if (argc == 0) {
+        const std::unordered_map<const cc::pipeline::Light *, cc::gfx::Framebuffer *>& result = cobj->getShadowFramebufferMap();
+        ok &= native_ptr_to_seval(result, &s.rval());
+        SE_PRECONDITION2(ok, false, "js_pipeline_ForwardPipeline_getShadowFramebufferMap : Error processing arguments");
+        return true;
+    }
+    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
+    return false;
+}
+SE_BIND_FUNC(js_pipeline_ForwardPipeline_getShadowFramebufferMap)
+
 SE_DECLARE_FINALIZE_FUNC(js_cc_pipeline_ForwardPipeline_finalize)
 
 static bool js_pipeline_ForwardPipeline_constructor(se::State& s)
@@ -966,9 +1006,10 @@ bool js_register_pipeline_ForwardPipeline(se::Object* obj)
     cls->defineFunction("getSphere", _SE(js_pipeline_ForwardPipeline_getSphere));
     cls->defineFunction("setRenderObjects", _SE(js_pipeline_ForwardPipeline_setRenderObjects));
     cls->defineFunction("setShadows", _SE(js_pipeline_ForwardPipeline_setShadows));
-    cls->defineFunction("getShadowFramebuffer", _SE(js_pipeline_ForwardPipeline_getShadowFramebuffer));
+    cls->defineFunction("setShadowFramebuffer", _SE(js_pipeline_ForwardPipeline_setShadowFramebuffer));
     cls->defineFunction("setSkybox", _SE(js_pipeline_ForwardPipeline_setSkybox));
     cls->defineFunction("setAmbient", _SE(js_pipeline_ForwardPipeline_setAmbient));
+    cls->defineFunction("getShadowFramebufferMap", _SE(js_pipeline_ForwardPipeline_getShadowFramebufferMap));
     cls->defineFinalizeFunction(_SE(js_cc_pipeline_ForwardPipeline_finalize));
     cls->install();
     JSBClassType::registerClass<cc::pipeline::ForwardPipeline>(cls);

--- a/cocos/bindings/auto/jsb_pipeline_auto.cpp
+++ b/cocos/bindings/auto/jsb_pipeline_auto.cpp
@@ -893,27 +893,6 @@ static bool js_pipeline_ForwardPipeline_setShadows(se::State& s)
 }
 SE_BIND_FUNC(js_pipeline_ForwardPipeline_setShadows)
 
-static bool js_pipeline_ForwardPipeline_setShadowFramebuffer(se::State& s)
-{
-    cc::pipeline::ForwardPipeline* cobj = (cc::pipeline::ForwardPipeline*)s.nativeThisObject();
-    SE_PRECONDITION2(cobj, false, "js_pipeline_ForwardPipeline_setShadowFramebuffer : Invalid Native Object");
-    const auto& args = s.args();
-    size_t argc = args.size();
-    CC_UNUSED bool ok = true;
-    if (argc == 2) {
-        const cc::pipeline::Light* arg0 = nullptr;
-        cc::gfx::Framebuffer* arg1 = nullptr;
-        ok &= seval_to_native_ptr(args[0], &arg0);
-        ok &= seval_to_native_ptr(args[1], &arg1);
-        SE_PRECONDITION2(ok, false, "js_pipeline_ForwardPipeline_setShadowFramebuffer : Error processing arguments");
-        cobj->setShadowFramebuffer(arg0, arg1);
-        return true;
-    }
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 2);
-    return false;
-}
-SE_BIND_FUNC(js_pipeline_ForwardPipeline_setShadowFramebuffer)
-
 static bool js_pipeline_ForwardPipeline_setSkybox(se::State& s)
 {
     cc::pipeline::ForwardPipeline* cobj = (cc::pipeline::ForwardPipeline*)s.nativeThisObject();
@@ -952,24 +931,6 @@ static bool js_pipeline_ForwardPipeline_setAmbient(se::State& s)
 }
 SE_BIND_FUNC(js_pipeline_ForwardPipeline_setAmbient)
 
-static bool js_pipeline_ForwardPipeline_getShadowFramebufferMap(se::State& s)
-{
-    cc::pipeline::ForwardPipeline* cobj = (cc::pipeline::ForwardPipeline*)s.nativeThisObject();
-    SE_PRECONDITION2(cobj, false, "js_pipeline_ForwardPipeline_getShadowFramebufferMap : Invalid Native Object");
-    const auto& args = s.args();
-    size_t argc = args.size();
-    CC_UNUSED bool ok = true;
-    if (argc == 0) {
-        const std::unordered_map<const cc::pipeline::Light *, cc::gfx::Framebuffer *>& result = cobj->getShadowFramebufferMap();
-        ok &= native_ptr_to_seval(result, &s.rval());
-        SE_PRECONDITION2(ok, false, "js_pipeline_ForwardPipeline_getShadowFramebufferMap : Error processing arguments");
-        return true;
-    }
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-    return false;
-}
-SE_BIND_FUNC(js_pipeline_ForwardPipeline_getShadowFramebufferMap)
-
 SE_DECLARE_FINALIZE_FUNC(js_cc_pipeline_ForwardPipeline_finalize)
 
 static bool js_pipeline_ForwardPipeline_constructor(se::State& s)
@@ -1006,10 +967,8 @@ bool js_register_pipeline_ForwardPipeline(se::Object* obj)
     cls->defineFunction("getSphere", _SE(js_pipeline_ForwardPipeline_getSphere));
     cls->defineFunction("setRenderObjects", _SE(js_pipeline_ForwardPipeline_setRenderObjects));
     cls->defineFunction("setShadows", _SE(js_pipeline_ForwardPipeline_setShadows));
-    cls->defineFunction("setShadowFramebuffer", _SE(js_pipeline_ForwardPipeline_setShadowFramebuffer));
     cls->defineFunction("setSkybox", _SE(js_pipeline_ForwardPipeline_setSkybox));
     cls->defineFunction("setAmbient", _SE(js_pipeline_ForwardPipeline_setAmbient));
-    cls->defineFunction("getShadowFramebufferMap", _SE(js_pipeline_ForwardPipeline_getShadowFramebufferMap));
     cls->defineFinalizeFunction(_SE(js_cc_pipeline_ForwardPipeline_finalize));
     cls->install();
     JSBClassType::registerClass<cc::pipeline::ForwardPipeline>(cls);

--- a/cocos/bindings/auto/jsb_pipeline_auto.cpp
+++ b/cocos/bindings/auto/jsb_pipeline_auto.cpp
@@ -400,24 +400,6 @@ bool js_register_pipeline_RenderPipelineInfo(se::Object* obj)
 se::Object* __jsb_cc_pipeline_RenderPipeline_proto = nullptr;
 se::Class* __jsb_cc_pipeline_RenderPipeline_class = nullptr;
 
-static bool js_pipeline_RenderPipeline_getDefaultTexture(se::State& s)
-{
-    cc::pipeline::RenderPipeline* cobj = (cc::pipeline::RenderPipeline*)s.nativeThisObject();
-    SE_PRECONDITION2(cobj, false, "js_pipeline_RenderPipeline_getDefaultTexture : Invalid Native Object");
-    const auto& args = s.args();
-    size_t argc = args.size();
-    CC_UNUSED bool ok = true;
-    if (argc == 0) {
-        cc::gfx::Texture* result = cobj->getDefaultTexture();
-        ok &= native_ptr_to_seval(result, &s.rval());
-        SE_PRECONDITION2(ok, false, "js_pipeline_RenderPipeline_getDefaultTexture : Error processing arguments");
-        return true;
-    }
-    SE_REPORT_ERROR("wrong number of arguments: %d, was expecting %d", (int)argc, 0);
-    return false;
-}
-SE_BIND_FUNC(js_pipeline_RenderPipeline_getDefaultTexture)
-
 static bool js_pipeline_RenderPipeline_activate(se::State& s)
 {
     cc::pipeline::RenderPipeline* cobj = (cc::pipeline::RenderPipeline*)s.nativeThisObject();
@@ -573,7 +555,6 @@ bool js_register_pipeline_RenderPipeline(se::Object* obj)
 
     cls->defineProperty("descriptorSet", _SE(js_pipeline_RenderPipeline_getDescriptorSet), nullptr);
     cls->defineProperty("descriptorSetLayout", _SE(js_pipeline_RenderPipeline_getDescriptorSetLayout), nullptr);
-    cls->defineFunction("getDefaultTexture", _SE(js_pipeline_RenderPipeline_getDefaultTexture));
     cls->defineFunction("activate", _SE(js_pipeline_RenderPipeline_activate));
     cls->defineFunction("render", _SE(js_pipeline_RenderPipeline_render));
     cls->defineFunction("setValue", _SE(js_pipeline_RenderPipeline_setValue));

--- a/cocos/bindings/auto/jsb_pipeline_auto.h
+++ b/cocos/bindings/auto/jsb_pipeline_auto.h
@@ -20,6 +20,7 @@ extern se::Class* __jsb_cc_pipeline_RenderPipeline_class;
 
 bool js_register_cc_pipeline_RenderPipeline(se::Object* obj);
 bool register_all_pipeline(se::Object* obj);
+SE_DECLARE_FUNC(js_pipeline_RenderPipeline_getDefaultTexture);
 SE_DECLARE_FUNC(js_pipeline_RenderPipeline_activate);
 SE_DECLARE_FUNC(js_pipeline_RenderPipeline_render);
 SE_DECLARE_FUNC(js_pipeline_RenderPipeline_setValue);
@@ -43,9 +44,10 @@ SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setFog);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_getSphere);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setRenderObjects);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setShadows);
-SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_getShadowFramebuffer);
+SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setShadowFramebuffer);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setSkybox);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setAmbient);
+SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_getShadowFramebufferMap);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_ForwardPipeline);
 
 extern se::Object* __jsb_cc_pipeline_RenderFlowInfo_proto;

--- a/cocos/bindings/auto/jsb_pipeline_auto.h
+++ b/cocos/bindings/auto/jsb_pipeline_auto.h
@@ -44,10 +44,8 @@ SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setFog);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_getSphere);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setRenderObjects);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setShadows);
-SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setShadowFramebuffer);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setSkybox);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_setAmbient);
-SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_getShadowFramebufferMap);
 SE_DECLARE_FUNC(js_pipeline_ForwardPipeline_ForwardPipeline);
 
 extern se::Object* __jsb_cc_pipeline_RenderFlowInfo_proto;

--- a/cocos/bindings/auto/jsb_pipeline_auto.h
+++ b/cocos/bindings/auto/jsb_pipeline_auto.h
@@ -20,7 +20,6 @@ extern se::Class* __jsb_cc_pipeline_RenderPipeline_class;
 
 bool js_register_cc_pipeline_RenderPipeline(se::Object* obj);
 bool register_all_pipeline(se::Object* obj);
-SE_DECLARE_FUNC(js_pipeline_RenderPipeline_getDefaultTexture);
 SE_DECLARE_FUNC(js_pipeline_RenderPipeline_activate);
 SE_DECLARE_FUNC(js_pipeline_RenderPipeline_render);
 SE_DECLARE_FUNC(js_pipeline_RenderPipeline_setValue);

--- a/cocos/renderer/gfx-metal/MTLCommandBuffer.h
+++ b/cocos/renderer/gfx-metal/MTLCommandBuffer.h
@@ -14,6 +14,7 @@ struct CCMTLGPUPipelineState;
 struct CCMTLGPUBuffer;
 class CCMTLInputAssembler;
 class CCMTLDevice;
+class CCMTLRenderPass;
 
 class CCMTLCommandBuffer : public CommandBuffer {
     friend class CCMTLQueue;
@@ -47,7 +48,7 @@ public:
 
 private:
     void bindDescriptorSets();
-    bool isRenderingEntireDrawable(const Rect &rect);
+    bool isRenderingEntireDrawable(const Rect &rect, const CCMTLRenderPass *renderPass);
 
 private:
     CCMTLGPUPipelineState *_gpuPipelineState = nullptr;
@@ -62,7 +63,6 @@ private:
     vector<vector<uint>> _dynamicOffsets;
     uint _firstDirtyDescriptorSet = UINT_MAX;
 
-    bool _hasSubRegionCleared = false;
     bool _indirectDrawSuppotred = false;
     bool _commandBufferBegan = false;
     CCMTLDevice *_mtlDevice = nullptr;

--- a/cocos/renderer/gfx-metal/MTLUtils.h
+++ b/cocos/renderer/gfx-metal/MTLUtils.h
@@ -70,7 +70,7 @@ uint getBlockSzie(Format format);
 uint getBytesPerRow(Format format, uint width);
 bool pixelFormatIsColorRenderable(Format format);
 bool isSamplerDescriptorCompareFunctionSupported(uint family);
-void clearRenderArea(CCMTLDevice *device, id<MTLCommandBuffer> commandBuffer, RenderPass *renderPass, const Rect &renderArea, const Color *colors, float depth, int stencil, bool &hasScreenClean);
+void clearRenderArea(CCMTLDevice *device, id<MTLCommandBuffer> commandBuffer, RenderPass *renderPass, const Rect &renderArea, const Color *colors, float depth, int stencil);
 CC_INLINE uint alignUp(uint inSize, uint align) { return ((inSize + align - 1) / align) * align; }
 } // namespace mu
 

--- a/cocos/renderer/gfx-metal/MTLUtils.mm
+++ b/cocos/renderer/gfx-metal/MTLUtils.mm
@@ -1535,17 +1535,11 @@ CCMTLGPUPipelineState *getClearRenderPassPipelineState(CCMTLDevice *device, Rend
     return static_cast<CCMTLPipelineState *>(pipelineState)->getGPUPipelineState();
 }
 
-void clearRenderArea(CCMTLDevice *device, id<MTLCommandBuffer> commandBuffer, RenderPass *renderPass, const Rect &renderArea, const Color *colors, float depth, int stencil, bool &hasSubRegionCleared) {
+void clearRenderArea(CCMTLDevice *device, id<MTLCommandBuffer> commandBuffer, RenderPass *renderPass, const Rect &renderArea, const Color *colors, float depth, int stencil) {
     const auto gpuPSO = getClearRenderPassPipelineState(device, renderPass);
     const auto mtlRenderPass = static_cast<CCMTLRenderPass *>(renderPass);
     uint slot = 0u;
     MTLRenderPassDescriptor *renderPassDescriptor = mtlRenderPass->getMTLRenderPassDescriptor();
-    if (!hasSubRegionCleared) {
-        renderPassDescriptor.colorAttachments[slot].loadAction = MTLLoadActionClear;
-        renderPassDescriptor.colorAttachments[slot].clearColor = toMTLClearColor(colors[0]);
-        renderPassDescriptor.depthAttachment.clearDepth = depth;
-        renderPassDescriptor.stencilAttachment.clearStencil = stencil;
-    }
     const auto &renderTargetSizes = mtlRenderPass->getRenderTargetSizes();
     float renderTargetWidth = renderTargetSizes[slot].x;
     float renderTargetHeight = renderTargetSizes[slot].y;
@@ -1600,10 +1594,7 @@ void clearRenderArea(CCMTLDevice *device, id<MTLCommandBuffer> commandBuffer, Re
                       vertexCount:count];
 
     [renderEncoder endEncoding];
-    if (!hasSubRegionCleared) {
-        hasSubRegionCleared = true;
-        renderPassDescriptor.colorAttachments[slot].loadAction = MTLLoadActionLoad;
-    }
+    renderPassDescriptor.colorAttachments[slot].loadAction = MTLLoadActionLoad;
 }
 
 } //namespace mu

--- a/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
+++ b/cocos/renderer/pipeline/RenderAdditiveLightQueue.cpp
@@ -321,12 +321,16 @@ void RenderAdditiveLightQueue::updateLightDescriptorSet(const RenderView *view, 
                 memcpy(_shadowUBO.data() + UBOShadow::SHADOW_COLOR_OFFSET, &shadowInfo->color, sizeof(Vec4));
                 memcpy(_shadowUBO.data() + UBOShadow::SHADOW_INFO_OFFSET, &shadowInfos, sizeof(shadowInfos));
                 // Spot light sampler binding
-                auto *texture = _pipeline->getShadowFramebuffer().at(light)->getColorTextures()[0];
-                if (texture) {
-                    descriptorSet->bindTexture(SPOT_LIGHTING_MAP::BINDING, texture);
-                } else {
-                    descriptorSet->bindTexture(SPOT_LIGHTING_MAP::BINDING, _pipeline->getDefaultTexture());
+                const auto &shadowFramebufferMap = _pipeline->getShadowFramebufferMap();
+                if (shadowFramebufferMap.count(light) > 0) {
+                    auto *texture = shadowFramebufferMap.at(light)->getColorTextures()[0];
+                    if (texture) {
+                        descriptorSet->bindTexture(SPOT_LIGHTING_MAP::BINDING, texture);
+                    } else {
+                        descriptorSet->bindTexture(SPOT_LIGHTING_MAP::BINDING, _pipeline->getDefaultTexture());
+                    }
                 }
+                
             } break;
             case LightType::SPHERE: {
                 // Reserve sphere light shadow interface

--- a/cocos/renderer/pipeline/forward/ForwardPipeline.cpp
+++ b/cocos/renderer/pipeline/forward/ForwardPipeline.cpp
@@ -79,6 +79,14 @@ void ForwardPipeline::setShadows(uint shadows) {
     _shadows = GET_SHADOWS(shadows);
 }
 
+void ForwardPipeline::destroyShadowFrameBuffers() {
+    for (auto &pair : _shadowFrameBufferMap) {
+        pair.second->destroy();
+        delete pair.second;
+    }
+    _shadowFrameBufferMap.clear();
+}
+
 bool ForwardPipeline::initialize(const RenderPipelineInfo &info) {
     RenderPipeline::initialize(info);
 
@@ -163,7 +171,7 @@ void ForwardPipeline::updateUBOs(RenderView *view) {
 
         Mat4 matShadowViewProj;
         const auto projectionSinY = device->getScreenSpaceSignY() * device->getUVSpaceSignY();
-        Mat4::createOrthographicOffCenter(-x, x, -y, y, shadowInfo->nearValue, shadowInfo->farValue, device->getClipSpaceMinZ(), projectionSinY, &matShadowViewProj);    
+        Mat4::createOrthographicOffCenter(-x, x, -y, y, shadowInfo->nearValue, shadowInfo->farValue, device->getClipSpaceMinZ(), projectionSinY, &matShadowViewProj);
 
         matShadowViewProj.multiply(matShadowView);
         float shadowInfos[4] = {shadowInfo->size.x, shadowInfo->size.y, (float)shadowInfo->pcfType, shadowInfo->bias};

--- a/cocos/renderer/pipeline/forward/ForwardPipeline.h
+++ b/cocos/renderer/pipeline/forward/ForwardPipeline.h
@@ -34,9 +34,10 @@ public:
     void setAmbient(uint);
     void setSkybox(uint);
     void setShadows(uint);
+    void destroyShadowFrameBuffers();
 
-    std::unordered_map<const Light *, gfx::Framebuffer *> &getShadowFramebuffer() { return _shadowFrameBufferMap; }
-
+    CC_INLINE void setShadowFramebuffer(const Light *light, gfx::Framebuffer *framebuffer) { _shadowFrameBufferMap.emplace(light, framebuffer); }
+    CC_INLINE const std::unordered_map<const Light *, gfx::Framebuffer *> &getShadowFramebufferMap() const { return _shadowFrameBufferMap; }
     CC_INLINE gfx::Buffer *getLightsUBO() const { return _lightsUBO; }
     CC_INLINE const LightList &getValidLights() const { return _validLights; }
     CC_INLINE const gfx::BufferList &getLightBuffers() const { return _lightBuffers; }

--- a/cocos/renderer/pipeline/shadow/ShadowFlow.cpp
+++ b/cocos/renderer/pipeline/shadow/ShadowFlow.cpp
@@ -47,12 +47,13 @@ void ShadowFlow::render(RenderView *view) {
     lightCollecting(view, _validLights);
     shadowCollecting(pipeline, view);
 
+    const auto &shadowFramebufferMap = pipeline->getShadowFramebufferMap();
     for (const auto *light : _validLights) {
-        if (!pipeline->getShadowFramebuffer().count(light)) {
+        if (!shadowFramebufferMap.count(light)) {
             initShadowFrameBuffer(pipeline, light);
         }
 
-        auto *shadowFrameBuffer = pipeline->getShadowFramebuffer().at(light);
+        auto *shadowFrameBuffer = shadowFramebufferMap.at(light);
         if (shadowInfo->shadowMapDirty) {
             resizeShadowMap(light, (uint)shadowInfo->size.x, (uint)shadowInfo->size.y);
         }
@@ -67,8 +68,8 @@ void ShadowFlow::render(RenderView *view) {
 void ShadowFlow::resizeShadowMap(const Light *light, const uint width, const uint height) const {
     auto *pipeline = static_cast<ForwardPipeline *>(_pipeline);
 
-    if (pipeline->getShadowFramebuffer().count(light)) {
-        auto *framebuffer = pipeline->getShadowFramebuffer().at(light);
+    if (pipeline->getShadowFramebufferMap().count(light)) {
+        auto *framebuffer = pipeline->getShadowFramebufferMap().at(light);
 
         if (!framebuffer) {
             return;
@@ -147,7 +148,7 @@ void ShadowFlow::initShadowFrameBuffer(ForwardPipeline *pipeline, const Light *l
         {}, //colorMipmapLevels
     });
 
-    pipeline->getShadowFramebuffer().emplace(map<const Light *, gfx::Framebuffer *>::value_type(light, framebuffer));
+    pipeline->setShadowFramebuffer(light, framebuffer);
 
     gfx::SamplerInfo info{
         gfx::Filter::LINEAR,
@@ -176,22 +177,12 @@ void ShadowFlow::initShadowFrameBuffer(ForwardPipeline *pipeline, const Light *l
 }
 
 void ShadowFlow::destroy() {
-    auto *pipeline = static_cast<ForwardPipeline *>(_pipeline);
-    for (auto &pair : pipeline->getShadowFramebuffer()) {
+    static_cast<ForwardPipeline *>(_pipeline)->destroyShadowFrameBuffers();
 
-        auto &renderTargets = pair.second->getColorTextures();
-        for (auto *renderTarget : renderTargets) {
-            CC_SAFE_DELETE(renderTarget);
-        }
-
-        auto *depth = pair.second->getDepthStencilTexture();
-        CC_SAFE_DELETE(depth);
-
-        pair.second->destroy();
-        CC_SAFE_DESTROY(pair.second);
+    if (_renderPass) {
+        _renderPass->destroy();
+        _renderPass = nullptr;
     }
-
-    CC_SAFE_DESTROY(_renderPass);
 
     _validLights.clear();
 

--- a/tools/tojs/pipeline.ini
+++ b/tools/tojs/pipeline.ini
@@ -39,7 +39,7 @@ classes = RenderPipeline ForwardPipeline ForwardFlow ForwardStage ShadowFlow Sha
 # will apply to all class names. This is a convenience wildcard to be able to skip similar named
 # functions from all classes.
 skip = ForwardPipeline::[updateUBOs setHDR getOrCreateRenderPass getLightsUBO getValidLights getLightBuffers getLightIndexOffsets getLightIndices getRenderObjects getShadowObjects getCommandBuffers getShadingScale getFpScale isHDR setRenderObjcts setShadowObjects getFog getAmbient getSkybox getShadows getShadowUBO setShadowFramebuffer getShadowFramebufferMap destroyShadowFrameBuffers],
-       RenderPipeline::[getFlows getTag getGlobalBindings getMacros],
+       RenderPipeline::[getFlows getTag getGlobalBindings getMacros getDefaultTexture],
        RenderFlow::[render destroy getPriority getName],
        RenderStage::[render destroy getPriority getName],
        ForwardFlow::[initialize activate destroy render],

--- a/tools/tojs/pipeline.ini
+++ b/tools/tojs/pipeline.ini
@@ -38,7 +38,7 @@ classes = RenderPipeline ForwardPipeline ForwardFlow ForwardStage ShadowFlow Sha
 # add a single "*" as functions. See bellow for several examples. A special class name is "*", which
 # will apply to all class names. This is a convenience wildcard to be able to skip similar named
 # functions from all classes.
-skip = ForwardPipeline::[updateUBOs setHDR getOrCreateRenderPass getLightsUBO getValidLights getLightBuffers getLightIndexOffsets getLightIndices getRenderObjects getShadowObjects getCommandBuffers getShadingScale getFpScale isHDR setRenderObjcts setShadowObjects getFog getAmbient getSkybox getShadows getShadowUBO],
+skip = ForwardPipeline::[updateUBOs setHDR getOrCreateRenderPass getLightsUBO getValidLights getLightBuffers getLightIndexOffsets getLightIndices getRenderObjects getShadowObjects getCommandBuffers getShadingScale getFpScale isHDR setRenderObjcts setShadowObjects getFog getAmbient getSkybox getShadows getShadowUBO setShadowFramebuffer getShadowFramebufferMap destroyShadowFrameBuffers],
        RenderPipeline::[getFlows getTag getGlobalBindings getMacros],
        RenderFlow::[render destroy getPriority getName],
        RenderStage::[render destroy getPriority getName],


### PR DESCRIPTION
- 修复没有检查 light 导致的崩溃问题
- 重构了一下代码，类内部的成员变量不应该在外部改变
  - getShadowFramebuffer -> getShadowFramebufferMap
  - 增加 setShadowFramebuffer 用于设置 light 对应的 frame buffer
  - 增加 destroyShadowFrameBuffers 用于销毁 light 对应的 framebuffer