### PR TITLE
V2.4.14 openharmony bug fix

### DIFF
--- a/cocos/audio/openharmony/PcmAudioService.cpp
+++ b/cocos/audio/openharmony/PcmAudioService.cpp
@@ -78,6 +78,22 @@ int32_t PcmAudioService::AudioRendererOnWriteData(OH_AudioRenderer* renderer,
     return 0;
 }
 
+int32_t PcmAudioService::AudioRendererOnInterrupt(OH_AudioRenderer* renderer,
+    void* userData,
+    OH_AudioInterrupt_ForceType type,
+    OH_AudioInterrupt_Hint hint)
+{
+    auto *thiz = reinterpret_cast<PcmAudioService *>(userData);
+    if (thiz->_audioRenderer != nullptr) {
+        if (hint == AUDIOSTREAM_INTERRUPT_HINT_RESUME) {
+            OH_AudioRenderer_Start(thiz->_audioRenderer);
+        } else if (hint == AUDIOSTREAM_INTERRUPT_HINT_PAUSE) {
+            OH_AudioRenderer_Pause(thiz->_audioRenderer);
+        }
+    }
+    return 0;
+}
+
 bool PcmAudioService::init(AudioMixerController *controller, int numChannels, int sampleRate, int *bufferSizeInBytes) {
     _controller = controller;
 
@@ -95,6 +111,9 @@ bool PcmAudioService::init(AudioMixerController *controller, int numChannels, in
 
     OH_AudioRenderer_Callbacks callbacks;
     callbacks.OH_AudioRenderer_OnWriteData = AudioRendererOnWriteData;
+    callbacks.OH_AudioRenderer_OnInterruptEvent = AudioRendererOnInterrupt;
+    callbacks.OH_AudioRenderer_OnError = nullptr;
+    callbacks.OH_AudioRenderer_OnStreamEvent = nullptr;
     ret = OH_AudioStreamBuilder_SetRendererCallback(_builder, callbacks, this);
     if (ret != AUDIOSTREAM_SUCCESS) {
         return false;

--- a/cocos/audio/openharmony/PcmAudioService.cpp
+++ b/cocos/audio/openharmony/PcmAudioService.cpp
@@ -91,6 +91,7 @@ bool PcmAudioService::init(AudioMixerController *controller, int numChannels, in
     OH_AudioStreamBuilder_SetSamplingRate(_builder, sampleRate);
     OH_AudioStreamBuilder_SetChannelCount(_builder, numChannels);
     OH_AudioStreamBuilder_SetLatencyMode(_builder, AUDIOSTREAM_LATENCY_MODE_FAST);
+    OH_AudioStreamBuilder_SetRendererInfo(_builder, AUDIOSTREAM_USAGE_GAME);
 
     OH_AudioRenderer_Callbacks callbacks;
     callbacks.OH_AudioRenderer_OnWriteData = AudioRendererOnWriteData;

--- a/cocos/audio/openharmony/PcmAudioService.h
+++ b/cocos/audio/openharmony/PcmAudioService.h
@@ -55,6 +55,7 @@ public:
 
 private:
     static int32_t AudioRendererOnWriteData(OH_AudioRenderer* renderer, void* userData, void* buffer, int32_t bufferLen);
+    static int32_t AudioRendererOnInterrupt(OH_AudioRenderer* renderer, void* userData, OH_AudioInterrupt_ForceType type, OH_AudioInterrupt_Hint hint);
     int _bufferSizeInBytes;
 
     AudioMixerController* _controller;

--- a/cocos/audio/openharmony/UrlAudioPlayer.cpp
+++ b/cocos/audio/openharmony/UrlAudioPlayer.cpp
@@ -248,6 +248,10 @@ void UrlAudioPlayer::onInfo(OH_AVPlayer *player, AVPlayerOnInfoType type, int32_
     }
 }
 
+void UrlAudioPlayer::onError(OH_AVPlayer *player, int32_t errorCode, const char *errorMsg) {
+    ALOGE("UrlAudioPlayer play failed, errorCode is: %d, errorMsg is %s", errorCode, errorMsg);
+}
+
 void UrlAudioPlayer::playEventCallback(){
     std::shared_ptr<bool> isDestroyed = _isDestroyed;
     auto func = [this, isDestroyed]() {
@@ -299,8 +303,10 @@ bool UrlAudioPlayer::prepare(const std::string &url, std::shared_ptr<AssetFd> as
 
     AVPlayerCallback callback;
     callback.onInfo = this->onInfo;
+    callback.onError = this->onError;
     OH_AVPlayer_SetPlayerCallback(_playObj, callback);
     OH_AVPlayer_SetFDSource(_playObj, _assetFd->getFd(), start, length);
+    OH_AVPlayer_SetAudioRendererInfo(_playObj, OH_AudioStream_Usage::AUDIOSTREAM_USAGE_GAME);
     OH_AVErrCode code = OH_AVPlayer_Prepare(_playObj);
     if (code == AV_ERR_OK) {
         setState(State::INITIALIZED);

--- a/cocos/audio/openharmony/UrlAudioPlayer.cpp
+++ b/cocos/audio/openharmony/UrlAudioPlayer.cpp
@@ -245,6 +245,20 @@ void UrlAudioPlayer::onInfo(OH_AVPlayer *player, AVPlayerOnInfoType type, int32_
                 audioPlayer->playEventCallback();
             }
         }
+    } else if (type == AV_INFO_TYPE_INTERRUPT_EVENT) {
+        auto it = __playerContainer.find(player);
+        if (it != __playerContainer.end()) {
+            UrlAudioPlayer *audioPlayer = it->second;
+            const int32_t interruptHintResume = 1;
+            const int32_t interruptHintPause = 2;
+            if (extra == interruptHintResume) {
+                audioPlayer->resume();
+            } else if (extra == interruptHintPause) {
+                audioPlayer->pause();
+            } else {
+                ALOGV("UrlAudioPlayer was interrupted, hint type is %d", extra);
+            }
+        }
     }
 }
 

--- a/cocos/audio/openharmony/UrlAudioPlayer.h
+++ b/cocos/audio/openharmony/UrlAudioPlayer.h
@@ -91,14 +91,14 @@ private:
 
     static void onInfo(OH_AVPlayer *player, AVPlayerOnInfoType type, int32_t extra);
 
-    static void onError(OH_AVPlayer *player, int32_t errorCode, const char *errorMsg)
+    static void onError(OH_AVPlayer *player, int32_t errorCode, const char *errorMsg);
 
     static void stopAll();
 
     void destroy();
 
     inline void setState(State state) { _state = state; };
-
+ 
     void playEventCallback();
     
     void setVolumeToAVPlayer(float volume);

--- a/cocos/audio/openharmony/UrlAudioPlayer.h
+++ b/cocos/audio/openharmony/UrlAudioPlayer.h
@@ -91,6 +91,8 @@ private:
 
     static void onInfo(OH_AVPlayer *player, AVPlayerOnInfoType type, int32_t extra);
 
+    static void onError(OH_AVPlayer *player, int32_t errorCode, const char *errorMsg)
+
     static void stopAll();
 
     void destroy();

--- a/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
+++ b/cocos/platform/openharmony/OpenHarmonyPlatform.cpp
@@ -318,8 +318,9 @@ void OpenHarmonyPlatform::tick() {
     static std::chrono::steady_clock::time_point now;
     static float dt = 0.f;
     now = std::chrono::steady_clock::now();
-    static double dtNS = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(now - _lastTickInNanoSeconds).count());
+    static double dtNS = NANOSECONDS_60FPS;
 
+    dtNS = static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(now - _lastTickInNanoSeconds).count());
     if(dtNS < static_cast<double>(_prefererredNanosecondsPerFrame)) {
         std::this_thread::sleep_for(std::chrono::nanoseconds(
         _prefererredNanosecondsPerFrame - static_cast<int64_t>(dtNS)));

--- a/cocos/platform/openharmony/OpenHarmonyPlatform.h
+++ b/cocos/platform/openharmony/OpenHarmonyPlatform.h
@@ -82,11 +82,13 @@ public:
     void setPreferedFramePersecond(int fps);
 
     int64_t _prefererredNanosecondsPerFrame{NANOSECONDS_60FPS};
+    std::chrono::steady_clock::time_point _lastTickInNanoSeconds;
     OH_NativeXComponent* _component{nullptr};
     OH_NativeXComponent_Callback _callback;
     uv_timer_t _timerHandle;
     uv_loop_t* _workerLoop{nullptr};
     uv_async_t _messageSignal{};
+    bool _timerInited{false};
     WorkerMessageQueue _messageQueue;
     EGLCore* eglCore_{nullptr};
 

--- a/cocos/platform/openharmony/modules/CCCanvasRenderingContext2D-openharmony.cpp
+++ b/cocos/platform/openharmony/modules/CCCanvasRenderingContext2D-openharmony.cpp
@@ -236,7 +236,6 @@ public:
         if (it != fontInfoMap.end()) {
             _fontCollection = it->second;
         } else {
-            const std::string defaultFontKey = "openharmony_system_font";
             _fontCollection = fontInfoMap.at(defaultFontKey);
         }
         _typographyStyle = OH_Drawing_CreateTypographyStyle();

--- a/cocos/platform/openharmony/modules/CCCanvasRenderingContext2D-openharmony.cpp
+++ b/cocos/platform/openharmony/modules/CCCanvasRenderingContext2D-openharmony.cpp
@@ -91,10 +91,6 @@ public:
             _typographyStyle = nullptr;
         }
 
-        if(_fontCollection) {
-            OH_Drawing_DestroyFontCollection(_fontCollection);
-        }
-
         if(_typographyCreate) {
             OH_Drawing_DestroyTypographyHandler(_typographyCreate);
             _typographyCreate = nullptr;
@@ -228,9 +224,6 @@ public:
         _fontName = fontName;
         _fontSize = static_cast<int>(fontSize);
         
-        if (_fontCollection) {
-            OH_Drawing_DestroyFontCollection(_fontCollection);
-        }
         if (_typographyCreate) {
             OH_Drawing_DestroyTypographyHandler(_typographyCreate);
         }
@@ -243,7 +236,7 @@ public:
         if (it != fontInfoMap.end()) {
             _fontCollection = it->second;
         } else {
-            _fontCollection = OH_Drawing_CreateSharedFontCollection();
+            _fontCollection = fontInfoMap.at("openharmony_system_font");
         }
         _typographyStyle = OH_Drawing_CreateTypographyStyle();
         OH_Drawing_SetTypographyTextDirection(_typographyStyle, TEXT_DIRECTION_LTR);

--- a/cocos/platform/openharmony/modules/CCCanvasRenderingContext2D-openharmony.cpp
+++ b/cocos/platform/openharmony/modules/CCCanvasRenderingContext2D-openharmony.cpp
@@ -236,7 +236,8 @@ public:
         if (it != fontInfoMap.end()) {
             _fontCollection = it->second;
         } else {
-            _fontCollection = fontInfoMap.at("openharmony_system_font");
+            const std::string defaultFontKey = "openharmony_system_font";
+            _fontCollection = fontInfoMap.at(defaultFontKey);
         }
         _typographyStyle = OH_Drawing_CreateTypographyStyle();
         OH_Drawing_SetTypographyTextDirection(_typographyStyle, TEXT_DIRECTION_LTR);

--- a/cocos/scripting/js-bindings/manual/jsb_platform.h
+++ b/cocos/scripting/js-bindings/manual/jsb_platform.h
@@ -26,6 +26,7 @@
 #pragma once
 #include "platform/CCPlatformConfig.h"
 #if CC_TARGET_PLATFORM == CC_PLATFORM_OPENHARMONY
+#include <string>
 #include <native_drawing/drawing_text_declaration.h>
 #endif
 #include <unordered_map>
@@ -37,5 +38,6 @@ namespace se {
 bool register_platform_bindings(se::Object* obj);
 const std::unordered_map<std::string, std::string>& getFontFamilyNameMap();
 #if CC_TARGET_PLATFORM == CC_PLATFORM_OPENHARMONY
+const std::string defaultFontKey = "openharmony_system_font";
 const std::unordered_map<std::string, OH_Drawing_FontCollection*>& getFontFamilyCollectionMap();
 #endif

--- a/cocos/scripting/js-bindings/manual/jsb_platform_openharmony.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_platform_openharmony.cpp
@@ -40,8 +40,6 @@
 
 using namespace cocos2d;
 
-static const std::string defaultFontKey = "openharmony_system_font";
-
 static std::unordered_map<std::string, OH_Drawing_FontCollection*> _fontCollectionMap = {
     { defaultFontKey, OH_Drawing_CreateSharedFontCollection() }
 };

--- a/cocos/scripting/js-bindings/manual/jsb_platform_openharmony.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_platform_openharmony.cpp
@@ -40,7 +40,9 @@
 
 using namespace cocos2d;
 
-static std::unordered_map<std::string, OH_Drawing_FontCollection*> _fontCollectionMap;
+static std::unordered_map<std::string, OH_Drawing_FontCollection*> _fontCollectionMap = {
+    {"openharmony_system_font", OH_Drawing_CreateSharedFontCollection()}
+};
 
 const std::unordered_map<std::string, OH_Drawing_FontCollection*>& getFontFamilyCollectionMap()
 {

--- a/cocos/scripting/js-bindings/manual/jsb_platform_openharmony.cpp
+++ b/cocos/scripting/js-bindings/manual/jsb_platform_openharmony.cpp
@@ -40,8 +40,10 @@
 
 using namespace cocos2d;
 
+static const std::string defaultFontKey = "openharmony_system_font";
+
 static std::unordered_map<std::string, OH_Drawing_FontCollection*> _fontCollectionMap = {
-    {"openharmony_system_font", OH_Drawing_CreateSharedFontCollection()}
+    { defaultFontKey, OH_Drawing_CreateSharedFontCollection() }
 };
 
 const std::unordered_map<std::string, OH_Drawing_FontCollection*>& getFontFamilyCollectionMap()

--- a/templates/js-template-default/frameworks/runtime-src/proj.openharmony/entry/src/main/ets/components/EditBoxDialog.ets
+++ b/templates/js-template-default/frameworks/runtime-src/proj.openharmony/entry/src/main/ets/components/EditBoxDialog.ets
@@ -60,7 +60,7 @@ export struct EditBoxDialog {
         })
       }.padding({ left: 8, right: 8, top: 8, bottom: 8 })
       .backgroundColor(Color.Gray)
-
+      .offset({ x : 0, y : 15 })
     }
     .width('100%')
 

--- a/templates/js-template-link/frameworks/runtime-src/proj.openharmony/entry/src/main/ets/components/EditBoxDialog.ets
+++ b/templates/js-template-link/frameworks/runtime-src/proj.openharmony/entry/src/main/ets/components/EditBoxDialog.ets
@@ -60,7 +60,7 @@ export struct EditBoxDialog {
         })
       }.padding({ left: 8, right: 8, top: 8, bottom: 8 })
       .backgroundColor(Color.Gray)
-
+      .offset({ x : 0, y : 15 })
     }
     .width('100%')
 


### PR DESCRIPTION
1. Fix the issue of inaccurate calculation of sleep time when locking frames.
2. Fix the issue of UV timer not stopped when sliding up to the multitask list.
3. Specify the audio stream type as GAME.
4. Fix the issue of custom font fontCollection being incorrectly destroyed.
5. Adjust editbox component position