### PR TITLE
Add support for avplayer to play files in the application sandbox in openHarmony

### DIFF
--- a/cocos/audio/android/AudioPlayerProvider.cpp
+++ b/cocos/audio/android/AudioPlayerProvider.cpp
@@ -433,6 +433,13 @@ AudioPlayerProvider::AudioFileInfo AudioPlayerProvider::getFileInfo(
         if (fp != nullptr)
         {
             fseek(fp, 0, SEEK_END);
+#if CC_TARGET_PLATFORM == CC_PLATFORM_OPENHARMONY
+            int fd = fileno(fp);
+            if (fd > 0) 
+            {
+                assetFd = dup(fd);
+            }
+#endif
             fileSize = ftell(fp);
             fclose(fp);
         }
@@ -454,13 +461,6 @@ bool AudioPlayerProvider::isSmallFile(const AudioFileInfo &info)
 {
     //REFINE: If file size is smaller than 100k, we think it's a small file. This value should be set by developers.
     AudioFileInfo &audioFileInfo = const_cast<AudioFileInfo &>(info);
-
-    #if CC_TARGET_PLATFORM == CC_PLATFORM_OPENHARMONY
-    if(audioFileInfo.url[0] == '/') {
-        // avplayer does not support playing audio files in sandbox path currently.
-        return true;
-    }
-    #endif
     size_t judgeCount = sizeof(__audioFileIndicator) / sizeof(__audioFileIndicator[0]);
     size_t pos = audioFileInfo.url.rfind(".");
     std::string extension;

--- a/cocos/audio/openharmony/UrlAudioPlayer.cpp
+++ b/cocos/audio/openharmony/UrlAudioPlayer.cpp
@@ -371,7 +371,7 @@ void UrlAudioPlayer::destroy()
     {
         *_isDestroyed = true;
         OH_AVErrCode code = OH_AVPlayer_Release(_playObj);
-        if (code == AV_ERR_OK) {
+        if (code != AV_ERR_OK) {
             ALOGE("UrlAudioPlayer release error, code: %d", code);
         }
     }


### PR DESCRIPTION
Add support for avplayer to play files in the application sandbox, avoiding stuttering due to decoding and resampling when playing large files.