### PR TITLE
Modify CMake to enable DB/Spine feature crop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,11 @@ if(NOT ANDROID AND NOT IOS)
     set(USE_WEBVIEW OFF)
 endif()
 
+## disable middleware when dragonbones and spine are disabled
+if(NOT USE_DRAGONBONES AND NOT USE_SPINE)
+	set(USE_MIDDLEWARE OFF)
+endif()
+
 ################################# list all option values ##############################
 
 inspect_values(

--- a/templates/template-link/common/CMakeLists.txt
+++ b/templates/template-link/common/CMakeLists.txt
@@ -19,10 +19,6 @@ option(USE_DRAGONBONES          "Enable Dragonbones"                ON)
 option(USE_SPINE                "Enable Spine"                      ON)
 option(USE_WEBSOCKET_SERVER     "Enable WebSocket Server"           OFF)
 
-if(NOT USE_DRAGONBONES AND NOT USE_SPINE)
-	set(USE_MIDDLEWARE OFF)
-endif()
-
 if(USE_SE_JSC AND APPLE)
     set(USE_SE_V8 OFF)
     set(USE_V8_DEBUGGER OFF)


### PR DESCRIPTION
修改CMake使剔除Dragonbones和Spine模块时将middleware/dragonbones/spine相关文件全部移除