### PR TITLE
Fix 'Object::createTypedArrayWithBuffer' for JSVM.

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/jsvm/Object.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsvm/Object.cpp
@@ -362,11 +362,11 @@ Object* Object::createTypedArrayWithBuffer(TypedArrayType type, const Object *ob
             sizeOfEle = 1;
             break;
         case TypedArrayType::INT16:
-            jsvmType  = JSVM_INT8_ARRAY;
+            jsvmType  = JSVM_INT16_ARRAY;
             sizeOfEle = 2;
             break;
         case TypedArrayType::UINT16:
-            jsvmType  = JSVM_UINT8_ARRAY;
+            jsvmType  = JSVM_UINT16_ARRAY;
             sizeOfEle = 2;
             break;
         case TypedArrayType::INT32:

--- a/cocos/scripting/js-bindings/jswrapper/napi/Object.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/napi/Object.cpp
@@ -312,11 +312,11 @@ Object* Object::createTypedArrayWithBuffer(TypedArrayType type, const Object *ob
             sizeOfEle = 1;
             break;
         case TypedArrayType::INT16:
-            napiType  = napi_int8_array;
+            napiType  = napi_int16_array;
             sizeOfEle = 2;
             break;
         case TypedArrayType::UINT16:
-            napiType  = napi_uint8_array;
+            napiType  = napi_uint16_array;
             sizeOfEle = 2;
             break;
         case TypedArrayType::INT32:


### PR DESCRIPTION
It's a bug starts from the first version of JSVM support in https://github.com/cocos/engine-native/pull/4366 .

Re: https://github.com/cocos/3d-tasks/issues/18837

https://github.com/cocos/cocos-engine/pull/18487

3.x napi backend was fixed at https://github.com/cocos/cocos-engine/pull/14743