### PR TITLE
fix wrong interface  orientation

### DIFF
--- a/templates/template-link/platforms/ios/AppDelegate.mm
+++ b/templates/template-link/platforms/ios/AppDelegate.mm
@@ -26,12 +26,9 @@
 #include "AppDelegate.h"
 #import "ViewController.h"
 #include "platform/ios/View.h"
-#include "cocos/bindings/event/EventDispatcher.h"
 
 #include "SDKWrapper.h"
 #include "Game.h"
-
-cc::Device::Orientation _lastOrientation;
 
 @implementation AppDelegate
 
@@ -57,39 +54,10 @@ Game* game = nullptr;
     // cocos2d application instance
     game = new Game(bounds.size.width, bounds.size.height);
     game->init();
-
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                          selector:@selector(orientationChanged:)name:UIDeviceOrientationDidChangeNotification object:nil];
-
+    
     [self.window makeKeyAndVisible];
 
     return YES;
-}
-
-
-- (void) orientationChanged:(NSNotification *)note {
-    cc::Device::Orientation orientation = cc::Device::Orientation::PORTRAIT;
-    UIDevice * device = note.object;
-    switch(device.orientation) {
-        case UIDeviceOrientationPortrait:
-            orientation = cc::Device::Orientation::PORTRAIT;
-            break;
-        case UIDeviceOrientationLandscapeRight:
-            orientation = cc::Device::Orientation::LANDSCAPE_RIGHT;
-            break;
-        case UIDeviceOrientationPortraitUpsideDown:
-            orientation = cc::Device::Orientation::PORTRAIT_UPSIDE_DOWN;
-            break;
-        case UIDeviceOrientationLandscapeLeft:
-            orientation = cc::Device::Orientation::LANDSCAPE_LEFT;
-            break;
-        default:
-            break;
-    }
-    if (_lastOrientation != orientation) {
-        cc::EventDispatcher::dispatchOrientationChangeEvent((int) orientation);
-        _lastOrientation = orientation;
-    }
 }
 
 - (void)applicationWillResignActive:(UIApplication *)application {

--- a/templates/template-link/platforms/ios/ViewController.mm
+++ b/templates/template-link/platforms/ios/ViewController.mm
@@ -24,6 +24,11 @@
  THE SOFTWARE.
 ****************************************************************************/
 #import "ViewController.h"
+#include "cocos/bindings/event/EventDispatcher.h"
+
+namespace {
+    cc::Device::Orientation _lastOrientation;
+}
 
 @interface ViewController ()
 
@@ -45,5 +50,31 @@
     return YES;
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    cc::Device::Orientation orientation = _lastOrientation;
+    // reference: https://developer.apple.com/documentation/uikit/uiinterfaceorientation?language=objc
+    // UIInterfaceOrientationLandscapeRight = UIDeviceOrientationLandscapeLeft
+    // UIInterfaceOrientationLandscapeLeft = UIDeviceOrientationLandscapeRight
+    switch ([UIDevice currentDevice].orientation) {
+        case UIDeviceOrientationPortrait:
+            orientation = cc::Device::Orientation::PORTRAIT;
+            break;
+        case UIDeviceOrientationLandscapeRight:
+            orientation = cc::Device::Orientation::LANDSCAPE_LEFT;
+            break;
+        case UIDeviceOrientationPortraitUpsideDown:
+            orientation = cc::Device::Orientation::PORTRAIT_UPSIDE_DOWN;
+            break;
+        case UIDeviceOrientationLandscapeLeft:
+            orientation = cc::Device::Orientation::LANDSCAPE_RIGHT;
+            break;
+        default:
+            break;
+    }
+    if (_lastOrientation != orientation) {
+        cc::EventDispatcher::dispatchOrientationChangeEvent((int) orientation);
+        _lastOrientation = orientation;
+    }
+}
 
 @end


### PR DESCRIPTION
resolve: https://github.com/cocos-creator/3d-tasks/issues/5814

NOTE:
iOS 设备的方向的改变通知流程是这样的：
设备方向 改变 -> 通知页面方向改变，游戏里比较关心的应该是页面的方向，而不是设备的方向

- UIDeviceOrientationDidChangeNotification 监听的是设备方向的改变，横屏模式下，即使设备摆到竖屏也会走这个回调，导致横屏模式，方向也会变成 PORTRAIT，实际上页面并没有发生旋转
- UIApplicationDidChangeStatusBarOrientationNotification 监听的是页面的方向改变，这个应该才是游戏关心的方向