### PR TITLE
[3.0] export `bindDescriptorSetForJS` to JS

### DIFF
--- a/cocos/bindings/manual/jsb_conversions.h
+++ b/cocos/bindings/manual/jsb_conversions.h
@@ -835,15 +835,6 @@ struct HolderType<std::function<R (ARGS...)>, true> {
     inline type value() { return data; }
 };
 
-template<>
-struct HolderType<const unsigned int *, false> {
-    using type = const unsigned int *;
-    using local_type = std::vector<unsigned int>;
-    local_type data;
-    std::remove_const_t<type> *ptr = nullptr;
-    inline type value() { return data.data(); }
-};
-
 
 ///////////////////////////////////convertion//////////////////////////////////////////////////////////
 
@@ -1305,14 +1296,6 @@ sevalue_to_native(const se::Value &from, HolderType<std::vector<T, allocator>, t
 }
 
 #endif // HAS_CONSTEXPR
-
-
-template<>
-inline bool sevalue_to_native(const se::Value &from, HolderType<const unsigned int *, false> *holder, se::Object *ctx)
-{
-    return sevalue_to_native(from, &(holder->data), ctx);
-}
-
 
 
 ///////////////////////////////////////////////////////////////////

--- a/cocos/bindings/manual/jsb_conversions.h
+++ b/cocos/bindings/manual/jsb_conversions.h
@@ -835,6 +835,15 @@ struct HolderType<std::function<R (ARGS...)>, true> {
     inline type value() { return data; }
 };
 
+template<>
+struct HolderType<const unsigned int *, false> {
+    using type = const unsigned int *;
+    using local_type = std::vector<unsigned int>;
+    local_type data;
+    std::remove_const_t<type> *ptr = nullptr;
+    inline type value() { return data.data(); }
+};
+
 
 ///////////////////////////////////convertion//////////////////////////////////////////////////////////
 
@@ -1296,6 +1305,14 @@ sevalue_to_native(const se::Value &from, HolderType<std::vector<T, allocator>, t
 }
 
 #endif // HAS_CONSTEXPR
+
+
+template<>
+inline bool sevalue_to_native(const se::Value &from, HolderType<const unsigned int *, false> *holder, se::Object *ctx)
+{
+    return sevalue_to_native(from, &(holder->data), ctx);
+}
+
 
 
 ///////////////////////////////////////////////////////////////////

--- a/cocos/renderer/core/gfx/GFXCommandBuffer.h
+++ b/cocos/renderer/core/gfx/GFXCommandBuffer.h
@@ -35,16 +35,12 @@ public:
     virtual void copyBuffersToTexture(const uint8_t *const *buffers, Texture *texture, const BufferTextureCopy *regions, uint count) = 0;
     virtual void execute(const CommandBuffer *const *cmdBuffs, uint32_t count) = 0;
     
-    CC_INLINE void bindDescriptorSetForJS(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const std::vector<uint> &dynamicOffsets) {
-        bindDescriptorSet(set, descriptorSet, dynamicOffsetCount, dynamicOffsets.data());
-    }
     CC_INLINE void bindDescriptorSetForJS(uint set, DescriptorSet *descriptorSet) {
         bindDescriptorSet(set, descriptorSet, 0, nullptr); 
     }
     CC_INLINE void bindDescriptorSetForJS(uint set, DescriptorSet *descriptorSet, const vector<uint> &dynamicOffsets) {
         bindDescriptorSet(set, descriptorSet, static_cast<uint>(dynamicOffsets.size()), dynamicOffsets.data());
     }
-
 
     CC_INLINE void begin() { begin(nullptr, 0, nullptr); }
     CC_INLINE void begin(RenderPass *renderPass) { begin(renderPass, 0, nullptr); }

--- a/cocos/renderer/core/gfx/GFXCommandBuffer.h
+++ b/cocos/renderer/core/gfx/GFXCommandBuffer.h
@@ -35,13 +35,13 @@ public:
     virtual void copyBuffersToTexture(const uint8_t *const *buffers, Texture *texture, const BufferTextureCopy *regions, uint count) = 0;
     virtual void execute(const CommandBuffer *const *cmdBuffs, uint32_t count) = 0;
     
