### PR TITLE
fix clearDepth crash in Metal

### DIFF
--- a/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
+++ b/cocos/renderer/gfx-metal/MTLCommandBuffer.mm
@@ -110,7 +110,9 @@ void CCMTLCommandBuffer::beginRenderPass(RenderPass *renderPass, Framebuffer *fb
             mtlRenderPassDescriptor.colorAttachments[slot].clearColor = mu::toMTLClearColor(colors[slot]);
             mtlRenderPassDescriptor.colorAttachments[slot].loadAction = colorAttachments[slot].loadOp == LoadOp::CLEAR ? MTLLoadActionClear : MTLLoadActionLoad;
         }
-
+        //Melta limits clearDepth at range [0.0, 1.0]
+        //to keep consistent with OpenGL, assume passed value ranges in [-1, 1];
+        depth = clampf(depth / 2 + 0.5f, 0.0f, 1.0f);
         mtlRenderPassDescriptor.depthAttachment.clearDepth = depth;
         mtlRenderPassDescriptor.stencilAttachment.clearStencil = stencil;
     }


### PR DESCRIPTION
now map depth [-1.0f, 1.0f] to [0.0f, 1.0f] in metal and clamped.