### PR TITLE
Fix texture-float extension query on gles2 devices

### DIFF
--- a/cocos/renderer/gfx-gles2/GLES2Device.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2Device.cpp
@@ -84,8 +84,14 @@ bool GLES2Device::initialize(const DeviceInfo &info) {
     String extStr = (const char *)glGetString(GL_EXTENSIONS);
     _extensions = StringUtil::Split(extStr, " ");
 
-    _features[(int)Feature::TEXTURE_FLOAT] = true;
-    _features[(int)Feature::TEXTURE_HALF_FLOAT] = true;
+    if (checkExtension("GL_OES_texture_float")) {
+        _features[(int)Feature::TEXTURE_FLOAT] = true;
+    }
+
+    if (checkExtension("GL_OES_texture_half_float")) {
+        _features[(int)Feature::TEXTURE_HALF_FLOAT] = true;
+    }
+
     _features[(int)Feature::FORMAT_R11G11B10F] = true;
     _features[(int)Feature::FORMAT_D24S8] = true;
     _features[(int)Feature::MSAA] = true;


### PR DESCRIPTION
`texture-float` is an extension that is optionally supported on GLES 2.

Related: https://www.khronos.org/registry/OpenGL/extensions/OES/OES_texture_float.txt