### PR TITLE
use float type color for particle to fix color lerp precision

### DIFF
--- a/cocos/editor-support/particle/ParticleSimulator.cpp
+++ b/cocos/editor-support/particle/ParticleSimulator.cpp
@@ -44,7 +44,7 @@ void Particle::reset()
 {
     pos = cocos2d::Vec3::ZERO;
     startPos = cocos2d::Vec3::ZERO;
-    color = cocos2d::Color4B::BLACK;
+    color = cocos2d::Color4F::BLACK;
     deltaColor = cocos2d::Color4F::BLACK;
     size = 0;
     deltaSize = 0;
@@ -427,10 +427,10 @@ void ParticleSimulator::render(float dt)
             
             auto rad = -CC_DEGREES_TO_RADIANS(particle.rotation);
             auto cr = cos(rad), sr = sin(rad);
-            uint32_t tempColor = ((particle.color.a << 24) & 0xff000000) +
-                                 ((particle.color.b << 16) & 0x00ff0000) +
-                                 ((particle.color.g << 8)  & 0x0000ff00) +
-                                 ((particle.color.r)       & 0x000000ff);
+            uint32_t tempColor = (((GLuint)particle.color.a << 24) & 0xff000000) +
+                                 (((GLuint)particle.color.b << 16) & 0x00ff0000) +
+                                 (((GLuint)particle.color.g << 8)  & 0x0000ff00) +
+                                 (((GLuint)particle.color.r)       & 0x000000ff);
             // bl
             vb.writeFloat32(x1 * cr - y1 * sr + x);
             vb.writeFloat32(x1 * sr + y1 * cr + y);

--- a/cocos/editor-support/particle/ParticleSimulator.h
+++ b/cocos/editor-support/particle/ParticleSimulator.h
@@ -38,7 +38,7 @@ struct Particle {
 public:
     cocos2d::Vec3 pos;
     cocos2d::Vec3 startPos;
-    cocos2d::Color4B color = cocos2d::Color4B::BLACK;
+    cocos2d::Color4F color = cocos2d::Color4F::BLACK;
     cocos2d::Color4F deltaColor = cocos2d::Color4F::BLACK;
     float size = 0.0f;
     float deltaSize = 0.0f;


### PR DESCRIPTION
## Related Issue
https://github.com/cocos-creator/engine/issues/7206, this fixed JS version particle in early time.
This PR fix native version.

Particle color animation is not accurate for long living particle, use float type color to fix it.
