### PR TITLE
Fix the probabilistic crash of JSVM

### DIFF
--- a/cocos/scripting/js-bindings/jswrapper/jsvm/Object.cpp
+++ b/cocos/scripting/js-bindings/jswrapper/jsvm/Object.cpp
@@ -524,10 +524,13 @@ bool Object::call(const ValueArray& args, Object* thisObject, Value* rval) {
     });
     NODE_API_CALL(status, _env,
         OH_JSVM_CallFunction(_env, thisObj, _getJSObject(), argc, argv.data(), &return_val));
-    if (rval) {
-        internal::jsToSeValue(return_val, rval);
+    if (status == JSVM_OK) {
+        if (rval) {
+            internal::jsToSeValue(return_val, rval);
+        }
+        return true;
     }
-    return true;
+    return false;
 }
 
 void Object::_setFinalizeCallback(JSVM_Finalize finalizeCb) {


### PR DESCRIPTION
When the JSVM execution fails, the value of return_val remains the random value allocated on the stack during initialization. Then, when the OH_JSVM_Typeof method is executed, there is a probability of a crash occurring.