-    CC_INLINE void bindDescriptorSetJS(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const std::vector<uint> &dynamicOffsets) {
+    CC_INLINE void bindDescriptorSetForJS(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const std::vector<uint> &dynamicOffsets) {
         bindDescriptorSet(set, descriptorSet, dynamicOffsetCount, dynamicOffsets.data());
     }
-    CC_INLINE void bindDescriptorSetJS(uint set, DescriptorSet *descriptorSet) {
+    CC_INLINE void bindDescriptorSetForJS(uint set, DescriptorSet *descriptorSet) {
         bindDescriptorSet(set, descriptorSet, 0, nullptr); 
     }
-    CC_INLINE void bindDescriptorSetJS(uint set, DescriptorSet *descriptorSet, const vector<uint> &dynamicOffsets) {
+    CC_INLINE void bindDescriptorSetForJS(uint set, DescriptorSet *descriptorSet, const vector<uint> &dynamicOffsets) {
         bindDescriptorSet(set, descriptorSet, static_cast<uint>(dynamicOffsets.size()), dynamicOffsets.data());
     }
 

--- a/cocos/renderer/core/gfx/GFXCommandBuffer.h
+++ b/cocos/renderer/core/gfx/GFXCommandBuffer.h
@@ -20,7 +20,7 @@ public:
     virtual void beginRenderPass(RenderPass *renderPass, Framebuffer *fbo, const Rect &renderArea, const Color *colors, float depth, int stencil) = 0;
     virtual void endRenderPass() = 0;
     virtual void bindPipelineState(PipelineState *pso) = 0;
-    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const vector<uint>& dynamicOffsets) = 0;
+    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) = 0;
     virtual void bindInputAssembler(InputAssembler *ia) = 0;
     virtual void setViewport(const Viewport &vp) = 0;
     virtual void setScissor(const Rect &rect) = 0;
@@ -34,6 +34,17 @@ public:
     virtual void updateBuffer(Buffer *buff, const void *data, uint size, uint offset) = 0;
     virtual void copyBuffersToTexture(const uint8_t *const *buffers, Texture *texture, const BufferTextureCopy *regions, uint count) = 0;
     virtual void execute(const CommandBuffer *const *cmdBuffs, uint32_t count) = 0;
+    
+    CC_INLINE void bindDescriptorSetJS(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const std::vector<uint> &dynamicOffsets) {
+        bindDescriptorSet(set, descriptorSet, dynamicOffsetCount, dynamicOffsets.data());
+    }
+    CC_INLINE void bindDescriptorSetJS(uint set, DescriptorSet *descriptorSet) {
+        bindDescriptorSet(set, descriptorSet, 0, nullptr); 
+    }
+    CC_INLINE void bindDescriptorSetJS(uint set, DescriptorSet *descriptorSet, const vector<uint> &dynamicOffsets) {
+        bindDescriptorSet(set, descriptorSet, static_cast<uint>(dynamicOffsets.size()), dynamicOffsets.data());
+    }
+
 
     CC_INLINE void begin() { begin(nullptr, 0, nullptr); }
     CC_INLINE void begin(RenderPass *renderPass) { begin(renderPass, 0, nullptr); }
@@ -41,9 +52,9 @@ public:
     CC_INLINE void updateBuffer(Buffer *buff, const void *data, uint size) { updateBuffer(buff, data, size, 0); }
     CC_INLINE void updateBuffer(Buffer *buff, const void *data) { updateBuffer(buff, data, buff->getSize(), 0); }
     CC_INLINE void execute(const CommandBufferList &cmdBuffs, uint32_t count) { execute(cmdBuffs.data(), count); }
-    CC_INLINE void bindDescriptorSet(uint set, DescriptorSet *descriptorSet) { bindDescriptorSet(set, descriptorSet, 0, {}); }
+    CC_INLINE void bindDescriptorSet(uint set, DescriptorSet *descriptorSet) { bindDescriptorSet(set, descriptorSet, 0, nullptr); }
     CC_INLINE void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, const vector<uint> &dynamicOffsets) {
-        bindDescriptorSet(set, descriptorSet, static_cast<uint>(dynamicOffsets.size()), dynamicOffsets);
+        bindDescriptorSet(set, descriptorSet, static_cast<uint>(dynamicOffsets.size()), dynamicOffsets.data());
     }
     CC_INLINE void beginRenderPass(RenderPass *renderPass, Framebuffer *fbo, const Rect &renderArea, const ColorList &colors, float depth, int stencil) {
         beginRenderPass(renderPass, fbo, renderArea, colors.data(), depth, stencil);

--- a/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
@@ -93,7 +93,7 @@ void GLES2CommandBuffer::bindPipelineState(PipelineState *pso) {
     }
 }
 
