### PR TITLE
mq: more accurate switch chunk size

### DIFF
--- a/cocos/base/Utils.h
+++ b/cocos/base/Utils.h
@@ -64,6 +64,9 @@ CC_DLL double atof(const char *str);
 
 CC_DLL uint alignTo(uint size, uint alignment);
 
+template<uint size, uint alignment>
+constexpr uint ALIGN_TO = ((size - 1) / alignment + 1) * alignment;
+
 template <class T>
 uint toUint(T value) {
     static_assert(std::is_arithmetic<T>::value, "T must be numeric");

--- a/cocos/base/threading/MessageQueue.h
+++ b/cocos/base/threading/MessageQueue.h
@@ -26,9 +26,9 @@
 #pragma once
 
 #include <cstdint>
+#include "../memory/Memory.h"
 #include "Event.h"
 #include "concurrentqueue/concurrentqueue.h"
-#include "../memory/Memory.h"
 
 namespace cc {
 

--- a/cocos/renderer/gfx-gles2/GLES2RenderPass.cpp
+++ b/cocos/renderer/gfx-gles2/GLES2RenderPass.cpp
@@ -47,6 +47,7 @@ void GLES2RenderPass::doInit(const RenderPassInfo & /*info*/) {
     _gpuRenderPass->subpasses              = _subpasses;
 
     // assign a dummy subpass if not specified
+    uint32_t colorCount = utils::toUint(_gpuRenderPass->colorAttachments.size());
     if (_gpuRenderPass->subpasses.empty()) {
         _gpuRenderPass->subpasses.emplace_back();
         auto &subpass = _gpuRenderPass->subpasses.back();
@@ -55,11 +56,10 @@ void GLES2RenderPass::doInit(const RenderPassInfo & /*info*/) {
             subpass.colors[i] = i;
         }
         if (_depthStencilAttachment.format != Format::UNKNOWN) {
-            subpass.depthStencil = _colorAttachments.size();
+            subpass.depthStencil = colorCount;
         }
     } else {
         // unify depth stencil index
-        uint32_t colorCount = _gpuRenderPass->colorAttachments.size();
         for (auto &subpass : _gpuRenderPass->subpasses) {
             if (subpass.depthStencil != INVALID_BINDING && subpass.depthStencil > colorCount) {
                 subpass.depthStencil = colorCount;

--- a/cocos/renderer/gfx-gles3/GLES3RenderPass.cpp
+++ b/cocos/renderer/gfx-gles3/GLES3RenderPass.cpp
@@ -48,6 +48,7 @@ void GLES3RenderPass::doInit(const RenderPassInfo & /*info*/) {
     _gpuRenderPass->subpasses              = _subpasses;
 
     // assign a dummy subpass if not specified
+    uint32_t colorCount = utils::toUint(_gpuRenderPass->colorAttachments.size());
     if (_gpuRenderPass->subpasses.empty()) {
         _gpuRenderPass->subpasses.emplace_back();
         auto &subpass = _gpuRenderPass->subpasses.back();
@@ -56,11 +57,10 @@ void GLES3RenderPass::doInit(const RenderPassInfo & /*info*/) {
             subpass.colors[i] = i;
         }
         if (_depthStencilAttachment.format != Format::UNKNOWN) {
-            subpass.depthStencil = utils::toUint(_colorAttachments.size());
+            subpass.depthStencil = colorCount;
         }
     } else {
         // unify depth stencil index
-        uint32_t colorCount = utils::toUint(_gpuRenderPass->colorAttachments.size());
         for (auto &subpass : _gpuRenderPass->subpasses) {
             if (subpass.depthStencil != INVALID_BINDING && subpass.depthStencil > colorCount) {
                 subpass.depthStencil = colorCount;

--- a/cocos/renderer/gfx-vulkan/VKRenderPass.cpp
+++ b/cocos/renderer/gfx-vulkan/VKRenderPass.cpp
@@ -48,6 +48,7 @@ void CCVKRenderPass::doInit(const RenderPassInfo & /*info*/) {
     _gpuRenderPass->dependencies           = _dependencies;
 
     // assign a dummy subpass if not specified
+    uint32_t colorCount = utils::toUint(_gpuRenderPass->colorAttachments.size());
     if (_gpuRenderPass->subpasses.empty()) {
         _gpuRenderPass->subpasses.emplace_back();
         auto &subpass = _gpuRenderPass->subpasses.back();
@@ -56,11 +57,10 @@ void CCVKRenderPass::doInit(const RenderPassInfo & /*info*/) {
             subpass.colors[i] = i;
         }
         if (_depthStencilAttachment.format != Format::UNKNOWN) {
-            subpass.depthStencil = utils::toUint(_colorAttachments.size());
+            subpass.depthStencil = colorCount;
         }
     } else {
         // unify depth stencil index
-        uint32_t colorCount = _gpuRenderPass->colorAttachments.size();
         for (auto &subpass : _gpuRenderPass->subpasses) {
             if (subpass.depthStencil != INVALID_BINDING && subpass.depthStencil > colorCount) {
                 subpass.depthStencil = colorCount;


### PR DESCRIPTION
fix the case when `MEMORY_CHUNK_SIZE - ALIGN_TO<sizeof(DummyMessage), 16> < alignedSize + SWITCH_CHUNK_MEMORY_REQUIREMENT < MEMORY_CHUNK_SIZE`