### PR TITLE
adjust stagingBufferPool size when recieve memory warning #3733

### DIFF
--- a/cocos/renderer/gfx-metal/MTLDevice.h
+++ b/cocos/renderer/gfx-metal/MTLDevice.h
@@ -49,6 +49,9 @@ public:
     CC_INLINE bool isSamplerDescriptorCompareFunctionSupported() const { return _isSamplerDescriptorCompareFunctionSupported; }
 
 private:
+    void responseToMemoryAlarm();
+    
+private:
     void *_mtlCommandQueue = nullptr;
     void *_mtkView = nullptr;
     void *_mtlDevice = nullptr;
@@ -62,6 +65,7 @@ private:
     CCMTLGPUStagingBufferPool *_gpuStagingBufferPools[MAX_FRAMES_IN_FLIGHT] = { nullptr };
     CCMTLSemaphore *_inFlightSemaphore = nullptr;
     uint _currentFrameIndex = 0;
+    uint32_t    _memoryAlarmListenerId = 0;
 };
 
 } // namespace gfx

--- a/cocos/renderer/gfx-metal/MTLDevice.h
+++ b/cocos/renderer/gfx-metal/MTLDevice.h
@@ -49,8 +49,8 @@ public:
     CC_INLINE bool isSamplerDescriptorCompareFunctionSupported() const { return _isSamplerDescriptorCompareFunctionSupported; }
 
 private:
-    void responseToMemoryAlarm();
-    
+    void onMemoryWarning();
+
 private:
     void *_mtlCommandQueue = nullptr;
     void *_mtkView = nullptr;
@@ -62,10 +62,10 @@ private:
     bool _icbSuppored = false;
     bool _indirectDrawSupported = false;
     bool _isSamplerDescriptorCompareFunctionSupported = false;
-    CCMTLGPUStagingBufferPool *_gpuStagingBufferPools[MAX_FRAMES_IN_FLIGHT] = { nullptr };
+    CCMTLGPUStagingBufferPool *_gpuStagingBufferPools[MAX_FRAMES_IN_FLIGHT] = {nullptr};
     CCMTLSemaphore *_inFlightSemaphore = nullptr;
     uint _currentFrameIndex = 0;
-    uint32_t    _memoryAlarmListenerId = 0;
+    uint32_t _memoryAlarmListenerId = 0;
 };
 
 } // namespace gfx

--- a/cocos/renderer/gfx-metal/MTLGPUObjects.h
+++ b/cocos/renderer/gfx-metal/MTLGPUObjects.h
@@ -171,6 +171,22 @@ public:
         }
     }
 
+    void  shrink_to_fit()
+    {
+        for(auto iter = _pool.begin(); iter != _pool.end() && _pool.size() > 1;)
+        {
+            if (iter->curOffset == 0)
+            {
+                [iter->mtlBuffer release];
+                iter = _pool.erase(iter);
+            }
+            else
+            {
+                ++iter;
+            }
+        }
+    }
+
 private:
     struct Buffer {
         id<MTLBuffer> mtlBuffer = nil;

--- a/cocos/renderer/gfx-metal/MTLGPUObjects.h
+++ b/cocos/renderer/gfx-metal/MTLGPUObjects.h
@@ -171,17 +171,12 @@ public:
         }
     }
 
-    void  shrink_to_fit()
-    {
-        for(auto iter = _pool.begin(); iter != _pool.end() && _pool.size() > 1;)
-        {
-            if (iter->curOffset == 0)
-            {
+    void shrinkSize() {
+        for (auto iter = _pool.begin(); iter != _pool.end() && _pool.size() > 1;) {
+            if (iter->curOffset == 0) {
                 [iter->mtlBuffer release];
                 iter = _pool.erase(iter);
-            }
-            else
-            {
+            } else {
                 ++iter;
             }
         }


### PR DESCRIPTION
-add listener for memory warning and resize staging buffer pool;
-remove reset() in acquire but reset by the end of MTLCommandBuffer;

tested both on IOS14.2(iphone SE2) and MAC10.15.7, performance test case