### PR TITLE
Fix stack overflow error when allocate new memory

### DIFF
--- a/cocos/renderer/gfx-base/GFXCommandBuffer.h
+++ b/cocos/renderer/gfx-base/GFXCommandBuffer.h
@@ -29,7 +29,6 @@
 #include "GFXInputAssembler.h"
 #include "GFXObject.h"
 #include "base/Utils.h"
-#include <array>
 
 namespace cc {
 namespace gfx {
@@ -76,8 +75,6 @@ public:
 
     inline void bindDescriptorSet(uint32_t set, DescriptorSet *descriptorSet);
     inline void bindDescriptorSet(uint32_t set, DescriptorSet *descriptorSet, const vector<uint32_t> &dynamicOffsets);
-    template<size_t N>
-    inline void bindDescriptorSet(uint32_t set, DescriptorSet *descriptorSet, const std::array<uint32_t, N> &dynamicOffsets);
 
     inline void beginRenderPass(RenderPass *renderPass, Framebuffer *fbo, const Rect &renderArea, const ColorList &colors, float depth, uint32_t stencil, const CommandBufferList &secondaryCBs);
     inline void beginRenderPass(RenderPass *renderPass, Framebuffer *fbo, const Rect &renderArea, const ColorList &colors, float depth, uint32_t stencil);
@@ -137,11 +134,6 @@ void CommandBuffer::bindDescriptorSet(uint32_t set, DescriptorSet *descriptorSet
 }
 
 void CommandBuffer::bindDescriptorSet(uint32_t set, DescriptorSet *descriptorSet, const vector<uint32_t> &dynamicOffsets) {
-    bindDescriptorSet(set, descriptorSet, utils::toUint(dynamicOffsets.size()), dynamicOffsets.data());
-}
-
-template <size_t N>
-void CommandBuffer::bindDescriptorSet(uint32_t set, DescriptorSet *descriptorSet, const std::array<uint32_t, N> &dynamicOffsets) {
     bindDescriptorSet(set, descriptorSet, utils::toUint(dynamicOffsets.size()), dynamicOffsets.data());
 }
 

--- a/cocos/scene/DrawBatch2D.h
+++ b/cocos/scene/DrawBatch2D.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <vector>
-#include <array>
 #include "renderer/gfx-base/GFXDescriptorSet.h"
 #include "renderer/gfx-base/GFXInputAssembler.h"
 
@@ -38,7 +37,7 @@ class Pass;
 struct DrawCall final {
     gfx::Buffer *         bufferView{nullptr};
     gfx::DescriptorSet *  descriptorSet{nullptr};
-    std::array<uint32_t, 2> dynamicOffsets{0, 0};
+    std::vector<uint32_t> dynamicOffsets{0, 0};
     gfx::DrawInfo *       drawInfo;
 
     void setDynamicOffsets(uint32_t value) {


### PR DESCRIPTION
DynamicOffset will bump to 10000+ and exceed memory block. According to ChiaNing, dynamicOffsets should be in size 2. Here goes with the solution.
* reset Drawcall's dynamicOffset's size to 2, and only change second value each update