-void GLES2CommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const std::vector<uint> &dynamicOffsets) {
+void GLES2CommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) {
     CCASSERT(_curGPUDescriptorSets.size() > set, "Invalid set index");
 
     GLES2GPUDescriptorSet *gpuDescriptorSet = ((GLES2DescriptorSet *)descriptorSet)->gpuDescriptorSet();
@@ -102,7 +102,7 @@ void GLES2CommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSe
         _isStateInvalid = true;
     }
     if (dynamicOffsetCount) {
-        _curDynamicOffsets[set].assign(dynamicOffsets.begin(), dynamicOffsets.begin() + dynamicOffsetCount);
+        _curDynamicOffsets[set].assign(dynamicOffsets, dynamicOffsets + dynamicOffsetCount);
         _isStateInvalid = true;
     }
 }

--- a/cocos/renderer/gfx-gles2/GLES2CommandBuffer.h
+++ b/cocos/renderer/gfx-gles2/GLES2CommandBuffer.h
@@ -24,7 +24,7 @@ public:
     virtual void beginRenderPass(RenderPass *renderPass, Framebuffer *fbo, const Rect &renderArea, const Color *colors, float depth, int stencil) override;
     virtual void endRenderPass() override;
     virtual void bindPipelineState(PipelineState *pso) override;
-    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const std::vector<uint>& dynamicOffsets) override;
+    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) override;
     virtual void bindInputAssembler(InputAssembler *ia) override;
     virtual void setViewport(const Viewport &vp) override;
     virtual void setScissor(const Rect &rect) override;

--- a/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
@@ -93,7 +93,7 @@ void GLES3CommandBuffer::bindPipelineState(PipelineState *pso) {
     }
 }
 
-void GLES3CommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const vector<uint> &dynamicOffsets) {
+void GLES3CommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) {
     CCASSERT(_curGPUDescriptorSets.size() > set, "Invalid set index");
 
     GLES3GPUDescriptorSet *gpuDescriptorSet = ((GLES3DescriptorSet *)descriptorSet)->gpuDescriptorSet();
@@ -102,7 +102,7 @@ void GLES3CommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSe
         _isStateInvalid = true;
     }
     if (dynamicOffsetCount) {
-        _curDynamicOffsets[set].assign(dynamicOffsets.begin(), dynamicOffsets.begin() + dynamicOffsetCount);
+        _curDynamicOffsets[set].assign(dynamicOffsets, dynamicOffsets + dynamicOffsetCount);
         _isStateInvalid = true;
     }
 }

--- a/cocos/renderer/gfx-gles3/GLES3CommandBuffer.h
+++ b/cocos/renderer/gfx-gles3/GLES3CommandBuffer.h
@@ -24,7 +24,7 @@ public:
     virtual void beginRenderPass(RenderPass *renderPass, Framebuffer *fbo, const Rect &renderArea, const Color *colors, float depth, int stencil) override;
     virtual void endRenderPass() override;
     virtual void bindPipelineState(PipelineState *pso) override;
-    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const vector<uint> &dynamicOffsets) override;
+    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) override;
     virtual void bindInputAssembler(InputAssembler *ia) override;
     virtual void setViewport(const Viewport &vp) override;
     virtual void setScissor(const Rect &rect) override;

