### PR TITLE
[3.0] bugfix: link library name sqlite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1557,7 +1557,7 @@ if(APPLE)
         "-framework GameController"
         "-framework Metal"
         "-framework MetalKit"
-        "-lSQLite3"
+        "-lsqlite3"
         "-framework Security"
         "-framework SystemConfiguration"
         ${CC_EXTERNAL_LIBS}


### PR DESCRIPTION
fix macosx link library