### PR TITLE
nullptr protect for bindStates in GLES

### DIFF
--- a/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
@@ -355,6 +355,10 @@ void GLES2CommandBuffer::execute(const CommandBuffer *const *cmdBuffs, uint32_t 
 
 void GLES2CommandBuffer::BindStates() {
     GLES2CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
+
+    if (!_curGPUPipelineState)
+        return;
+    
     cmd->gpuPipelineState = _curGPUPipelineState;
     cmd->gpuInputAssembler = _curGPUInputAssember;
     cmd->gpuDescriptorSets = _curGPUDescriptorSets;

--- a/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
@@ -355,13 +355,12 @@ void GLES2CommandBuffer::execute(const CommandBuffer *const *cmdBuffs, uint32_t 
 
 void GLES2CommandBuffer::BindStates() {
     GLES2CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
-    
+
     cmd->gpuPipelineState = _curGPUPipelineState;
     cmd->gpuInputAssembler = _curGPUInputAssember;
     cmd->gpuDescriptorSets = _curGPUDescriptorSets;
 
-    if (_curGPUPipelineState)
-    {
+    if (_curGPUPipelineState) {
         vector<uint> &dynamicOffsetOffsets = _curGPUPipelineState->gpuPipelineLayout->dynamicOffsetOffsets;
         cmd->dynamicOffsets.resize(_curGPUPipelineState->gpuPipelineLayout->dynamicOffsetCount);
         for (size_t i = 0u; i < _curDynamicOffsets.size(); i++) {

--- a/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
@@ -354,22 +354,22 @@ void GLES2CommandBuffer::execute(const CommandBuffer *const *cmdBuffs, uint32_t 
 }
 
 void GLES2CommandBuffer::BindStates() {
-    if (!_curGPUPipelineState)
-        return;
-        
     GLES2CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
     
     cmd->gpuPipelineState = _curGPUPipelineState;
     cmd->gpuInputAssembler = _curGPUInputAssember;
     cmd->gpuDescriptorSets = _curGPUDescriptorSets;
 
-    vector<uint> &dynamicOffsetOffsets = _curGPUPipelineState->gpuPipelineLayout->dynamicOffsetOffsets;
-    cmd->dynamicOffsets.resize(_curGPUPipelineState->gpuPipelineLayout->dynamicOffsetCount);
-    for (size_t i = 0u; i < _curDynamicOffsets.size(); i++) {
-        size_t count = dynamicOffsetOffsets[i + 1] - dynamicOffsetOffsets[i];
-        //CCASSERT(_curDynamicOffsets[i].size() >= count, "missing dynamic offsets?");
-        count = std::min(count, _curDynamicOffsets[i].size());
-        if (count) memcpy(&cmd->dynamicOffsets[dynamicOffsetOffsets[i]], _curDynamicOffsets[i].data(), count * sizeof(uint));
+    if (_curGPUPipelineState)
+    {
+        vector<uint> &dynamicOffsetOffsets = _curGPUPipelineState->gpuPipelineLayout->dynamicOffsetOffsets;
+        cmd->dynamicOffsets.resize(_curGPUPipelineState->gpuPipelineLayout->dynamicOffsetCount);
+        for (size_t i = 0u; i < _curDynamicOffsets.size(); i++) {
+            size_t count = dynamicOffsetOffsets[i + 1] - dynamicOffsetOffsets[i];
+            //CCASSERT(_curDynamicOffsets[i].size() >= count, "missing dynamic offsets?");
+            count = std::min(count, _curDynamicOffsets[i].size());
+            if (count) memcpy(&cmd->dynamicOffsets[dynamicOffsetOffsets[i]], _curDynamicOffsets[i].data(), count * sizeof(uint));
+        }
     }
 
     cmd->viewport = _curViewport;

--- a/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2CommandBuffer.cpp
@@ -354,10 +354,10 @@ void GLES2CommandBuffer::execute(const CommandBuffer *const *cmdBuffs, uint32_t 
 }
 
 void GLES2CommandBuffer::BindStates() {
-    GLES2CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
-
     if (!_curGPUPipelineState)
         return;
+        
+    GLES2CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
     
     cmd->gpuPipelineState = _curGPUPipelineState;
     cmd->gpuInputAssembler = _curGPUInputAssember;

--- a/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
@@ -361,10 +361,10 @@ void GLES3CommandBuffer::execute(const CommandBuffer *const *cmdBuffs, uint32_t 
 }
 
 void GLES3CommandBuffer::BindStates() {
-    GLES3CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
-    
     if (!_curGPUPipelineState)
         return;
+
+    GLES3CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
 
     cmd->gpuPipelineState = _curGPUPipelineState;
     cmd->gpuInputAssembler = _curGPUInputAssember;

--- a/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
@@ -361,22 +361,22 @@ void GLES3CommandBuffer::execute(const CommandBuffer *const *cmdBuffs, uint32_t 
 }
 
 void GLES3CommandBuffer::BindStates() {
-    if (!_curGPUPipelineState)
-        return;
-
     GLES3CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
 
     cmd->gpuPipelineState = _curGPUPipelineState;
     cmd->gpuInputAssembler = _curGPUInputAssember;
     cmd->gpuDescriptorSets = _curGPUDescriptorSets;
 
-    vector<uint> &dynamicOffsetOffsets = _curGPUPipelineState->gpuPipelineLayout->dynamicOffsetOffsets;
-    cmd->dynamicOffsets.resize(_curGPUPipelineState->gpuPipelineLayout->dynamicOffsetCount);
-    for (size_t i = 0u; i < _curDynamicOffsets.size(); i++) {
-        size_t count = dynamicOffsetOffsets[i + 1] - dynamicOffsetOffsets[i];
-        //CCASSERT(_curDynamicOffsets[i].size() >= count, "missing dynamic offsets?");
-        count = std::min(count, _curDynamicOffsets[i].size());
-        if (count) memcpy(&cmd->dynamicOffsets[dynamicOffsetOffsets[i]], _curDynamicOffsets[i].data(), count * sizeof(uint));
+    if (_curGPUPipelineState)
+    {
+        vector<uint> &dynamicOffsetOffsets = _curGPUPipelineState->gpuPipelineLayout->dynamicOffsetOffsets;
+        cmd->dynamicOffsets.resize(_curGPUPipelineState->gpuPipelineLayout->dynamicOffsetCount);
+        for (size_t i = 0u; i < _curDynamicOffsets.size(); i++) {
+            size_t count = dynamicOffsetOffsets[i + 1] - dynamicOffsetOffsets[i];
+            //CCASSERT(_curDynamicOffsets[i].size() >= count, "missing dynamic offsets?");
+            count = std::min(count, _curDynamicOffsets[i].size());
+            if (count) memcpy(&cmd->dynamicOffsets[dynamicOffsetOffsets[i]], _curDynamicOffsets[i].data(), count * sizeof(uint));
+        }
     }
 
     cmd->viewport = _curViewport;

--- a/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
@@ -362,6 +362,10 @@ void GLES3CommandBuffer::execute(const CommandBuffer *const *cmdBuffs, uint32_t 
 
 void GLES3CommandBuffer::BindStates() {
     GLES3CmdBindStates *cmd = _cmdAllocator->bindStatesCmdPool.alloc();
+    
+    if (!_curGPUPipelineState)
+        return;
+
     cmd->gpuPipelineState = _curGPUPipelineState;
     cmd->gpuInputAssembler = _curGPUInputAssember;
     cmd->gpuDescriptorSets = _curGPUDescriptorSets;

--- a/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3CommandBuffer.cpp
@@ -367,8 +367,7 @@ void GLES3CommandBuffer::BindStates() {
     cmd->gpuInputAssembler = _curGPUInputAssember;
     cmd->gpuDescriptorSets = _curGPUDescriptorSets;
 
-    if (_curGPUPipelineState)
-    {
+    if (_curGPUPipelineState) {
         vector<uint> &dynamicOffsetOffsets = _curGPUPipelineState->gpuPipelineLayout->dynamicOffsetOffsets;
         cmd->dynamicOffsets.resize(_curGPUPipelineState->gpuPipelineLayout->dynamicOffsetCount);
         for (size_t i = 0u; i < _curDynamicOffsets.size(); i++) {


### PR DESCRIPTION
https://github.com/cocos-creator/3d-tasks/issues/6096

本质上是js经过begin()之后没有bindPipeLineState而直接调用render(),  render里面的_curGPUPipelineState没有被初始化导致的。

现在nullptr return之后渲染空场景。

GLES2还无法验证，同样的环境启动在splash-screen出现之前报错：
```
E/jswrapper (168): [ERROR] (D:\project\cocos2d-x-lite\cocos\bindings\manual\jsb_global.cpp, 168): Can't decrypt code for C:/Users/Administrator/AppData/Local/npm-case/gamecaches/main/16111139625951.jsc
E/jswrapper (916): ScriptEngine::runScript script C:/Users/Administrator/AppData/Local/npm-case/gamecaches/main/16111139625951.jsc, buffer is empty!
E/jswrapper (272): [ERROR] Failed to invoke require, location: D:\project\cocos2d-x-lite\cocos\bindings\manual\jsb_global.cpp:272
D/jswrapper (143): JS: [ERROR]: Unable to instantiate virtual:///prerequisite-imports/main from undefined Error: Unable to instantiate virtual:///prerequisite-imports/main from undefined
    at y.<anonymous> (src/system.bundle.js:1:4276)
    at y.<anonymous> (src/system.bundle.js:1:5877)
    at y.instantiate (src/system.bundle.js:1:5039)
    at src/system.bundle.js:1:2141
D/jswrapper (143): JS: [ERROR]: Unable to instantiate virtual:///prerequisite-imports/main from undefined Error: Unable to instantiate virtual:///prerequisite-imports/main from undefined
    at y.<anonymous> (src/system.bundle.js:1:4276)
    at y.<anonymous> (src/system.bundle.js:1:5877)
    at y.instantiate (src/system.bundle.js:1:5039)
    at src/system.bundle.js:1:2141
D/jswrapper (130): JS: [ERROR]: Error: Unable to instantiate virtual:///prerequisite-imports/main from undefined
```
