### PR TITLE
Fix audio problems in openharmony

### DIFF
--- a/cocos/audio/openharmony/PcmAudioService.cpp
+++ b/cocos/audio/openharmony/PcmAudioService.cpp
@@ -47,7 +47,7 @@ PcmAudioService::~PcmAudioService() {
 }
 
 
-int32_t PcmAudioService::AudioRendererOnWriteData(OH_AudioRenderer* renderer,
+OH_AudioData_Callback_Result PcmAudioService::AudioRendererOnWriteData(OH_AudioRenderer* renderer,
     void* userData,
     void* buffer,
     int32_t bufferLen)
@@ -107,11 +107,16 @@ bool PcmAudioService::init(AudioMixerController *controller, int numChannels, in
     OH_AudioStreamBuilder_SetRendererInfo(_builder, AUDIOSTREAM_USAGE_GAME);
 
     OH_AudioRenderer_Callbacks callbacks;
-    callbacks.OH_AudioRenderer_OnWriteData = AudioRendererOnWriteData;
+    callbacks.OH_AudioRenderer_OnWriteData = nullptr;
     callbacks.OH_AudioRenderer_OnInterruptEvent = AudioRendererOnInterrupt;
     callbacks.OH_AudioRenderer_OnError = nullptr;
     callbacks.OH_AudioRenderer_OnStreamEvent = nullptr;
     ret = OH_AudioStreamBuilder_SetRendererCallback(_builder, callbacks, this);
+    if (ret != AUDIOSTREAM_SUCCESS) {
+        return false;
+    }
+    
+    ret =  OH_AudioStreamBuilder_SetRendererWriteDataCallback(_builder, AudioRendererOnWriteData, this);
     if (ret != AUDIOSTREAM_SUCCESS) {
         return false;
     }

--- a/cocos/audio/openharmony/PcmAudioService.h
+++ b/cocos/audio/openharmony/PcmAudioService.h
@@ -54,7 +54,7 @@ public:
     void resume();
 
 private:
-    static int32_t AudioRendererOnWriteData(OH_AudioRenderer* renderer, void* userData, void* buffer, int32_t bufferLen);
+    static OH_AudioData_Callback_Result AudioRendererOnWriteData(OH_AudioRenderer* renderer, void* userData, void* buffer, int32_t bufferLen);
     static int32_t AudioRendererOnInterrupt(OH_AudioRenderer* renderer, void* userData, OH_AudioInterrupt_ForceType type, OH_AudioInterrupt_Hint hint);
     int _bufferSizeInBytes;
 


### PR DESCRIPTION
The OH_AudioRenderer_OnWriteData callback of ohaudio does not support determining whether playback is required based on the return value. On some system versions, such as 5.0.0.135 (SP5), there may be issues with abnormal audio playback. It is recommended to switch to the OH_AudioRenderer_OnWriteDataCallback function on api12. The relevant link is: https://developer.huawei.com/consumer/cn/doc/harmonyos-guides/using-ohaudio-for-playback