### PR TITLE
fix iterator maybe invalid.

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/v8/Object.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/v8/Object.cpp
@@ -73,6 +73,7 @@ namespace se {
         if (iter != NativePtrToObjectMap::end())
         {
             Object* obj = iter->second;
+            NativePtrToObjectMap::erase(iter);
             if (obj->_finalizeCb != nullptr)
             {
                 obj->_finalizeCb(nativeObj);
@@ -84,7 +85,6 @@ namespace se {
                     obj->_getClass()->_finalizeFunc(nativeObj);
             }
             obj->decRef();
-            NativePtrToObjectMap::erase(iter);
         }
         else
         {


### PR DESCRIPTION
spine object dispose callback could recursively finalize , leading iter invalid.