--- a/cocos/renderer/gfx-metal/MTLCommandBuffer.h
+++ b/cocos/renderer/gfx-metal/MTLCommandBuffer.h
@@ -31,7 +31,7 @@ public:
     virtual void beginRenderPass(RenderPass *renderPass, Framebuffer *fbo, const Rect &renderArea, const Color *colors, float depth, int stencil) override;
     virtual void endRenderPass() override;
     virtual void bindPipelineState(PipelineState *pso) override;
-    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const vector<uint>& dynamicOffsets) override;
+    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) override;
     virtual void bindInputAssembler(InputAssembler *ia) override;
     virtual void setViewport(const Viewport &vp) override;
     virtual void setScissor(const Rect &rect) override;

--- a/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
+++ b/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
@@ -116,10 +116,10 @@ void CCMTLCommandBuffer::bindPipelineState(PipelineState *pso) {
     }
 }
 
-void CCMTLCommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const vector<uint> &dynamicOffsets) {
+void CCMTLCommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) {
     CCASSERT(set < _GPUDescriptorSets.size(), "Invalid set index");
     if (dynamicOffsetCount) {
-        _dynamicOffsets[set].assign(dynamicOffsets.begin(), dynamicOffsets.begin() + dynamicOffsetCount);
+        _dynamicOffsets[set].assign(dynamicOffsets, dynamicOffsets + dynamicOffsetCount);
         if (set < _firstDirtyDescriptorSet) _firstDirtyDescriptorSet = set;
     }
 

--- a/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
+++ b/cocos/renderer/gfx-vulkan/VKCommandBuffer.cpp
@@ -160,7 +160,7 @@ void CCVKCommandBuffer::bindPipelineState(PipelineState *pso) {
     }
 }
 
-void CCVKCommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const vector<uint> &dynamicOffsets) {
+void CCVKCommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) {
     CCASSERT(_curGPUDescriptorSets.size() > set, "Invalid set index");
 
     CCVKGPUDescriptorSet *gpuDescriptorSet = ((CCVKDescriptorSet *)descriptorSet)->gpuDescriptorSet();
@@ -170,7 +170,7 @@ void CCVKCommandBuffer::bindDescriptorSet(uint set, DescriptorSet *descriptorSet
         if (set < _firstDirtyDescriptorSet) _firstDirtyDescriptorSet = set;
     }
     if (dynamicOffsetCount) {
-        _curDynamicOffsets[set].assign(dynamicOffsets.begin(), dynamicOffsets.begin() + dynamicOffsetCount);
+        _curDynamicOffsets[set].assign(dynamicOffsets, dynamicOffsets + dynamicOffsetCount);
         if (set < _firstDirtyDescriptorSet) _firstDirtyDescriptorSet = set;
     }
 }

--- a/cocos/renderer/gfx-vulkan/VKCommandBuffer.h
+++ b/cocos/renderer/gfx-vulkan/VKCommandBuffer.h
@@ -22,7 +22,7 @@ public:
     virtual void beginRenderPass(RenderPass *renderPass, Framebuffer *fbo, const Rect &renderArea, const Color *colors, float depth, int stencil) override;
     virtual void endRenderPass() override;
     virtual void bindPipelineState(PipelineState *pso) override;
-    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const vector<uint> &dynamicOffsets) override;
+    virtual void bindDescriptorSet(uint set, DescriptorSet *descriptorSet, uint dynamicOffsetCount, const uint *dynamicOffsets) override;
     virtual void bindInputAssembler(InputAssembler *ia) override;
     virtual void setViewport(const Viewport &vp) override;
     virtual void setScissor(const Rect &rect) override;

--- a/tools/bindings-generator/generator.py
+++ b/tools/bindings-generator/generator.py
@@ -1081,11 +1081,11 @@ class NativeClass(object):
             if name == 'constructor':
                 should_skip = True
             else:
-                if self.generator.should_skip(self.class_name, name) and not self.generator.is_reserved_function(self.class_name, name):
+                if self.generator.should_skip(self.class_name, name):
                     should_skip = True
             if not should_skip:
-                ret.append({"name": name, "impl": impl})
-        return ret
+                ret.append({"name": self.generator.should_rename_function(self.class_name, name) or name, "impl": impl})
+        return sorted(ret, key=lambda fn: fn["name"])
 
     def static_methods_clean(self):
         '''
@@ -1239,7 +1239,7 @@ class NativeClass(object):
             # skip if variadic
             if self._current_visibility == cindex.AccessSpecifier.PUBLIC and not cursor.type.is_function_variadic():
                 m = NativeFunction(cursor, self.generator)
-                registration_name = self.generator.should_rename_function(self.class_name, m.func_name) or m.func_name
+                registration_name = m.func_name
                 # bail if the function is not supported (at least one arg not supported)
                 if m.not_supported:
                     return False

--- a/tools/bindings-generator/generator.py
+++ b/tools/bindings-generator/generator.py
@@ -1043,6 +1043,8 @@ class NativeClass(object):
 
 
     def skip_bind_function(self, method_name):
+        if self.generator.is_reserved_function(self.class_name, method_name["name"]):
+            return False
         if self.class_name in self.generator.shadowed_methods_by_getter_setter :
             #print("??? skip %s contains %s" %(self.generator.shadowed_methods_by_getter_setter[self.class_name], method_name))
             return method_name["name"] in self.generator.shadowed_methods_by_getter_setter[self.class_name]
@@ -1079,7 +1081,7 @@ class NativeClass(object):
             if name == 'constructor':
                 should_skip = True
             else:
-                if self.generator.should_skip(self.class_name, name):
+                if self.generator.should_skip(self.class_name, name) and not self.generator.is_reserved_function(self.class_name, name):
                     should_skip = True
             if not should_skip:
                 ret.append({"name": name, "impl": impl})
@@ -1503,7 +1505,13 @@ class Generator(object):
                         else:
                             raise Exception("getter_setter parse %s:%s failed" %(gs_kls, field))
 
-
+    def is_reserved_function(self, class_name, method_name):
+        if self.rename_functions.has_key(class_name):
+            rename_map = self.rename_functions[class_name]
+            for fn in rename_map:
+                if method_name == rename_map[fn]:
+                    return True
+        return False 
 
     def should_rename_function(self, class_name, method_name):
         if self.rename_functions.has_key(class_name) and self.rename_functions[class_name].has_key(method_name):

--- a/tools/tojs/gfx.ini
+++ b/tools/tojs/gfx.ini
@@ -45,7 +45,7 @@ classes_need_extend =
 # functions from all classes.
 
 skip = Buffer::[Buffer getDevice initialize update],
-       CommandBuffer::[CommandBuffer getDevice execute updateBuffer copyBuffersToTexture],
+       CommandBuffer::[CommandBuffer getDevice execute updateBuffer copyBuffersToTexture bindDescriptorSet$],
        Framebuffer::[Framebuffer getDevice],
        InputAssembler::[InputAssembler getDevice extractDrawInfo],
        DescriptorSet::[DescriptorSet getDevice],
@@ -77,7 +77,8 @@ getter_setter = Device::[gfxAPI surfaceTransform deviceName width height nativeW
 
 rename_functions = DepthStencilState::[getHash=hash],
                    BlendState::[getHash=hash],
-                   RasterizerState::[getHash=hash]
+                   RasterizerState::[getHash=hash],
+                   CommandBuffer::[bindDescriptorSetJS=bindDescriptorSet]
 
 rename_classes = Device::GFXDevice
 

--- a/tools/tojs/gfx.ini
+++ b/tools/tojs/gfx.ini
@@ -78,7 +78,7 @@ getter_setter = Device::[gfxAPI surfaceTransform deviceName width height nativeW
 rename_functions = DepthStencilState::[getHash=hash],
                    BlendState::[getHash=hash],
                    RasterizerState::[getHash=hash],
-                   CommandBuffer::[bindDescriptorSetJS=bindDescriptorSet]
+                   CommandBuffer::[bindDescriptorSetForJS=bindDescriptorSet]
 
 rename_classes = Device::GFXDevice
 


### PR DESCRIPTION
- Revert signature of `bindDescriptorSet` which modified in #3100 
- Sort exported class methods 